### PR TITLE
Class-based model generation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@
 - If regular type annotations aren't an appropriate way to express metadata, use decorators
 - Use jsdoc for pure text metadata (e.g. endpoint descriptions)
 - Minimize boilerplate
-- Models are always represented by interfaces; the contract between API client is best represented through a data structure, not a class or object
+- Models are best represented by interfaces (pure data structures), but can also be represented by classes
 
 ## How it works
 

--- a/src/decorators/example.ts
+++ b/src/decorators/example.ts
@@ -1,3 +1,3 @@
 export function Example<T>(exampleModel: T): any {
-  return null;
+  return () => { return; };
 }

--- a/src/decorators/methods.ts
+++ b/src/decorators/methods.ts
@@ -1,19 +1,19 @@
 export function Get(value?: string): any {
-  return;
+  return () => { return; };
 }
 
 export function Post(value?: string): any {
-  return;
+  return () => { return; };
 }
 
 export function Patch(value?: string): any {
-  return;
+  return () => { return; };
 }
 
 export function Put(value?: string): any {
-  return;
+  return () => { return; };
 }
 
 export function Delete(value?: string): any {
-  return;
+  return () => { return; };
 }

--- a/src/decorators/route.ts
+++ b/src/decorators/route.ts
@@ -1,3 +1,3 @@
 export function Route(name?: string): any {
-  return;
+  return () => { return; };
 }

--- a/src/metadataGeneration/metadataGenerator.ts
+++ b/src/metadataGeneration/metadataGenerator.ts
@@ -10,7 +10,6 @@ export class MetadataGenerator {
 
   public static IsExportedNode(node: ts.Node) {
     return true;
-    // return (node.flags & ts.NodeFlags.) !== 0 || (node.parent && node.parent.kind === ts.SyntaxKind.SourceFile);
   }
 
   constructor(entryFile: string) {

--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -47,38 +47,16 @@ function generateReferenceType(typeName: string, cacheReferenceType = true): Ref
   const existingType = localReferenceTypeCache[typeName];
   if (existingType) { return existingType; }
 
-  const interfaces = MetadataGenerator.current.nodes
-    .filter(node => {
-      if (node.kind !== ts.SyntaxKind.InterfaceDeclaration || !MetadataGenerator.IsExportedNode(node)) { return false; }
-      return (node as ts.InterfaceDeclaration).name.text.toLowerCase() === typeName.toLowerCase();
-    }) as ts.InterfaceDeclaration[];
-
-  if (!interfaces.length) { throw new Error(`No matching model found for referenced type ${typeName}`); }
-  if (interfaces.length > 1) { throw new Error(`Multiple matching models found for referenced type ${typeName}; please make model names unique.`); }
-
-  const interfaceDeclaration = interfaces[0];
+  const modelTypeDeclaration = getModelTypeDeclaration(typeName);
+  const properties = getModelTypeProperties(modelTypeDeclaration);
 
   const referenceType: ReferenceType = {
-    description: getModelDescription(interfaceDeclaration),
+    description: getModelDescription(modelTypeDeclaration),
     name: typeName,
-    properties: interfaceDeclaration.members
-      .filter(member => member.kind === ts.SyntaxKind.PropertySignature)
-      .map((property: any) => {
-        const propertyDeclaration = property as ts.PropertyDeclaration;
-        const identifier = propertyDeclaration.name as ts.Identifier;
-
-        if (!propertyDeclaration.type) { throw new Error('No valid type found for property declaration.'); }
-
-        return {
-          description: getPropertyDescription(propertyDeclaration),
-          name: identifier.text,
-          required: !property.questionToken,
-          type: ResolveType(propertyDeclaration.type)
-        };
-      })
+    properties: properties
   };
 
-  const extendedProperties = getExtendedProperties(interfaceDeclaration);
+  const extendedProperties = getInheritedProperties(modelTypeDeclaration);
   referenceType.properties = referenceType.properties.concat(extendedProperties);
 
   if (cacheReferenceType) {
@@ -89,18 +67,88 @@ function generateReferenceType(typeName: string, cacheReferenceType = true): Ref
   return referenceType;
 }
 
-function getExtendedProperties(interfaceDeclaration: ts.InterfaceDeclaration): Property[] {
+function getModelTypeDeclaration(typeName: string) {
+  const modelTypes = MetadataGenerator.current.nodes
+    .filter(node => {
+      if ((node.kind !== ts.SyntaxKind.InterfaceDeclaration && node.kind !== ts.SyntaxKind.ClassDeclaration) || !MetadataGenerator.IsExportedNode(node)) {
+        return false;
+      }
+
+      const modelTypeDeclaration = node as ts.InterfaceDeclaration | ts.ClassDeclaration;
+      return (modelTypeDeclaration.name as ts.Identifier).text.toLowerCase() === typeName.toLowerCase();
+    }) as Array<ts.InterfaceDeclaration | ts.ClassDeclaration>;
+
+  if (!modelTypes.length) { throw new Error(`No matching model found for referenced type ${typeName}`); }
+  if (modelTypes.length > 1) { throw new Error(`Multiple matching models found for referenced type ${typeName}; please make model names unique.`); }
+
+  return modelTypes[0];
+}
+
+function getModelTypeProperties(node: ts.InterfaceDeclaration | ts.ClassDeclaration) {
+  if (node.kind === ts.SyntaxKind.InterfaceDeclaration) {
+    const interfaceDeclaration = node as ts.InterfaceDeclaration;
+    return interfaceDeclaration.members
+      .filter(member => member.kind === ts.SyntaxKind.PropertySignature)
+      .map((property: any) => {
+        const propertyDeclaration = property as ts.PropertyDeclaration;
+        const identifier = propertyDeclaration.name as ts.Identifier;
+
+        if (!propertyDeclaration.type) { throw new Error('No valid type found for property declaration.'); }
+
+        return {
+          description: getNodeDescription(propertyDeclaration),
+          name: identifier.text,
+          required: !property.questionToken,
+          type: ResolveType(propertyDeclaration.type)
+        };
+      });
+  }
+
+  const classDeclaration = node as ts.ClassDeclaration;
+
+  let properties = classDeclaration.members.filter((member: any) => {
+    if (member.kind !== ts.SyntaxKind.PropertyDeclaration) { return false; }
+
+    const propertySignature = member as ts.PropertySignature;
+    return propertySignature && propertySignature.modifiers && hasPublicModifier(propertySignature);
+  }) as Array<ts.PropertyDeclaration | ts.ParameterDeclaration>;
+
+  const classConstructor = classDeclaration.members.find((member: any) => member.kind === ts.SyntaxKind.Constructor) as ts.ConstructorDeclaration;
+  if (classConstructor && classConstructor.parameters) {
+    properties = properties.concat(classConstructor.parameters.filter(parameter => hasPublicModifier(parameter)) as any);
+  }
+
+  return properties
+    .map(declaration => {
+      const identifier = declaration.name as ts.Identifier;
+
+      if (!declaration.type) { throw new Error('No valid type found for property declaration.'); }
+
+      return {
+        description: getNodeDescription(declaration),
+        name: identifier.text,
+        required: !declaration.questionToken,
+        type: ResolveType(declaration.type)
+      };
+    });
+}
+
+function hasPublicModifier(node: ts.Node) {
+  return node.modifiers && node.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.PublicKeyword);
+}
+
+function getInheritedProperties(modelTypeDeclaration: ts.InterfaceDeclaration | ts.ClassDeclaration): Property[] {
   const properties = new Array<Property>();
 
-  const heritageClauses = interfaceDeclaration.heritageClauses;
+  const heritageClauses = modelTypeDeclaration.heritageClauses;
   if (!heritageClauses) { return properties; }
 
-  heritageClauses.forEach(c => {
-    if (!c.types) { return; }
+  heritageClauses.forEach(clause => {
+    if (!clause.types) { return; }
 
-    c.types.forEach(t => {
-      const baseInterfaceName = t.expression as ts.Identifier;
-      generateReferenceType(baseInterfaceName.text, false).properties
+    clause.types.forEach(t => {
+      const baseIdentifier = t.expression as ts.Identifier;
+      generateReferenceType(baseIdentifier.text, false).properties
         .forEach(property => properties.push(property));
     });
   });
@@ -108,16 +156,22 @@ function getExtendedProperties(interfaceDeclaration: ts.InterfaceDeclaration): P
   return properties;
 }
 
-function getModelDescription(interfaceDeclaration: ts.InterfaceDeclaration) {
-  return getNodeDescription(interfaceDeclaration);
+function getModelDescription(modelTypeDeclaration: ts.InterfaceDeclaration | ts.ClassDeclaration) {
+  return getNodeDescription(modelTypeDeclaration);
 }
 
-function getPropertyDescription(propertyDeclaration: ts.PropertyDeclaration) {
-  return getNodeDescription(propertyDeclaration);
-}
+function getNodeDescription(node: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration) {
+  let symbol = MetadataGenerator.current.typeChecker.getSymbolAtLocation(node.name as ts.Node);
 
-function getNodeDescription(node: ts.InterfaceDeclaration | ts.PropertyDeclaration) {
-  let symbol = MetadataGenerator.current.typeChecker.getSymbolAtLocation(node.name);
+  /**
+   * TODO: Workaround for what seems like a bug in the compiler
+   * Warrants more investigation and possibly a PR against typescript
+   */
+  // 
+  if (node.kind === ts.SyntaxKind.Parameter) {
+    // TypeScript won't parse jsdoc if the flag is 4, i.e. 'Property'
+    symbol.flags = 0;
+  }
 
   let comments = symbol.getDocumentationComment();
   if (comments.length) { return ts.displayPartsToString(comments); }

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -2,7 +2,7 @@ import { Example } from '../../../src/decorators/example';
 import { Get } from '../../../src/decorators/methods';
 import { ModelService } from '../services/modelService';
 import { Route } from '../../../src/decorators/route';
-import { TestModel, TestSubModel } from '../testModel';
+import { TestModel, TestSubModel, TestClassModel } from '../testModel';
 
 @Route('GetTest')
 export class GetTestController {
@@ -33,6 +33,11 @@ export class GetTestController {
   @Get('Current')
   public async getCurrentModel(): Promise<TestModel> {
     return new ModelService().getModel();
+  }
+
+  @Get('ClassModel')
+  public async getClassModel(): Promise<TestClassModel> {
+    return new ModelService().getClassModel();
   }
 
   @Get('Multi')

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -1,6 +1,6 @@
 import { Route } from '../../../src/decorators/route';
 import { Post, Patch } from '../../../src/decorators/methods';
-import { TestModel } from '../testModel';
+import { TestModel, TestClassModel } from '../testModel';
 import { ModelService } from '../services/modelService';
 
 @Route('PostTest')
@@ -13,6 +13,14 @@ export class PostTestController {
   @Patch()
   public async updateModel(model: TestModel): Promise<TestModel> {
     return await new ModelService().getModel();
+  }
+
+  @Post('WithClassModel')
+  public async postClassModel(model: TestClassModel): Promise<TestClassModel> {
+    const augmentedModel = new TestClassModel('test', 'test2', 'test3');
+    augmentedModel.id = 700;
+
+    return augmentedModel;
   }
 
   @Post('Location')

--- a/tests/fixtures/routes.ts
+++ b/tests/fixtures/routes.ts
@@ -28,6 +28,13 @@ const models: any = {
     'optionalString': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
+  'TestClassModel': {
+    'publicStringProperty': { typeName: 'string', required: true },
+    'optionalPublicStringProperty': { typeName: 'string', required: false },
+    'publicConstructorVar': { typeName: 'string', required: true },
+    'optionalPublicConstructorVar': { typeName: 'string', required: false },
+    'id': { typeName: 'number', required: true },
+  },
   'Result': {
     'value': { typeName: 'object', required: true },
   },
@@ -121,6 +128,21 @@ export function RegisterRoutes(app: any) {
 
     const controller = new PostTestController();
     promiseHandler(controller.updateModel.apply(controller, validatedParams), res, next);
+  });
+  app.post('/PostTest/WithClassModel', function(req: any, res: any, next: any) {
+    const params = {
+      'model': { typeName: 'TestClassModel', required: true },
+    };
+
+    let validatedParams: any[] = [];
+    try {
+      validatedParams = getValidatedParams(params, req, 'model');
+    } catch (err) {
+      return next(err);
+    }
+
+    const controller = new PostTestController();
+    promiseHandler(controller.postClassModel.apply(controller, validatedParams), res, next);
   });
   app.post('/PostTest/Location', function(req: any, res: any, next: any) {
     const params = {
@@ -266,6 +288,20 @@ export function RegisterRoutes(app: any) {
 
     const controller = new GetTestController();
     promiseHandler(controller.getCurrentModel.apply(controller, validatedParams), res, next);
+  });
+  app.get('/GetTest/ClassModel', function(req: any, res: any, next: any) {
+    const params = {
+    };
+
+    let validatedParams: any[] = [];
+    try {
+      validatedParams = getValidatedParams(params, req, '');
+    } catch (err) {
+      return next(err);
+    }
+
+    const controller = new GetTestController();
+    promiseHandler(controller.getClassModel.apply(controller, validatedParams), res, next);
   });
   app.get('/GetTest/Multi', function(req: any, res: any, next: any) {
     const params = {

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -1,4 +1,4 @@
-import { TestModel, TestSubModel } from '../testModel';
+import { TestModel, TestSubModel, TestClassModel } from '../testModel';
 
 export class ModelService {
   public getModel(): TestModel {
@@ -17,5 +17,13 @@ export class ModelService {
       stringArray: ['string one', 'string two'],
       stringValue: 'a string'
     };
+  }
+
+  public getClassModel(): TestClassModel {
+    const testClassModel = new TestClassModel('constructor var', 'private constructor var');
+    testClassModel.id = 1;
+    testClassModel.publicStringProperty = 'public string property';
+
+    return testClassModel;
   }
 }

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -24,3 +24,30 @@ export interface TestSubModel extends Model {
 export interface Model {
   id: number;
 }
+
+export class TestClassBaseModel {
+  public id: number;
+}
+
+/**
+ * This is a description of TestClassModel
+ */
+export class TestClassModel extends TestClassBaseModel {
+  /**
+   * This is a description of a public string property
+   */
+  public publicStringProperty: string;
+  public optionalPublicStringProperty?: string;
+  protected protectedStringProperty: string;
+
+  /**
+   * @param publicConstructorVar This is a description for publicConstructorVar
+   */
+  constructor(
+    public publicConstructorVar: string,
+    protected protectedConstructorVar: string,
+    public optionalPublicConstructorVar?: string
+  ) {
+    super();
+  }
+}

--- a/tests/integration/server.spec.ts
+++ b/tests/integration/server.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { app } from '../fixtures/server';
-import { TestModel } from '../fixtures/testModel';
+import { TestModel, TestClassModel } from '../fixtures/testModel';
 import * as chai from 'chai';
 import * as request from 'supertest';
 
@@ -73,6 +73,15 @@ describe('Server', () => {
     return verifyPostRequest('/PostTest', data, (err: any, res: any) => {
       const model = res.body as TestModel;
       expect(model).to.deep.equal(model);
+    });
+  });
+
+  it('parses class model as body parameter', () => {
+    const data = getFakeClassModel();
+
+    return verifyPostRequest('/PostTest/WithClassModel', data, (err: any, res: any) => {
+      const model = res.body as TestClassModel;
+      expect(model.id).to.equal(700); // this gets changed on the server
     });
   });
 
@@ -175,5 +184,13 @@ describe('Server', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234'
     };
+  }
+
+  function getFakeClassModel() {
+    const model = new TestClassModel('test', 'test', 'test');
+    model.id = 100;
+    model.publicStringProperty = 'test';
+
+    return model;
   }
 });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -23,48 +23,141 @@ describe('Definition generation', () => {
     return definition;
   };
 
-  it('should generate a definition for referenced models', () => {
-    const expectedModels = ['TestModel', 'TestSubModel', 'Result'];
-    expectedModels.forEach(modelName => {
-      getValidatedDefinition(modelName);
+  describe('Interface-based generation', () => {
+    it('should generate a definition for referenced models', () => {
+      const expectedModels = ['TestModel', 'TestSubModel', 'Result'];
+      expectedModels.forEach(modelName => {
+        getValidatedDefinition(modelName);
+      });
+    });
+
+    it('should generate an member of type object for union type', () => {
+      const definition = getValidatedDefinition('Result');
+      if (!definition.properties) { throw new Error('Definition has no properties.'); }
+      if (!definition.properties['value']) { throw new Error('There was no \'value\' property.'); }
+
+      expect(definition.properties['value'].type).to.equal('object');
+    });
+
+    it('should generate a definition description from a model jsdoc comment', () => {
+      const definition = getValidatedDefinition('TestModel');
+      expect(definition.description).to.equal('This is a description of a model');
+    });
+
+    it('should generate a property description from a property jsdoc comment', () => {
+      const definition = getValidatedDefinition('TestModel');
+      if (!definition.properties) { throw new Error('Definition has no properties.'); }
+
+      const property = definition.properties['numberValue'];
+      if (!property) { throw new Error('There was no \'numberValue\' property.'); }
+
+      expect(property).to.exist;
+      expect(property.description).to.equal('This is a description of this model property, numberValue');
+    });
+
+    it('should generate properties from extended interface', () => {
+      const definition = getValidatedDefinition('TestModel');
+      if (!definition.properties) { throw new Error('Definition has no properties.'); }
+
+      const property = definition.properties['id'];
+
+      expect(property).to.exist;
+    });
+
+    it('should generate an optional property from an optional property', () => {
+      const definition = getValidatedDefinition('TestModel');
+      expect(definition.required).to.not.contain('optionalString');
     });
   });
 
-  it('should generate an member of type object for union type', () => {
-    const definition = getValidatedDefinition('Result');
-    if (!definition.properties) { throw new Error('Definition has no properties.'); }
-    if (!definition.properties['value']) { throw new Error('There was no \'value\' property.'); }
-
-    expect(definition.properties['value'].type).to.equal('object');
-  });
-
-  it('should generate a definition description from a model jsdoc comment', () => {
-    const definition = getValidatedDefinition('TestModel');
-    expect(definition.description).to.equal('This is a description of a model');
-  });
-
-  it('should generate a property description from a property jsdoc comment', () => {
-    const definition = getValidatedDefinition('TestModel');
+  describe('Class-based generation', () => {
+    const modelName = 'TestClassModel';
+    const definition = getValidatedDefinition(modelName);
     if (!definition.properties) { throw new Error('Definition has no properties.'); }
 
-    const property = definition.properties['numberValue'];
-    if (!property) { throw new Error('There was no \'numberValue\' property.'); }
+    const properties = definition.properties;
 
-    expect(property).to.exist;
-    expect(property.description).to.equal('This is a description of this model property, numberValue');
-  });
+    it('should generate a definition for referenced model', () => {
+      getValidatedDefinition(modelName);
+    });
 
-  it('should generate properties from extended interface', () => {
-    const definition = getValidatedDefinition('TestModel');
-    if (!definition.properties) { throw new Error('Definition has no properties.'); }
+    it('should generate a required property from a required property', () => {
+      const propertyName = 'publicStringProperty';
+      if (!properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was expected to exist.`);
+      }
 
-    const property = definition.properties['id'];
+      expect(definition.required).to.contain(propertyName);
+    });
 
-    expect(property).to.exist;
-  });
+    it('should generate an optional property from an optional property', () => {
+      const propertyName = 'optionalPublicStringProperty';
+      if (!properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was expected to exist.`);
+      }
 
-  it('should generate an optional property from an optional property', () => {
-    const definition = getValidatedDefinition('TestModel');
-    expect(definition.required).to.not.contain('optionalString');
+      expect(definition.required).to.not.contain(propertyName);
+    });
+
+    it('should generate a required property from a required constructor var', () => {
+      const propertyName = 'publicConstructorVar';
+      if (!properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was expected to exist.`);
+      }
+
+      expect(definition.required).to.contain(propertyName);
+    });
+
+    it('should generate an optional property from an optional constructor var', () => {
+      const propertyName = 'optionalPublicConstructorVar';
+      if (!properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was expected to exist.`);
+      }
+
+      expect(definition.required).to.not.contain(propertyName);
+    });
+
+    it('should not generate a property for a non-public property', () => {
+      const propertyName = 'protectedStringProperty';
+      if (properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was not expected to exist.`);
+      }
+    });
+
+    it('should not generate a property for a non-public constructor var', () => {
+      const propertyName = 'protectedConstructorVar';
+      if (properties[propertyName]) {
+        throw new Error(`Property '{propertyName}' was not expected to exist.`);
+      }
+    });
+
+    it('should generate properties from a base class', () => {
+      const property = properties['id'];
+      expect(property).to.exist;
+    });
+
+    it('should generate a definition description from a model jsdoc comment', () => {
+      expect(definition.description).to.equal('This is a description of TestClassModel');
+    });
+
+    it('should generate a property description from a property jsdoc comment', () => {
+      const propertyName = 'publicStringProperty';
+
+      const property = properties[propertyName];
+      if (!property) { throw new Error(`There was no '${propertyName}' property.`); }
+
+      expect(property).to.exist;
+      expect(property.description).to.equal('This is a description of a public string property');
+    });
+
+    it('should generate a property description from a constructor var jsdoc comment', () => {
+      const propertyName = 'publicConstructorVar';
+
+      const property = properties[propertyName];
+      if (!property) { throw new Error(`There was no '${propertyName}' property.`); }
+
+      expect(property).to.exist;
+      expect(property.description).to.equal('This is a description for publicConstructorVar');
+    });
   });
 });


### PR DESCRIPTION
Today, only interfaces can be used as controller method return types or param types. As #13 points out, there is a valid use case for using classes for definitions.

This revision implements class-based model generation in the following ways.

TypeScript classes can be used as return type models, e.g.

```
@Route('GetTest')
export class GetTestController {

  @Get('ClassModel')
  public async getClassModel(): Promise<TestClassModel> {
    return new ModelService().getClassModel();
  }
}

export class TestClassBaseModel {
  public id: number;
}

/**
 * This is a description of TestClassModel
 */
export class TestClassModel extends TestClassBaseModel {
  /**
   * This is a description of a public string property
   */
  public publicStringProperty: string;
  public optionalPublicStringProperty?: string;
  protected protectedStringProperty: string;

  /**
   * @param publicConstructorVar This is a description for publicConstructorVar
   */
  constructor(
    public publicConstructorVar: string,
    protected protectedConstructorVar: string,
    public optionalPublicConstructorVar?: string
  ) {
    super();
  }
}
```

Classes can also be used (and thus validated) in requests to the server:

```
@Route('PostTest')
export class PostTestController {
  @Post('WithClassModel')
  public async postClassModel(model: TestClassModel): Promise<TestClassModel> {
    const augmentedModel = new TestClassModel('test', 'test2', 'test3');
    augmentedModel.id = 700;

    return augmentedModel;
  }
}
```

Generation of swagger descriptions works in similar fashion to interfaces, where jsdoc comments are parsed and added to the spec.

Constructor variables (e.g. `constructor(public readonly myProperty: string)` are treated as properties and are added to the spec. Only public properties and constructor properties are added.

## Caveats

One 'gotcha' is, when making a request to the server using the generated routes where the contract requires an instance of a class in the request (see the second example above), that class is *not* instantiated, which could lead to some deceptive behavior. From the body of your controller method, you may actually work with your instance as if it were a fully bonified class. In reality, you're working with a POJO with no methods or other class behavior.

I've updated the readme to state that interfaces as models are _preferred_. Classes may make sense to use in some cases, but in the majority of cases, I think interfaces are a better representation of the data exchange that occurs between client and server.