### PR TITLE
add an opportunity to add various tags to routes methods of swagger.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 typings
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 typings
 .idea
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 typings
 .idea
 yarn.lock
+*.log

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sl-tsoa",
   "description": "Build swagger-compliant REST APIs using TypeScript and Node",
-  "version": "0.0.63",
+  "version": "0.1.0",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sl-tsoa",
   "description": "Build swagger-compliant REST APIs using TypeScript and Node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsoa",
+  "name": "sl-tsoa",
   "description": "Build swagger-compliant REST APIs using TypeScript and Node",
   "version": "0.0.63",
   "main": "./dist/index.js",
@@ -33,7 +33,7 @@
     "handlebars": "^4.0.5",
     "mkdirp": "^0.5.1",
     "moment": "^2.14.1",
-    "typescript": "^2.1.0-dev.20160910",
+    "typescript": "^2.0.3",
     "typescript-formatter": "^2.3.0",
     "yargs": "^4.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sl-tsoa",
+  "name": "tsoa",
   "description": "Build swagger-compliant REST APIs using TypeScript and Node",
-  "version": "0.1.1",
+  "version": "0.0.63",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "keywords": [
@@ -33,7 +33,7 @@
     "handlebars": "^4.0.5",
     "mkdirp": "^0.5.1",
     "moment": "^2.14.1",
-    "typescript": "^2.0.3",
+    "typescript": "^2.1.0-dev.20160910",
     "typescript-formatter": "^2.3.0",
     "yargs": "^4.8.1"
   },

--- a/src/metadataGeneration/extraTagsGenerator.ts
+++ b/src/metadataGeneration/extraTagsGenerator.ts
@@ -18,7 +18,7 @@ export class ExtraTagsGenerator {
 
     public static getTags(node: tsserver.Node): string[]{
         let tags: string[] = [];
-        node.jsDocComments.forEach((comment: ts.JSDocComment)=> {
+        node.jsDocComments && node.jsDocComments.forEach((comment: ts.JSDocComment)=> {
             if(comment.tags){
                 comment.tags.forEach((tag: tsserver.JSDocTag)=>{
                     tags = ExtraTagsGenerator.processTag(tag);

--- a/src/metadataGeneration/extraTagsGenerator.ts
+++ b/src/metadataGeneration/extraTagsGenerator.ts
@@ -1,0 +1,69 @@
+import { Type, Parameter } from './metadataGenerator';
+import {MethodGenerator} from "./methodGenerator";
+import * as ts from 'typescript';
+
+
+export interface Method {
+    description: string;
+    example: any;
+    method: string;
+    name: string;
+    parameters: Parameter[];
+    path: string;
+    type: Type;
+    tags?: string[];
+}
+
+export class ExtraTagsGenerator {
+
+    public static getTags(generator: MethodGenerator): string[]{
+        let tags: string[] = [];
+        generator.node.jsDocComments.forEach((comment)=>{
+            if(comment.tags){
+                comment.tags.forEach((tag)=>{
+                    tags = ExtraTagsGenerator.processTag(tag);
+                });
+            }
+        });
+        return tags;
+    }
+
+    private static processTag(tag: ts.JsDocTag): string[]{
+        let tags: string[] = [];
+        if(tag && tag.tagName.text == "tags"){
+            switch(tag.tagName.text){
+                case "tags":
+                    tags = tags.concat(new Function(`return ${tag.comment};`)());
+                    break;
+            }
+        }
+        return tags;
+    }
+
+}
+
+export function ExtraTags(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any>{
+    let originalMethod = descriptor.value;
+    descriptor.value = function(...args: any[]){
+        let result = originalMethod.apply(this, args);
+        // here we should add our extra tags
+        result.tags = ExtraTagsGenerator.getTags(this);
+        return result;
+    }
+    return descriptor;
+}
+
+export function ExtraMethodProperty(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>): TypedPropertyDescriptor<any>{
+    let originalMethod = descriptor.value;
+    descriptor.value = function(...args: any[]){
+        let result = originalMethod.apply(this, args);
+        // here we should add our extra properties for swagger.json
+        let method = args[0], pathObject = args[1];
+        let pathMethod = pathObject[method.method];
+        if(method.tags && method.tags.length){
+            pathMethod.tags = method.tags;
+        }
+        return result;
+    }
+    return descriptor;
+}

--- a/src/metadataGeneration/extraTagsGenerator.ts
+++ b/src/metadataGeneration/extraTagsGenerator.ts
@@ -18,9 +18,9 @@ export class ExtraTagsGenerator {
 
     public static getTags(node: tsserver.Node): string[]{
         let tags: string[] = [];
-        node.jsDocComments && node.jsDocComments.forEach((comment: ts.JSDocComment)=> {
+        node.jsDocComments && node.jsDocComments.forEach((comment: ts.JSDoc)=> {
             if(comment.tags){
-                comment.tags.forEach((tag: tsserver.JSDocTag)=>{
+                comment.tags.forEach((tag: ts.JSDocTag)=>{
                     tags = ExtraTagsGenerator.processTag(tag);
                 });
             }
@@ -28,7 +28,7 @@ export class ExtraTagsGenerator {
         return tags;
     }
 
-    private static processTag(tag: tsserver.JSDocTag): string[]{
+    private static processTag(tag: ts.JSDocTag): string[]{
         let tags: string[] = [];
         if(tag && tag.tagName.text == "tags"){
             switch(tag.tagName.text){

--- a/src/metadataGeneration/extraTagsGenerator.ts
+++ b/src/metadataGeneration/extraTagsGenerator.ts
@@ -1,6 +1,6 @@
 import { Type, Parameter } from './metadataGenerator';
-import {MethodGenerator} from "./methodGenerator";
 import * as ts from 'typescript';
+import * as tsserver from '../tsserver';
 
 
 export interface Method {
@@ -16,11 +16,11 @@ export interface Method {
 
 export class ExtraTagsGenerator {
 
-    public static getTags(generator: MethodGenerator): string[]{
+    public static getTags(node: tsserver.Node): string[]{
         let tags: string[] = [];
-        generator.node.jsDocComments.forEach((comment)=>{
+        node.jsDocComments.forEach((comment: ts.JSDocComment)=> {
             if(comment.tags){
-                comment.tags.forEach((tag)=>{
+                comment.tags.forEach((tag: tsserver.JSDocTag)=>{
                     tags = ExtraTagsGenerator.processTag(tag);
                 });
             }
@@ -28,7 +28,7 @@ export class ExtraTagsGenerator {
         return tags;
     }
 
-    private static processTag(tag: ts.JsDocTag): string[]{
+    private static processTag(tag: tsserver.JSDocTag): string[]{
         let tags: string[] = [];
         if(tag && tag.tagName.text == "tags"){
             switch(tag.tagName.text){
@@ -47,9 +47,9 @@ export function ExtraTags(target: Object, propertyKey: string, descriptor: Typed
     descriptor.value = function(...args: any[]){
         let result = originalMethod.apply(this, args);
         // here we should add our extra tags
-        result.tags = ExtraTagsGenerator.getTags(this);
+        result.tags = ExtraTagsGenerator.getTags(this.node);
         return result;
-    }
+    };
     return descriptor;
 }
 

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
-import { Method, MetadataGenerator } from './metadataGenerator';
+import { MetadataGenerator } from './metadataGenerator';
+import { Method, ExtraTags } from './extraTagsGenerator';
 import { ResolveType } from './resolveType';
 import { ParameterGenerator } from './parameterGenerator';
 
@@ -15,6 +16,7 @@ export class MethodGenerator {
     return !!this.method;
   }
 
+  @ExtraTags
   public Generate(): Method {
     if (!this.IsValid()) { throw new Error('This isn\'t a valid a controller method.'); }
     if (!this.node.type) { throw new Error('Controller methods must have a return type.'); }

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -31,7 +31,7 @@ export class RouteGenerator {
   private buildContent(middlewareTemplate: string) {
     let canImportByAlias: boolean;
     try {
-      require('sl-tsoa');
+      require('tsoa');
       canImportByAlias = true;
     } catch (err) {
       canImportByAlias = false;
@@ -42,7 +42,7 @@ export class RouteGenerator {
             /**
              * THIS IS GENERATED CODE - DO NOT EDIT
              */
-            import {ValidateParam} from '${canImportByAlias ? 'sl-tsoa' : '../../src/routeGeneration/templateHelpers'}';
+            import {ValidateParam} from '${canImportByAlias ? 'tsoa' : '../../src/routeGeneration/templateHelpers'}';
             {{#each controllers}}
             import { {{name}} } from '{{modulePath}}';
             {{/each}}

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -31,18 +31,18 @@ export class RouteGenerator {
   private buildContent(middlewareTemplate: string) {
     let canImportByAlias: boolean;
     try {
-      require('tsoa');
+      require('sl-tsoa');
       canImportByAlias = true;
     } catch (err) {
       canImportByAlias = false;
     }
 
     const routesTemplate = handlebars.compile(`
+            /* tslint:disable */
             /**
              * THIS IS GENERATED CODE - DO NOT EDIT
              */
-            /* tslint:disable */
-            import {ValidateParam} from '${canImportByAlias ? 'tsoa' : '../../src/routeGeneration/templateHelpers'}';
+            import {ValidateParam} from '${canImportByAlias ? 'sl-tsoa' : '../../src/routeGeneration/templateHelpers'}';
             {{#each controllers}}
             import { {{name}} } from '{{modulePath}}';
             {{/each}}

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -1,5 +1,6 @@
 /// <reference path="../ambient.d.ts" />
-import { Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Method, Parameter } from '../metadataGeneration/metadataGenerator';
+import { Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Parameter } from '../metadataGeneration/metadataGenerator';
+import { Method, ExtraMethodProperty } from '../metadataGeneration/extraTagsGenerator';
 import { Swagger } from './swagger';
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
@@ -85,6 +86,7 @@ export class SpecGenerator {
     return paths;
   }
 
+  @ExtraMethodProperty
   private buildPathMethod(method: Method, pathObject: any) {
     const swaggerType = this.getSwaggerType(method.type);
     const pathMethod: any = pathObject[method.method] = swaggerType.type === 'void'

--- a/src/tsserver.d.ts
+++ b/src/tsserver.d.ts
@@ -2,10 +2,7 @@ import * as ts from 'typescript';
 
 declare namespace tsserver {
     interface Node extends ts.Node {
-        jsDocComments?: ts.JSDocComment[];
-    }
-    interface JSDocTag extends ts.JSDocTag {
-        comment: string;
+        jsDocComments?: ts.JSDoc[];
     }
 }
 

--- a/src/tsserver.d.ts
+++ b/src/tsserver.d.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 
 declare namespace tsserver {
     interface Node extends ts.Node {
-        jsDocComments: ts.JSDocComment[];
+        jsDocComments?: ts.JSDocComment[];
     }
     interface JSDocTag extends ts.JSDocTag {
         comment: string;

--- a/src/tsserver.d.ts
+++ b/src/tsserver.d.ts
@@ -1,0 +1,12 @@
+import * as ts from 'typescript';
+
+declare namespace tsserver {
+    interface Node extends ts.Node {
+        jsDocComments: ts.JSDocComment[];
+    }
+    interface JSDocTag extends ts.JSDocTag {
+        comment: string;
+    }
+}
+
+export = tsserver;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "newLine": "LF"
-
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
Hi, Luke.

I added an opportunity to add various tags to swagger.json file methods.
For example there was not any ways to add "tags" property to any methods to separate our api methods in swagger. Now we can just add @tags ["users", "accounts"] to our controller method jsdoc description and they will appear into swagger.json.

Regards, Anatoly.
