### PR TITLE
Add support for injected express request and other values

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -104,6 +104,28 @@ app.listen(3000);
 
 ```
 
+### Get access to the request object of express in Controllers
+
+To access the request object of express in a controller method use the `@Request`-decorator:
+```typescript
+// controllers/usersController.ts
+
+import * as express from 'express';
+import {Get, Route, Request} from 'tsoa';
+import {User, UserCreationRequest} from '../models/user';
+
+@Route('Users')
+export class UsersController {
+    @Get('{id}')
+    public async getUser(id: number, @Request() request: express.Request): Promise<User> {
+        // TODO: implement some code that uses request as well
+    }
+}
+```
+Note that the parameter `request` does not appear in your swagger definition file. 
+Likewise you can use the decorator `@Inject` to mark a parameter as being injected manually and should be omitted in swagger generation.
+In this case you should write your own custom template where you inject the needed objects/values in the method-call. 
+
 ### Use awesome Swagger tools
 
 Now that you have a swagger spec (swagger.json), you can use all kinds of amazing tools that [generate documentation, client SDKs, and more](http://swagger.io/).

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -1,0 +1,22 @@
+/**
+ * Decorator to denote a controller methods parameter
+ *  as being injected instead of being parsed from
+ *  the request.
+ * To inject a parameter in your controller use a custom
+ *  template.
+ * Injected parameters do not show up in your swagger file.
+ */
+export function Inject(value?: string): any {
+  return () => { return; };
+}
+
+/**
+ * Decorator to mark a controller methods parameter to
+ *  be the express request object. This parameter is
+ *  injected automatically by the express template into
+ *  your controller.
+ * Request parameters do not show up in your swagger file.
+ */
+export function Request(value?: string): any {
+  return () => { return; };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Example } from './decorators/example';
+import { Inject, Request } from './decorators/inject';
 import { Post, Get, Patch, Delete, Put } from './decorators/methods';
 import { Route } from './decorators/route';
 import { JWT } from './decorators/jwt';
@@ -9,9 +10,11 @@ export {
   Delete,
   Example,
   Get,
+  Inject,
   Patch,
   Post,
   Put,
+  Request,
   Route,
   ValidateParam,
   JWT,

--- a/src/metadataGeneration/metadataGenerator.ts
+++ b/src/metadataGeneration/metadataGenerator.ts
@@ -84,12 +84,15 @@ export interface Method {
   type: Type;
 }
 
+export type InjectType = 'request' | 'inject';
+
 export interface Parameter {
   description: string;
   in: string;
   name: string;
   required: boolean;
   type: Type;
+  injected?: InjectType;
 }
 
 export type Type = PrimitiveType | ReferenceType | ArrayType;

--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -1,4 +1,4 @@
-import { MetadataGenerator, Parameter, Type } from './metadataGenerator';
+import { InjectType, MetadataGenerator, Parameter, Type } from './metadataGenerator';
 import { ResolveType } from './resolveType';
 import * as ts from 'typescript';
 
@@ -11,6 +11,22 @@ export class ParameterGenerator {
 
   public Generate(): Parameter {
     const parameterIdentifier = this.parameter.name as ts.Identifier;
+    const injectDecorators = this.getDecorators(identifier => {
+      return this.getValidInjectors().some(m => m.toLowerCase() === identifier.text.toLowerCase());
+    });
+    if (injectDecorators && injectDecorators.length > 1) {
+      throw new Error(`Only one inject decorator allowed per parameter. Found: ${injectDecorators.map(d => d.text).join(', ')}`);
+    }
+    if (injectDecorators && injectDecorators.length === 1) {
+      return {
+        description: this.getParameterDescription(this.parameter),
+        in: 'inject',
+        injected: <InjectType>injectDecorators[0].text.toLowerCase(),
+        name: parameterIdentifier.text,
+        required: !this.parameter.questionToken,
+        type: 'object'
+      };
+    }
     if (this.path.includes(`{${parameterIdentifier.text}}`)) {
       return this.getPathParameter(this.parameter);
     }
@@ -102,5 +118,19 @@ export class ParameterGenerator {
   private getValidatedType(parameter: ts.ParameterDeclaration) {
     if (!parameter.type) { throw new Error(`Parameter ${parameter.name} doesn't have a valid type assigned.`); }
     return ResolveType(parameter.type);
+  }
+
+  private getDecorators(isMatching: (identifier: ts.Identifier) => boolean) {
+    const decorators = this.parameter.decorators;
+    if (!decorators || !decorators.length) { return; }
+
+    return decorators
+      .map(d => d.expression as ts.CallExpression)
+      .map(e => e.expression as ts.Identifier)
+      .filter(isMatching);
+  }
+
+  private getValidInjectors() {
+    return ['inject', 'request'];
   }
 }

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -1,5 +1,5 @@
 import { expressTemplate } from './templates/express';
-import { Metadata, Type, ArrayType, ReferenceType, Parameter, Property } from '../metadataGeneration/metadataGenerator';
+import { InjectType, Metadata, Type, ArrayType, ReferenceType, Parameter, Property } from '../metadataGeneration/metadataGenerator';
 import { RoutesConfig } from './../config';
 import * as fs from 'fs';
 import * as handlebars from 'handlebars';
@@ -123,6 +123,10 @@ export class RouteGenerator {
       required: source.required,
       typeName: this.getStringRepresentationOfType(source.type)
     };
+    const parameter = source as Parameter;
+    if (parameter.injected) {
+      templateProperty.injected = parameter.injected;
+    }
 
     const arrayType = source.type as ArrayType;
     if (arrayType.elementType) {
@@ -147,4 +151,5 @@ interface TemplateProperty {
   typeName: string;
   required: boolean;
   arrayType?: string;
+  injected?: InjectType;
 }

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -5,7 +5,7 @@ export function RegisterRoutes(app: any) {
         app.{{method}}('{{../../basePath}}/{{../path}}{{path}}', function (req: any, res: any, next: any) {
             const params = {
                 {{#each parameters}}
-                '{{name}}': { typeName: '{{typeName}}', required: {{required}} {{#if arrayType}}, arrayType: '{{arrayType}}' {{/if}} },
+                '{{name}}': { typeName: '{{typeName}}', required: {{required}} {{#if arrayType}}, arrayType: '{{arrayType}}' {{/if}} {{#if injected}}, injected: '{{injected}}' {{/if}} },
                 {{/each}}
             };
 
@@ -57,7 +57,13 @@ export function RegisterRoutes(app: any) {
         const requestParams = getRequestParams(request, bodyParamName);
         
         return Object.keys(params).map(key => {
-            return ValidateParam(params[key], requestParams[key], models, key);
+            if (params[key].injected === 'inject') {
+              return undefined;
+            } else if (params[key].injected === 'request') {
+              return request;
+            } else {
+              return ValidateParam(params[key], requestParams[key], models, key);
+            }
         });
     }
 }`;

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -99,7 +99,7 @@ export class SpecGenerator {
       : this.get200Operation(swaggerType, method.example, method.name);
 
     pathMethod.description = method.description;
-    pathMethod.parameters = method.parameters.map(p => this.buildParameter(p));
+    pathMethod.parameters = method.parameters.filter(p => !p.injected).map(p => this.buildParameter(p));
 
     if (jwtUserProperty !== '') {
       pathMethod.security = [

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -1,4 +1,5 @@
 import { Example } from '../../../src/decorators/example';
+import { Inject, Request } from '../../../src/decorators/inject';
 import { Get } from '../../../src/decorators/methods';
 import { ModelService } from '../services/modelService';
 import { Route } from '../../../src/decorators/route';
@@ -81,6 +82,22 @@ export class GetTestController {
   @Get('UnionTypeResponse')
   public async getUnionTypeResponse(): Promise<string | boolean> {
     return '';
+  }
+
+  @Get('InjectedRequest')
+  public async getInjectedRequest( @Request() request: Object): Promise<TestModel> {
+    let model = new ModelService().getModel();
+    // set the stringValue from the request context to test successful injection
+    model.stringValue = (<any>request).stringValue;
+    return model;
+  }
+
+  @Get('InjectedValue')
+  public async getInjectedValue( @Inject() someValue: string): Promise<TestModel> {
+    let model = new ModelService().getModel();
+    // set the stringValue to the injected value to test successful injection
+    model.stringValue = someValue;
+    return model;
   }
 }
 

--- a/tests/fixtures/routes.ts
+++ b/tests/fixtures/routes.ts
@@ -372,6 +372,36 @@ export function RegisterRoutes(app: any) {
     const controller = new GetTestController();
     promiseHandler(controller.getUnionTypeResponse.apply(controller, validatedParams), res, next);
   });
+  app.get('/v1/GetTest/InjectedRequest', function(req: any, res: any, next: any) {
+    const params = {
+      'request': { typeName: 'object', required: true, injected: 'request' },
+    };
+
+    let validatedParams: any[] = [];
+    try {
+      validatedParams = getValidatedParams(params, req, '');
+    } catch (err) {
+      return next(err);
+    }
+
+    const controller = new GetTestController();
+    promiseHandler(controller.getInjectedRequest.apply(controller, validatedParams), res, next);
+  });
+  app.get('/v1/GetTest/InjectedValue', function(req: any, res: any, next: any) {
+    const params = {
+      'someValue': { typeName: 'object', required: true, injected: 'inject' },
+    };
+
+    let validatedParams: any[] = [];
+    try {
+      validatedParams = getValidatedParams(params, req, '');
+    } catch (err) {
+      return next(err);
+    }
+
+    const controller = new GetTestController();
+    promiseHandler(controller.getInjectedValue.apply(controller, validatedParams), res, next);
+  });
   app.delete('/v1/DeleteTest', function(req: any, res: any, next: any) {
     const params = {
     };
@@ -468,7 +498,13 @@ export function RegisterRoutes(app: any) {
     const requestParams = getRequestParams(request, bodyParamName);
 
     return Object.keys(params).map(key => {
-      return ValidateParam(params[key], requestParams[key], models, key);
+      if (params[key].injected === 'inject') {
+        return undefined;
+      } else if (params[key].injected === 'request') {
+        return request;
+      } else {
+        return ValidateParam(params[key], requestParams[key], models, key);
+      }
     });
   }
 }

--- a/tests/fixtures/server.ts
+++ b/tests/fixtures/server.ts
@@ -15,6 +15,11 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(methodOverride());
 app.use('/v1/JwtGetTest', jwt(<Options>{ userProperty: 'user_jwt_data' }));
+// set a context value in express request object to test request injection
+app.use((req: any, res: any, next: any) => {
+  req.stringValue = 'fancyStringForContext';
+  next();
+});
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered

--- a/tests/integration/server.spec.ts
+++ b/tests/integration/server.spec.ts
@@ -39,6 +39,22 @@ describe('Server', () => {
     });
   });
 
+  it('injects express request in parameters', () => {
+    return verifyGetRequest(basePath + `/GetTest/InjectedRequest`, (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+      expect(model.stringValue).to.equal('fancyStringForContext');
+    });
+  });
+
+  it('injects undefined as custom value in parameters', () => {
+    return verifyGetRequest(basePath + `/GetTest/InjectedValue`, (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+      expect(model.stringValue).to.be.undefined;
+    });
+  });
+
   it('returns error if missing required query parameter', () => {
     return verifyGetRequest(basePath + `/GetTest/${1}/${true}/test?booleanParam=true&stringParam=test1234`, (err: any, res: any) => {
       expect(err.text).to.equal('numberParam is a required parameter.');

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1,0 +1,64 @@
+import 'mocha';
+import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
+import * as chai from 'chai';
+
+const expect = chai.expect;
+
+describe('Metadata generation', () => {
+  const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
+
+  describe('MetadataGenerator', () => {
+    it('should generate one controller', () => {
+      expect(metadata.Controllers.length).to.equal(1);
+      expect(metadata.Controllers[0].name).to.equal('GetTestController');
+      expect(metadata.Controllers[0].path).to.equal('GetTest');
+    });
+  });
+
+  describe('MethodGenerator', () => {
+    const controller = metadata.Controllers[0];
+    const definedMethods = ['getModel', 'getCurrentModel',
+      'getClassModel', 'getMultipleModels', 'getModelByParams',
+      'getResponseWithUnionTypeProperty', 'getUnionTypeResponse',
+      'getInjectedRequest', 'getInjectedValue'];
+
+    it('should only generate the defined methods', () => {
+      expect(controller.methods.filter(m => definedMethods.indexOf(m.name) === -1).length).to.equal(0);
+    });
+
+    it('should generate the defined methods', () => {
+      expect(definedMethods.filter(methodName =>
+        controller.methods.map(m => m.name).indexOf(methodName) === -1).length).to.equal(0);
+    });
+
+    it('should generate an injected request parameter', () => {
+      const method = controller.methods.find(m => m.name === 'getInjectedRequest');
+      if (!method) {
+        throw new Error('Method getInjectedRequest not defined!');
+      }
+      expect(method.parameters.length).to.equal(1);
+      const requestParameter = method.parameters[0];
+      expect(requestParameter.description).to.equal('');
+      expect(requestParameter.in).to.equal('inject');
+      expect(requestParameter.injected).to.equal('request');
+      expect(requestParameter.name).to.equal('request');
+      expect(requestParameter.required).to.be.true;
+      expect(requestParameter.type).to.equal('object');
+    });
+
+    it('should generate an injected value parameter', () => {
+      const method = controller.methods.find(m => m.name === 'getInjectedValue');
+      if (!method) {
+        throw new Error('Method getInjectedValue not defined!');
+      }
+      expect(method.parameters.length).to.equal(1);
+      const requestParameter = method.parameters[0];
+      expect(requestParameter.description).to.equal('');
+      expect(requestParameter.in).to.equal('inject');
+      expect(requestParameter.injected).to.equal('inject');
+      expect(requestParameter.name).to.equal('someValue');
+      expect(requestParameter.required).to.be.true;
+      expect(requestParameter.type).to.equal('object');
+    });
+  });
+});

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -101,6 +101,24 @@ describe('GET route generation', () => {
     expect(successResponse.schema.type).to.equal('object');
   });
 
+  it('should not generate a parameter for a parameter decorated with @Request', () => {
+    const actionRoute = `${baseRoute}/InjectedRequest`;
+    const get = getValidatedGetOperation(actionRoute);
+    expect(get.parameters).not.to.be.undefined;
+    if (get.parameters) {
+      expect(get.parameters.length).to.equal(0);
+    }
+  });
+
+  it('should not generate a parameter for a parameter decorated with @Reject', () => {
+    const actionRoute = `${baseRoute}/InjectedValue`;
+    const get = getValidatedGetOperation(actionRoute);
+    expect(get.parameters).not.to.be.undefined;
+    if (get.parameters) {
+      expect(get.parameters.length).to.equal(0);
+    }
+  });
+
   it('should reject complex types as arguments', () => {
     expect(() => {
       const invalidMetadata = new MetadataGenerator('./tests/fixtures/controllers/invalidGetController.ts').Generate();


### PR DESCRIPTION
Here is a proposition how to implement support for express request parameter in controllers as well as other custom values injected by a custom template.
See also my proposition/question [here](https://github.com/lukeautry/tsoa/issues/7)