### PR TITLE
fix for more recent typescript version + stricker checks

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -17,11 +17,11 @@ export function ValidateParam(typeData: any, value: any, generatedModels: any, n
     case 'string':
       return validateString(value, name);
     case 'boolean':
-      return validateBool(value, name);
+      return validateBool(value, <any>name);
     case 'number':
-      return validateNumber(value, name);
+      return validateNumber(value, <any>name);
     case 'array':
-      return validateArray(value, typeData.arrayType, name);
+      return validateArray(value, typeData.arrayType, <any>name);
     case 'datetime':
       return validateDate(value, name);
     default:

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -1,4 +1,5 @@
 export const expressTemplate = `
+/* tslint:disable:forin */
 export function RegisterRoutes(app: any) {
     {{#each controllers}}
     {{#each actions}}
@@ -45,7 +46,7 @@ export function RegisterRoutes(app: any) {
     function getRequestParams(request: any, bodyParamName?: string) {
         const merged: any = {};
         if (bodyParamName) {
-            merged[bodyParamName] = request.body;            
+            merged[bodyParamName] = request.body;
         }
 
         for (let attrname in request.params) { merged[attrname] = request.params[attrname]; }
@@ -55,7 +56,7 @@ export function RegisterRoutes(app: any) {
 
     function getValidatedParams(params: any, request: any, bodyParamName?: string): any[] {
         const requestParams = getRequestParams(request, bodyParamName);
-        
+
         return Object.keys(params).map(key => {
             if (params[key].injected === 'inject') {
               return undefined;

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -1,5 +1,6 @@
 // TODO: Replace this with HAPI middleware stuff
 export const hapiTemplate = `
+/* tslint:disable:forin */
 import * as hapi from 'hapi';
 
 export function RegisterRoutes(server: hapi.Server) {

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -1,4 +1,5 @@
 export const koaTemplate = `
+/* tslint:disable:forin */
 import * as KoaRouter from 'koa-router';
 
 export function RegisterRoutes(router: KoaRouter) {
@@ -41,14 +42,14 @@ export function RegisterRoutes(router: KoaRouter) {
         .catch((error: any) => {
           context.status = error.status || 500;
           context.body = error;
-          next();  
+          next();
         });
     }
 
     function getRequestParams(context: KoaRouter.IRouterContext, bodyParamName?: string) {
         const merged: any = {};
         if (bodyParamName) {
-            merged[bodyParamName] = context.request.body;            
+            merged[bodyParamName] = context.request.body;
         }
 
         for (let attrname in context.params) { merged[attrname] = context.params[attrname]; }
@@ -58,7 +59,7 @@ export function RegisterRoutes(router: KoaRouter) {
 
     function getValidatedParams(params: any, context: KoaRouter.IRouterContext, bodyParamName?: string): any[] {
         const requestParams = getRequestParams(context, bodyParamName);
-        
+
         return Object.keys(params).map(key => {
             if (params[key].injected === 'inject') {
               return undefined;


### PR DESCRIPTION
Recent versions of typescript (+it's typings) have stricker checks on handling nulls for strings.