### PR TITLE
Custom generated spec behavior configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "app-root-path": "^1.4.0",
     "express": "^4.14.0",
     "handlebars": "^4.0.6",
+    "merge": "^1.2.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.17.1",
     "tslint": "^4.1.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,16 @@ export interface SwaggerConfig {
   * Note that generated properties will always take precedence over what get specified here
   */
   spec?: any;
+  
+  /**
+   * Alter how the spec is merged to generated swagger spec.
+   * Possible values:
+   *  - 'immediate' is overriding top level elements only thus you can not append a new path or alter an existing value without erasing same level elements.
+   *  - 'recursive' proceed to a deep merge and will concat every branches or override or create new values if needed. @see https://www.npmjs.com/package/merge
+   * The default is set to immediate so it is not breaking previous versions.
+   * @default 'immediate'
+   */
+  specMerging?: 'immediate' | 'recursive';
 }
 
 export interface RoutesConfig {

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -38,7 +38,7 @@ export class SpecGenerator {
     }
 
     if (this.config.description) { spec.info.description = this.config.description; }
-    if (this.config.license) { spec.info.license = {name: this.config.license}; }
+    if (this.config.license) { spec.info.license = { name: this.config.license }; }
     if (this.config.name) { spec.info.title = this.config.name; }
     if (this.config.version) { spec.info.version = this.config.version; }
     if (this.config.host) { spec.host = this.config.host; }
@@ -174,7 +174,7 @@ export class SpecGenerator {
   }
 
   private getSwaggerTypeForPrimitiveType(primitiveTypeName: PrimitiveType) {
-    const typeMap: {[name: string]: Swagger.Schema} = {
+    const typeMap: { [name: string]: Swagger.Schema } = {
       boolean: { type: 'boolean' },
       buffer: { type: 'string', format: 'base64' },
       datetime: { format: 'date-time', type: 'string' },
@@ -202,7 +202,7 @@ export class SpecGenerator {
       operationId: methodName,
       produces: ['application/json'],
       responses: {
-        '200': { description: '', examples: {'application/json': example}, schema: swaggerType }
+        '200': { description: '', examples: { 'application/json': example }, schema: swaggerType }
       }
     };
   }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -1,11 +1,11 @@
-import { SwaggerConfig } from './../config';
-import { Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Method, Parameter } from '../metadataGeneration/metadataGenerator';
-import { Swagger } from './swagger';
+import {SwaggerConfig} from './../config';
+import {Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Method, Parameter} from '../metadataGeneration/metadataGenerator';
+import {Swagger} from './swagger';
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
 
 export class SpecGenerator {
-  constructor(private readonly metadata: Metadata, private readonly config: SwaggerConfig) { }
+  constructor(private readonly metadata: Metadata, private readonly config: SwaggerConfig) {}
 
   public GenerateJson(swaggerDir: string) {
     mkdirp(swaggerDir, (dirErr: any) => {
@@ -37,21 +37,27 @@ export class SpecGenerator {
       spec.securityDefinitions = this.buildJwtSecurityDefinition();
     }
 
-    if (this.config.description) { spec.info.description = this.config.description; }
-    if (this.config.license) { spec.info.license = { name: this.config.license }; }
-    if (this.config.name) { spec.info.title = this.config.name; }
-    if (this.config.version) { spec.info.version = this.config.version; }
-    if (this.config.host) { spec.host = this.config.host; }
+    if (this.config.description) {spec.info.description = this.config.description;}
+    if (this.config.license) {spec.info.license = {name: this.config.license};}
+    if (this.config.name) {spec.info.title = this.config.name;}
+    if (this.config.version) {spec.info.version = this.config.version;}
+    if (this.config.host) {spec.host = this.config.host;}
 
     if (this.config.spec) {
-      spec = Object.assign(spec, this.config.spec);
+      this.config.specMerging = this.config.specMerging || 'immediate';
+      const mergeFuncs: {[key: string]: Function} = {
+        recursive: require('merge').recursive,
+        immediate: Object.assign
+      };
+      
+      spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);
     }
 
     return spec;
   }
 
   private buildDefinitions() {
-    const definitions: { [definitionsName: string]: Swagger.Schema } = {};
+    const definitions: {[definitionsName: string]: Swagger.Schema} = {};
     Object.keys(this.metadata.ReferenceTypes).map(typeName => {
       const referenceType = this.metadata.ReferenceTypes[typeName];
       definitions[referenceType.name] = {
@@ -73,7 +79,7 @@ export class SpecGenerator {
 
   private buildJwtSecurityDefinition() {
     return {
-      'Bearer': <Swagger.ApiKeySecurity>{
+      'Bearer': <Swagger.ApiKeySecurity> {
         description: 'JWT token with bearer word in front of it',
         in: 'header',
         name: 'Authorization',
@@ -83,7 +89,7 @@ export class SpecGenerator {
   }
 
   private buildPaths() {
-    const paths: { [pathName: string]: Swagger.Path } = {};
+    const paths: {[pathName: string]: Swagger.Path} = {};
 
     this.metadata.Controllers.forEach(controller => {
       controller.methods.forEach(method => {
@@ -105,7 +111,7 @@ export class SpecGenerator {
     pathMethod.description = method.description;
     pathMethod.parameters = method.parameters.filter(p => !p.injected).map(p => this.buildParameter(p));
 
-    if (method.tags.length) { pathMethod.tags = method.tags; }
+    if (method.tags.length) {pathMethod.tags = method.tags;}
 
     if (jwtUserProperty !== '') {
       pathMethod.security = [
@@ -135,13 +141,13 @@ export class SpecGenerator {
       swaggerParameter.type = parameterType.type;
     }
 
-    if (parameterType.format) { swaggerParameter.format = parameterType.format; }
+    if (parameterType.format) {swaggerParameter.format = parameterType.format;}
 
     return swaggerParameter;
   }
 
   private buildProperties(properties: Property[]) {
-    const swaggerProperties: { [propertyName: string]: Swagger.Schema } = {};
+    const swaggerProperties: {[propertyName: string]: Swagger.Schema} = {};
 
     properties.forEach(property => {
       const swaggerType = this.getSwaggerType(property.type);
@@ -168,14 +174,14 @@ export class SpecGenerator {
   }
 
   private getSwaggerTypeForPrimitiveType(primitiveTypeName: PrimitiveType) {
-    const typeMap: { [name: string]: Swagger.Schema } = {
-      boolean: { type: 'boolean' },
-      buffer: { type: 'string', format: 'base64' },
-      datetime: { format: 'date-time', type: 'string' },
-      number: { format: 'int64', type: 'integer' },
-      object: { type: 'object' },
-      string: { type: 'string' },
-      void: { type: 'void' }
+    const typeMap: {[name: string]: Swagger.Schema} = {
+      boolean: {type: 'boolean'},
+      buffer: {type: 'string', format: 'base64'},
+      datetime: {format: 'date-time', type: 'string'},
+      number: {format: 'int64', type: 'integer'},
+      object: {type: 'object'},
+      string: {type: 'string'},
+      void: {type: 'void'}
     };
 
     return typeMap[primitiveTypeName];
@@ -184,11 +190,11 @@ export class SpecGenerator {
   private getSwaggerTypeForArrayType(arrayType: ArrayType): Swagger.Schema {
     const elementType = arrayType.elementType;
 
-    return { items: this.getSwaggerType(elementType), type: 'array' };
+    return {items: this.getSwaggerType(elementType), type: 'array'};
   }
 
   private getSwaggerTypeForReferenceType(referenceType: ReferenceType): Swagger.Schema {
-    return { $ref: `#/definitions/${referenceType.name}` };
+    return {$ref: `#/definitions/${referenceType.name}`};
   }
 
   private get200Operation(swaggerType: Swagger.Schema, example: any, methodName: string) {
@@ -196,7 +202,7 @@ export class SpecGenerator {
       operationId: methodName,
       produces: ['application/json'],
       responses: {
-        '200': { description: '', examples: { 'application/json': example }, schema: swaggerType }
+        '200': {description: '', examples: {'application/json': example}, schema: swaggerType}
       }
     };
   }
@@ -205,7 +211,7 @@ export class SpecGenerator {
     return {
       operationId: methodName,
       responses: {
-        '204': { description: 'No content' }
+        '204': {description: 'No content'}
       }
     };
   }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -1,11 +1,11 @@
-import {SwaggerConfig} from './../config';
-import {Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Method, Parameter} from '../metadataGeneration/metadataGenerator';
-import {Swagger} from './swagger';
+import { SwaggerConfig } from './../config';
+import { Metadata, Type, ArrayType, ReferenceType, PrimitiveType, Property, Method, Parameter } from '../metadataGeneration/metadataGenerator';
+import { Swagger } from './swagger';
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
 
 export class SpecGenerator {
-  constructor(private readonly metadata: Metadata, private readonly config: SwaggerConfig) {}
+  constructor(private readonly metadata: Metadata, private readonly config: SwaggerConfig) { }
 
   public GenerateJson(swaggerDir: string) {
     mkdirp(swaggerDir, (dirErr: any) => {
@@ -37,11 +37,11 @@ export class SpecGenerator {
       spec.securityDefinitions = this.buildJwtSecurityDefinition();
     }
 
-    if (this.config.description) {spec.info.description = this.config.description;}
-    if (this.config.license) {spec.info.license = {name: this.config.license};}
-    if (this.config.name) {spec.info.title = this.config.name;}
-    if (this.config.version) {spec.info.version = this.config.version;}
-    if (this.config.host) {spec.host = this.config.host;}
+    if (this.config.description) { spec.info.description = this.config.description; }
+    if (this.config.license) { spec.info.license = {name: this.config.license}; }
+    if (this.config.name) { spec.info.title = this.config.name; }
+    if (this.config.version) { spec.info.version = this.config.version; }
+    if (this.config.host) { spec.host = this.config.host; }
 
     if (this.config.spec) {
       this.config.specMerging = this.config.specMerging || 'immediate';
@@ -57,7 +57,7 @@ export class SpecGenerator {
   }
 
   private buildDefinitions() {
-    const definitions: {[definitionsName: string]: Swagger.Schema} = {};
+    const definitions: { [definitionsName: string]: Swagger.Schema } = {};
     Object.keys(this.metadata.ReferenceTypes).map(typeName => {
       const referenceType = this.metadata.ReferenceTypes[typeName];
       definitions[referenceType.name] = {
@@ -79,7 +79,7 @@ export class SpecGenerator {
 
   private buildJwtSecurityDefinition() {
     return {
-      'Bearer': <Swagger.ApiKeySecurity> {
+      'Bearer': <Swagger.ApiKeySecurity>{
         description: 'JWT token with bearer word in front of it',
         in: 'header',
         name: 'Authorization',
@@ -89,7 +89,7 @@ export class SpecGenerator {
   }
 
   private buildPaths() {
-    const paths: {[pathName: string]: Swagger.Path} = {};
+    const paths: { [pathName: string]: Swagger.Path } = {};
 
     this.metadata.Controllers.forEach(controller => {
       controller.methods.forEach(method => {
@@ -111,7 +111,7 @@ export class SpecGenerator {
     pathMethod.description = method.description;
     pathMethod.parameters = method.parameters.filter(p => !p.injected).map(p => this.buildParameter(p));
 
-    if (method.tags.length) {pathMethod.tags = method.tags;}
+    if (method.tags.length) { pathMethod.tags = method.tags; }
 
     if (jwtUserProperty !== '') {
       pathMethod.security = [
@@ -141,13 +141,13 @@ export class SpecGenerator {
       swaggerParameter.type = parameterType.type;
     }
 
-    if (parameterType.format) {swaggerParameter.format = parameterType.format;}
+    if (parameterType.format) { swaggerParameter.format = parameterType.format; }
 
     return swaggerParameter;
   }
 
   private buildProperties(properties: Property[]) {
-    const swaggerProperties: {[propertyName: string]: Swagger.Schema} = {};
+    const swaggerProperties: { [propertyName: string]: Swagger.Schema } = {};
 
     properties.forEach(property => {
       const swaggerType = this.getSwaggerType(property.type);
@@ -175,13 +175,13 @@ export class SpecGenerator {
 
   private getSwaggerTypeForPrimitiveType(primitiveTypeName: PrimitiveType) {
     const typeMap: {[name: string]: Swagger.Schema} = {
-      boolean: {type: 'boolean'},
-      buffer: {type: 'string', format: 'base64'},
-      datetime: {format: 'date-time', type: 'string'},
-      number: {format: 'int64', type: 'integer'},
-      object: {type: 'object'},
-      string: {type: 'string'},
-      void: {type: 'void'}
+      boolean: { type: 'boolean' },
+      buffer: { type: 'string', format: 'base64' },
+      datetime: { format: 'date-time', type: 'string' },
+      number: { format: 'int64', type: 'integer' },
+      object: { type: 'object' },
+      string: { type: 'string' },
+      void: { type: 'void' }
     };
 
     return typeMap[primitiveTypeName];
@@ -190,11 +190,11 @@ export class SpecGenerator {
   private getSwaggerTypeForArrayType(arrayType: ArrayType): Swagger.Schema {
     const elementType = arrayType.elementType;
 
-    return {items: this.getSwaggerType(elementType), type: 'array'};
+    return { items: this.getSwaggerType(elementType), type: 'array' };
   }
 
   private getSwaggerTypeForReferenceType(referenceType: ReferenceType): Swagger.Schema {
-    return {$ref: `#/definitions/${referenceType.name}`};
+    return { $ref: `#/definitions/${referenceType.name}` };
   }
 
   private get200Operation(swaggerType: Swagger.Schema, example: any, methodName: string) {
@@ -202,7 +202,7 @@ export class SpecGenerator {
       operationId: methodName,
       produces: ['application/json'],
       responses: {
-        '200': {description: '', examples: {'application/json': example}, schema: swaggerType}
+        '200': { description: '', examples: {'application/json': example}, schema: swaggerType }
       }
     };
   }
@@ -211,7 +211,7 @@ export class SpecGenerator {
     return {
       operationId: methodName,
       responses: {
-        '204': {description: 'No content'}
+        '204': { description: 'No content' }
       }
     };
   }


### PR DESCRIPTION
Allow to alter the way custom spec (from tsao.json by default) is merged to generated swagger spec by a configuration option in SwaggerConfig interface named specMerging. The default value is meant to not break existing projects meaning this update is harmless.
```typescript
 /**
   * Alter how the spec is merged to generated swagger spec.
   * Possible values:
   *  - 'immediate' is overriding top level elements only thus you can not append a new path or alter an existing value without erasing same level elements.
   *  - 'recursive' proceed to a deep merge and will concat every branches or override or create new values if needed. @see https://www.npmjs.com/package/merge
   * The default is set to immediate so it is not breaking previous versions.
   * @default 'immediate'
   */
  specMerging?: 'immediate' | 'recursive';
```