### PR TITLE
Added genericType handling for request/response objects

### DIFF
--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -105,7 +105,7 @@ function getTypeName(typeName: string, genericTypes?: ts.TypeNode[]): string {
     return getAnyTypeName(t);
   });
 
-  return typeName + '<' + names.join(', ') + '>';
+  return typeName + names.join('');
 }
 
 function getAnyTypeName(typeNode: ts.TypeNode): string {

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -77,7 +77,7 @@ export class RouteGenerator {
                 },
                 {{/each}}
             };
-        `.concat(middlewareTemplate));
+        `.concat(middlewareTemplate), { noEscape: true });
 
     const authenticationModule = this.options.authenticationModule ? this.getRelativeImportPath(this.options.authenticationModule) : undefined;
     const iocModule = this.options.iocModule ? this.getRelativeImportPath(this.options.iocModule) : undefined;

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -4,7 +4,7 @@ import { Get } from '../../../src/decorators/methods';
 import { Controller } from '../../../src/interfaces/controller';
 import { ModelService } from '../services/modelService';
 import { Route } from '../../../src/decorators/route';
-import { TestModel, TestSubModel, TestClassModel } from '../testModel';
+import { GenericModel, TestModel, TestSubModel, TestClassModel } from '../testModel';
 import { Tags } from '../../../src/decorators/tags';
 
 @Route('GetTest')
@@ -121,6 +121,36 @@ export class GetTestController extends Controller {
   @Get('HandleBufferType')
   public async getBuffer(@Query() buffer: Buffer): Promise<Buffer> {
     return new Buffer('testbuffer');
+  }
+
+  @Get('GenericModel')
+  public async getGenericModel(): Promise<GenericModel<TestModel>> {
+    return {
+      result: new ModelService().getModel()
+    };
+  }
+
+  @Get('GenericModelArray')
+  public async getGenericModelArray(): Promise<GenericModel<TestModel[]>> {
+    return {
+      result: [
+        new ModelService().getModel()
+      ]
+    };
+  }
+
+  @Get('GenericPrimitive')
+  public async getGenericPrimitive(): Promise<GenericModel<string>> {
+    return {
+      result: new ModelService().getModel().stringValue
+    };
+  }
+
+  @Get('GenericPrimitiveArray')
+  public async getGenericPrimitiveArray(): Promise<GenericModel<string[]>> {
+    return {
+      result: new ModelService().getModel().stringArray
+    };
   }
 }
 

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -1,7 +1,7 @@
 import { Route } from '../../../src/decorators/route';
 import { Body, Query } from '../../../src/decorators/parameter';
 import { Post, Patch } from '../../../src/decorators/methods';
-import { TestModel, TestClassModel } from '../testModel';
+import { GenericRequest, TestModel, TestClassModel } from '../testModel';
 import { ModelService } from '../services/modelService';
 
 @Route('PostTest')
@@ -47,5 +47,10 @@ export class PostTestController {
   @Post('WithBodyAndQueryParams')
   public async postWithBodyAndQueryParams(@Body() model: TestModel, @Query() query: string): Promise<TestModel> {
     return new ModelService().getModel();
+  }
+
+  @Post('GenericBody')
+  public async getGenericRequest(@Body() genericReq: GenericRequest<TestModel>): Promise<TestModel> {
+    return genericReq.value;
   }
 }

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -41,23 +41,23 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
-  'GenericRequest<TestModel>': {
+  'GenericRequestTestModel': {
     'name': { typeName: 'string', required: true },
     'value': { typeName: 'TestModel', required: true },
   },
   'Result': {
     'value': { typeName: 'object', required: true },
   },
-  'GenericModel<TestModel>': {
+  'GenericModelTestModel': {
     'result': { typeName: 'TestModel', required: true },
   },
-  'GenericModel<TestModel[]>': {
+  'GenericModelTestModel[]': {
     'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
   },
-  'GenericModel<string>': {
+  'GenericModelstring': {
     'result': { typeName: 'string', required: true },
   },
-  'GenericModel<string[]>': {
+  'GenericModelstring[]': {
     'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
@@ -334,7 +334,7 @@ export function RegisterRoutes(app: any) {
   app.post('/v1/PostTest/GenericBody',
     function(request: any, response: any, next: any) {
       const args = {
-        'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+        'genericReq': { name: 'genericReq', typeName: 'GenericRequestTestModel', required: true, in: 'body', },
       };
 
       let validatedArgs: any[] = [];

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -41,8 +41,24 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
+  'GenericRequest<TestModel>': {
+    'name': { typeName: 'string', required: true },
+    'value': { typeName: 'TestModel', required: true },
+  },
   'Result': {
     'value': { typeName: 'object', required: true },
+  },
+  'GenericModel<TestModel>': {
+    'result': { typeName: 'TestModel', required: true },
+  },
+  'GenericModel<TestModel[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
+  },
+  'GenericModel<string>': {
+    'result': { typeName: 'string', required: true },
+  },
+  'GenericModel<string[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
     'status': { typeName: 'number', required: true },
@@ -309,6 +325,29 @@ export function RegisterRoutes(app: any) {
 
 
       const promise = controller.postWithBodyAndQueryParams.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+      promiseHandler(promise, statusCode, response, next);
+    });
+  app.post('/v1/PostTest/GenericBody',
+    function(request: any, response: any, next: any) {
+      const args = {
+        'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller = new PostTestController();
+
+
+      const promise = controller.getGenericRequest.apply(controller, validatedArgs);
       let statusCode = undefined;
       if (controller instanceof Controller) {
         statusCode = (controller as Controller).getStatus();
@@ -673,6 +712,94 @@ export function RegisterRoutes(app: any) {
 
 
       const promise = controller.getBuffer.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+      promiseHandler(promise, statusCode, response, next);
+    });
+  app.get('/v1/GetTest/GenericModel',
+    function(request: any, response: any, next: any) {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller = new GetTestController();
+
+
+      const promise = controller.getGenericModel.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+      promiseHandler(promise, statusCode, response, next);
+    });
+  app.get('/v1/GetTest/GenericModelArray',
+    function(request: any, response: any, next: any) {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller = new GetTestController();
+
+
+      const promise = controller.getGenericModelArray.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+      promiseHandler(promise, statusCode, response, next);
+    });
+  app.get('/v1/GetTest/GenericPrimitive',
+    function(request: any, response: any, next: any) {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller = new GetTestController();
+
+
+      const promise = controller.getGenericPrimitive.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+      promiseHandler(promise, statusCode, response, next);
+    });
+  app.get('/v1/GetTest/GenericPrimitiveArray',
+    function(request: any, response: any, next: any) {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller = new GetTestController();
+
+
+      const promise = controller.getGenericPrimitiveArray.apply(controller, validatedArgs);
       let statusCode = undefined;
       if (controller instanceof Controller) {
         statusCode = (controller as Controller).getStatus();

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -41,8 +41,24 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
+  'GenericRequest<TestModel>': {
+    'name': { typeName: 'string', required: true },
+    'value': { typeName: 'TestModel', required: true },
+  },
   'Result': {
     'value': { typeName: 'object', required: true },
+  },
+  'GenericModel<TestModel>': {
+    'result': { typeName: 'TestModel', required: true },
+  },
+  'GenericModel<TestModel[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
+  },
+  'GenericModel<string>': {
+    'result': { typeName: 'string', required: true },
+  },
+  'GenericModel<string[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
     'status': { typeName: 'number', required: true },
@@ -352,6 +368,33 @@ export function RegisterRoutes(server: hapi.Server) {
         const controller = new PostTestController();
 
         const promise = controller.postWithBodyAndQueryParams.apply(controller, validatedArgs);
+        let statusCode = undefined;
+        if (controller instanceof Controller) {
+          statusCode = (controller as Controller).getStatus();
+        }
+        return promiseHandler(promise, statusCode, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
+    path: '/v1/PostTest/GenericBody',
+    config: {
+      handler: (request: any, reply) => {
+        const args = {
+          'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+        };
+
+        let validatedArgs: any[] = [];
+        try {
+          validatedArgs = getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status || 500);
+        }
+
+        const controller = new PostTestController();
+
+        const promise = controller.getGenericRequest.apply(controller, validatedArgs);
         let statusCode = undefined;
         if (controller instanceof Controller) {
           statusCode = (controller as Controller).getStatus();
@@ -789,6 +832,110 @@ export function RegisterRoutes(server: hapi.Server) {
     }
   });
   server.route({
+    method: 'get',
+    path: '/v1/GetTest/GenericModel',
+    config: {
+      handler: (request: any, reply) => {
+        const args = {
+        };
+
+        let validatedArgs: any[] = [];
+        try {
+          validatedArgs = getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status || 500);
+        }
+
+        const controller = new GetTestController();
+
+        const promise = controller.getGenericModel.apply(controller, validatedArgs);
+        let statusCode = undefined;
+        if (controller instanceof Controller) {
+          statusCode = (controller as Controller).getStatus();
+        }
+        return promiseHandler(promise, statusCode, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
+    path: '/v1/GetTest/GenericModelArray',
+    config: {
+      handler: (request: any, reply) => {
+        const args = {
+        };
+
+        let validatedArgs: any[] = [];
+        try {
+          validatedArgs = getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status || 500);
+        }
+
+        const controller = new GetTestController();
+
+        const promise = controller.getGenericModelArray.apply(controller, validatedArgs);
+        let statusCode = undefined;
+        if (controller instanceof Controller) {
+          statusCode = (controller as Controller).getStatus();
+        }
+        return promiseHandler(promise, statusCode, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
+    path: '/v1/GetTest/GenericPrimitive',
+    config: {
+      handler: (request: any, reply) => {
+        const args = {
+        };
+
+        let validatedArgs: any[] = [];
+        try {
+          validatedArgs = getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status || 500);
+        }
+
+        const controller = new GetTestController();
+
+        const promise = controller.getGenericPrimitive.apply(controller, validatedArgs);
+        let statusCode = undefined;
+        if (controller instanceof Controller) {
+          statusCode = (controller as Controller).getStatus();
+        }
+        return promiseHandler(promise, statusCode, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
+    path: '/v1/GetTest/GenericPrimitiveArray',
+    config: {
+      handler: (request: any, reply) => {
+        const args = {
+        };
+
+        let validatedArgs: any[] = [];
+        try {
+          validatedArgs = getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status || 500);
+        }
+
+        const controller = new GetTestController();
+
+        const promise = controller.getGenericPrimitiveArray.apply(controller, validatedArgs);
+        let statusCode = undefined;
+        if (controller instanceof Controller) {
+          statusCode = (controller as Controller).getStatus();
+        }
+        return promiseHandler(promise, statusCode, request, reply);
+      }
+    }
+  });
+  server.route({
     method: 'delete',
     path: '/v1/DeleteTest',
     config: {
@@ -1113,8 +1260,8 @@ export function RegisterRoutes(server: hapi.Server) {
       pre: [
         {
           method: authenticateMiddleware('api_key'
-          )        
-}
+          )
+        }
       ],
       handler: (request: any, reply) => {
         const args = {
@@ -1149,8 +1296,8 @@ export function RegisterRoutes(server: hapi.Server) {
               'write:pets',
               'read:pets'
             ]
-          )
-        }
+          )        
+}
       ],
       handler: (request: any, reply) => {
         const args = {
@@ -1381,8 +1528,8 @@ export function RegisterRoutes(server: hapi.Server) {
       pre: [
         {
           method: authenticateMiddleware('api_key'
-          )
-        }
+          )        
+}
       ],
       handler: (request: any, reply) => {
         const args = {
@@ -1414,8 +1561,8 @@ export function RegisterRoutes(server: hapi.Server) {
       pre: [
         {
           method: authenticateMiddleware('api_key'
-          )        
-}
+          )
+        }
       ],
       handler: (request: any, reply) => {
         const args = {

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -41,23 +41,23 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
-  'GenericRequest<TestModel>': {
+  'GenericRequestTestModel': {
     'name': { typeName: 'string', required: true },
     'value': { typeName: 'TestModel', required: true },
   },
   'Result': {
     'value': { typeName: 'object', required: true },
   },
-  'GenericModel<TestModel>': {
+  'GenericModelTestModel': {
     'result': { typeName: 'TestModel', required: true },
   },
-  'GenericModel<TestModel[]>': {
+  'GenericModelTestModel[]': {
     'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
   },
-  'GenericModel<string>': {
+  'GenericModelstring': {
     'result': { typeName: 'string', required: true },
   },
-  'GenericModel<string[]>': {
+  'GenericModelstring[]': {
     'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
@@ -382,7 +382,7 @@ export function RegisterRoutes(server: hapi.Server) {
     config: {
       handler: (request: any, reply) => {
         const args = {
-          'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+          'genericReq': { name: 'genericReq', typeName: 'GenericRequestTestModel', required: true, in: 'body', },
         };
 
         let validatedArgs: any[] = [];

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -41,8 +41,24 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
+  'GenericRequest<TestModel>': {
+    'name': { typeName: 'string', required: true },
+    'value': { typeName: 'TestModel', required: true },
+  },
   'Result': {
     'value': { typeName: 'object', required: true },
+  },
+  'GenericModel<TestModel>': {
+    'result': { typeName: 'TestModel', required: true },
+  },
+  'GenericModel<TestModel[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
+  },
+  'GenericModel<string>': {
+    'result': { typeName: 'string', required: true },
+  },
+  'GenericModel<string[]>': {
+    'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
     'status': { typeName: 'number', required: true },
@@ -331,6 +347,31 @@ export function RegisterRoutes(router: KoaRouter) {
       const controller = new PostTestController();
 
       const promise = controller.postWithBodyAndQueryParams.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+
+      return promiseHandler(promise, statusCode, context, next);
+    });
+  router.post('/v1/PostTest/GenericBody',
+    async (context, next) => {
+      const args = {
+        'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, context);
+      } catch (error) {
+        context.status = error.status || 500;
+        context.body = error;
+        return next();
+      }
+
+      const controller = new PostTestController();
+
+      const promise = controller.getGenericRequest.apply(controller, validatedArgs);
       let statusCode = undefined;
       if (controller instanceof Controller) {
         statusCode = (controller as Controller).getStatus();
@@ -727,6 +768,102 @@ export function RegisterRoutes(router: KoaRouter) {
       const controller = new GetTestController();
 
       const promise = controller.getBuffer.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+
+      return promiseHandler(promise, statusCode, context, next);
+    });
+  router.get('/v1/GetTest/GenericModel',
+    async (context, next) => {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, context);
+      } catch (error) {
+        context.status = error.status || 500;
+        context.body = error;
+        return next();
+      }
+
+      const controller = new GetTestController();
+
+      const promise = controller.getGenericModel.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+
+      return promiseHandler(promise, statusCode, context, next);
+    });
+  router.get('/v1/GetTest/GenericModelArray',
+    async (context, next) => {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, context);
+      } catch (error) {
+        context.status = error.status || 500;
+        context.body = error;
+        return next();
+      }
+
+      const controller = new GetTestController();
+
+      const promise = controller.getGenericModelArray.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+
+      return promiseHandler(promise, statusCode, context, next);
+    });
+  router.get('/v1/GetTest/GenericPrimitive',
+    async (context, next) => {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, context);
+      } catch (error) {
+        context.status = error.status || 500;
+        context.body = error;
+        return next();
+      }
+
+      const controller = new GetTestController();
+
+      const promise = controller.getGenericPrimitive.apply(controller, validatedArgs);
+      let statusCode = undefined;
+      if (controller instanceof Controller) {
+        statusCode = (controller as Controller).getStatus();
+      }
+
+      return promiseHandler(promise, statusCode, context, next);
+    });
+  router.get('/v1/GetTest/GenericPrimitiveArray',
+    async (context, next) => {
+      const args = {
+      };
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = getValidatedArgs(args, context);
+      } catch (error) {
+        context.status = error.status || 500;
+        context.body = error;
+        return next();
+      }
+
+      const controller = new GetTestController();
+
+      const promise = controller.getGenericPrimitiveArray.apply(controller, validatedArgs);
       let statusCode = undefined;
       if (controller instanceof Controller) {
         statusCode = (controller as Controller).getStatus();

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -41,23 +41,23 @@ const models: any = {
     'optionalPublicConstructorVar': { typeName: 'string', required: false },
     'id': { typeName: 'number', required: true },
   },
-  'GenericRequest<TestModel>': {
+  'GenericRequestTestModel': {
     'name': { typeName: 'string', required: true },
     'value': { typeName: 'TestModel', required: true },
   },
   'Result': {
     'value': { typeName: 'object', required: true },
   },
-  'GenericModel<TestModel>': {
+  'GenericModelTestModel': {
     'result': { typeName: 'TestModel', required: true },
   },
-  'GenericModel<TestModel[]>': {
+  'GenericModelTestModel[]': {
     'result': { typeName: 'array', required: true, arrayType: 'TestModel' },
   },
-  'GenericModel<string>': {
+  'GenericModelstring': {
     'result': { typeName: 'string', required: true },
   },
-  'GenericModel<string[]>': {
+  'GenericModelstring[]': {
     'result': { typeName: 'array', required: true, arrayType: 'string' },
   },
   'ErrorResponseModel': {
@@ -357,7 +357,7 @@ export function RegisterRoutes(router: KoaRouter) {
   router.post('/v1/PostTest/GenericBody',
     async (context, next) => {
       const args = {
-        'genericReq': { name: 'genericReq', typeName: 'GenericRequest<TestModel>', required: true, in: 'body', },
+        'genericReq': { name: 'genericReq', typeName: 'GenericRequestTestModel', required: true, in: 'body', },
       };
 
       let validatedArgs: any[] = [];

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -83,3 +83,12 @@ export class TestClassModel extends TestClassBaseModel {
     super();
   }
 }
+
+export interface GenericModel<T> {
+  result: T;
+}
+
+export interface GenericRequest<T> {
+  name: string;
+  value: T;
+}

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { app } from '../fixtures/express/server';
-import { TestModel, TestClassModel, UserResponseModel, ParameterTestModel } from '../fixtures/testModel';
+import { GenericModel, GenericRequest, TestModel, TestClassModel, UserResponseModel, ParameterTestModel } from '../fixtures/testModel';
 import * as chai from 'chai';
 import * as request from 'supertest';
 import { base64image } from '../fixtures/base64image';
@@ -263,6 +263,46 @@ describe('Express Server', () => {
         expect(model.lastname).to.equal('Stark');
         expect(model.age).to.equal(45);
         expect(model.human).to.equal(true);
+      });
+    });
+
+    it('can get request with generic type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
+        const model = res.body as GenericModel<TestModel>;
+        expect(model.result.id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
+        const model = res.body as GenericModel<TestModel[]>;
+        expect(model.result[0].id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic primative type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
+        const model = res.body as GenericModel<string>;
+        expect(model.result).to.equal('a string');
+      });
+    });
+
+    it('can get request with generic primative array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
+        const model = res.body as GenericModel<string[]>;
+        expect(model.result[0]).to.equal('string one');
+      });
+    });
+
+    it('can post request with a generic body', () => {
+
+      const data: GenericRequest<TestModel> = {
+        name: 'something',
+        value: getFakeModel()
+      };
+      return verifyPostRequest(basePath + '/PostTest/GenericBody', data, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.id).to.equal(1);
       });
     });
   });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { server } from '../fixtures/hapi/server';
-import { TestModel, TestClassModel, Model, ParameterTestModel } from '../fixtures/testModel';
+import { GenericModel, GenericRequest, TestModel, TestClassModel, Model, ParameterTestModel } from '../fixtures/testModel';
 import * as chai from 'chai';
 import * as request from 'supertest';
 
@@ -250,6 +250,46 @@ describe('Hapi Server', () => {
         expect(model.lastname).to.equal('Stark');
         expect(model.age).to.equal(45);
         expect(model.human).to.equal(true);
+      });
+    });
+
+    it('can get request with generic type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
+        const model = res.body as GenericModel<TestModel>;
+        expect(model.result.id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
+        const model = res.body as GenericModel<TestModel[]>;
+        expect(model.result[0].id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic primative type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
+        const model = res.body as GenericModel<string>;
+        expect(model.result).to.equal('a string');
+      });
+    });
+
+    it('can get request with generic primative array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
+        const model = res.body as GenericModel<string[]>;
+        expect(model.result[0]).to.equal('string one');
+      });
+    });
+
+    it('can post request with a generic body', () => {
+
+      const data: GenericRequest<TestModel> = {
+        name: 'something',
+        value: getFakeModel()
+      };
+      return verifyPostRequest(basePath + '/PostTest/GenericBody', data, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.id).to.equal(1);
       });
     });
   });

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { server } from '../fixtures/koa/server';
-import { TestModel, TestClassModel, Model, ParameterTestModel } from '../fixtures/testModel';
+import { GenericModel, GenericRequest, TestModel, TestClassModel, Model, ParameterTestModel } from '../fixtures/testModel';
 import * as chai from 'chai';
 import * as request from 'supertest';
 
@@ -228,6 +228,46 @@ describe('Koa Server', () => {
         expect(model.lastname).to.equal('Stark');
         expect(model.age).to.equal(45);
         expect(model.human).to.equal(true);
+      });
+    });
+
+    it('can get request with generic type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
+        const model = res.body as GenericModel<TestModel>;
+        expect(model.result.id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
+        const model = res.body as GenericModel<TestModel[]>;
+        expect(model.result[0].id).to.equal(1);
+      });
+    });
+
+    it('can get request with generic primative type', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
+        const model = res.body as GenericModel<string>;
+        expect(model.result).to.equal('a string');
+      });
+    });
+
+    it('can get request with generic primative array', () => {
+      return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
+        const model = res.body as GenericModel<string[]>;
+        expect(model.result[0]).to.equal('string one');
+      });
+    });
+
+    it('can post request with a generic body', () => {
+
+      const data: GenericRequest<TestModel> = {
+        name: 'something',
+        value: getFakeModel()
+      };
+      return verifyPostRequest(basePath + '/PostTest/GenericBody', data, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.id).to.equal(1);
       });
     });
   });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -171,7 +171,7 @@ describe('Definition generation', () => {
 
   describe('Generic-based generation', () => {
     it('should generate different definitions for a generic model', () => {
-      const definition = getValidatedDefinition('GenericModel<TestModel>').properties;
+      const definition = getValidatedDefinition('GenericModelTestModel').properties;
 
       if (!definition) { throw new Error(`There were no properties on model.`); }
 
@@ -181,7 +181,7 @@ describe('Definition generation', () => {
       expect(property['$ref']).to.equal('#/definitions/TestModel');
     });
     it('should generate different definitions for a generic model array', () => {
-      const definition = getValidatedDefinition('GenericModel<TestModel[]>').properties;
+      const definition = getValidatedDefinition('GenericModelTestModel[]').properties;
 
       if (!definition) { throw new Error(`There were no properties on model.`); }
 
@@ -194,7 +194,7 @@ describe('Definition generation', () => {
       expect((property.items as Swagger.Schema)['$ref']).to.equal('#/definitions/TestModel');
     });
     it('should generate different definitions for a generic primitive', () => {
-      const definition = getValidatedDefinition('GenericModel<string>').properties;
+      const definition = getValidatedDefinition('GenericModelstring').properties;
 
       if (!definition) { throw new Error(`There were no properties on model.`); }
 
@@ -204,7 +204,7 @@ describe('Definition generation', () => {
       expect(property.type).to.equal('string');
     });
     it('should generate different definitions for a generic primitive array', () => {
-      const definition = getValidatedDefinition('GenericModel<string[]>').properties;
+      const definition = getValidatedDefinition('GenericModelstring[]').properties;
 
       if (!definition) { throw new Error(`There were no properties on model.`); }
 

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1,5 +1,6 @@
 import 'mocha';
 import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
+import {Swagger} from '../../../../src/swagger/swagger';
 import { SpecGenerator } from '../../../../src/swagger/specGenerator';
 import { getDefaultOptions } from '../../../fixtures/defaultOptions';
 import * as chai from 'chai';
@@ -165,6 +166,55 @@ describe('Definition generation', () => {
 
       expect(property).to.exist;
       expect(property.description).to.equal('This is a description for publicConstructorVar');
+    });
+  });
+
+  describe('Generic-based generation', () => {
+    it('should generate different definitions for a generic model', () => {
+      const definition = getValidatedDefinition('GenericModel<TestModel>').properties;
+
+      if (!definition) { throw new Error(`There were no properties on model.`); }
+
+      const property = definition['result'];
+
+      expect(property).to.exist;
+      expect(property['$ref']).to.equal('#/definitions/TestModel');
+    });
+    it('should generate different definitions for a generic model array', () => {
+      const definition = getValidatedDefinition('GenericModel<TestModel[]>').properties;
+
+      if (!definition) { throw new Error(`There were no properties on model.`); }
+
+      const property = definition['result'];
+
+      expect(property).to.exist;
+      expect(property.type).to.equal('array');
+
+      if (!property.items) { throw new Error(`There were no items on the property model.`); }
+      expect((property.items as Swagger.Schema)['$ref']).to.equal('#/definitions/TestModel');
+    });
+    it('should generate different definitions for a generic primitive', () => {
+      const definition = getValidatedDefinition('GenericModel<string>').properties;
+
+      if (!definition) { throw new Error(`There were no properties on model.`); }
+
+      const property = definition['result'];
+
+      expect(property).to.exist;
+      expect(property.type).to.equal('string');
+    });
+    it('should generate different definitions for a generic primitive array', () => {
+      const definition = getValidatedDefinition('GenericModel<string[]>').properties;
+
+      if (!definition) { throw new Error(`There were no properties on model.`); }
+
+      const property = definition['result'];
+
+      expect(property).to.exist;
+      expect(property.type).to.equal('array');
+
+      if (!property.items) { throw new Error(`There were no items on the property model.`); }
+      expect((property.items as Swagger.Schema)['type']).to.equal('string');
     });
   });
 });


### PR DESCRIPTION
This PR implements this feature request https://github.com/lukeautry/tsoa/issues/27.

It adds the ability to return and take in generic types.


Example:

```javascript
@Route('user')
export class UserController {

    @Get('{id}')
    public async getUser(@Path() id: string): Promise<IResponse<User>> {
        return {
            success: true,
            result: new User(id, 'Foo Bar')
        };
    }
}

export interface IResponse<T> {
    success: boolean;
    result: T;
}

export class User {
    public id: string;
    public name: string;

    constructor(id, name) {
        this.id = id;
        this.name = name;
    }
}
```