### PR TITLE
(fix) fixes enum validation not throwing an error

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -60,8 +60,8 @@ function validateEnum(enumValue: string, name: string, members?: string[]): any 
     throw new InvalidRequestException(name + ' no member.');
   }
   const existValue = members.filter(m => m === enumValue);
-  if (!existValue || !enumValue.length) {
-    throw new InvalidRequestException(name + ' ' + members.join(','));
+  if (!existValue || !enumValue.length || !existValue.length) {
+    throw new InvalidRequestException(name + ' should be one of the following; ' + members.join(', '));
   }
   return existValue[0];
 }


### PR DESCRIPTION
If you now pass an invalid value to an enum, tsoa throws the appropriate error.

Also tidied up the error messaging here.