### PR TITLE
Return the auth function to prevent 404

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -81,7 +81,7 @@ export function RegisterRoutes(app: any) {
     function authenticateMiddleware(name: string, scopes: string[] = []) {
         return (request: any, response: any, next: any) => {
             return expressAuthentication(request, name, scopes).then((user: any) => {
-                set(request, 'user', user);
+                request['user'] = user;
                 next();
             })
             .catch((error: any) => {

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -80,7 +80,7 @@ export function RegisterRoutes(app: any) {
     {{#if useSecurity}}
     function authenticateMiddleware(name: string, scopes: string[] = []) {
         return (request: any, response: any, next: any) => {
-            expressAuthentication(request, name, scopes).then((user: any) => {
+            return expressAuthentication(request, name, scopes).then((user: any) => {
                 set(request, 'user', user);
                 next();
             })

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -91,7 +91,7 @@ export function RegisterRoutes(server: hapi.Server) {
     function authenticateMiddleware(name: string, scopes: string[] = []) {
       return (request: hapi.Request, reply: hapi.IReply) => {
             return hapiAuthentication(request, name, scopes).then((user: any) => {
-                set(request, 'user', user);
+                request['user'] = user;
                 reply.continue();
             })
             .catch((error: any) => reply(error).code(error.status || 401));

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -90,7 +90,7 @@ export function RegisterRoutes(server: hapi.Server) {
     {{#if useSecurity}}
     function authenticateMiddleware(name: string, scopes: string[] = []) {
       return (request: hapi.Request, reply: hapi.IReply) => {
-            hapiAuthentication(request, name, scopes).then((user: any) => {
+            return hapiAuthentication(request, name, scopes).then((user: any) => {
                 set(request, 'user', user);
                 reply.continue();
             })

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -84,7 +84,7 @@ export function RegisterRoutes(router: KoaRouter) {
   {{#if useSecurity}}
   function authenticateMiddleware(name: string, scopes: string[] = []) {
       return async (context: any, next: any) => {
-          koaAuthentication(context.request, name, scopes).then((user: any) => {
+          return koaAuthentication(context.request, name, scopes).then((user: any) => {
               set(context.request, 'user', user);
               next();
           })

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -85,7 +85,7 @@ export function RegisterRoutes(router: KoaRouter) {
   function authenticateMiddleware(name: string, scopes: string[] = []) {
       return async (context: any, next: any) => {
           return koaAuthentication(context.request, name, scopes).then((user: any) => {
-              set(context.request, 'user', user);
+              context.request['user'] = user;
               next();
           })
           .catch((error: any) => {


### PR DESCRIPTION
I'm not sure why I didn't have this issue before when I was testing out security, but when using the `@Security` decorator, it is causing a 404 on that route. Through a lot of trial and error I narrowed it down to missing this return statement. I've tested it in Koa but am not familiar enough with Express/Hapi to test it there. 

Maybe this is some fluke on my end and this is not needed? I cannot get `@Security` to work otherwise.