### PR TITLE
Changing authenticateMiddleware to return the auth function.

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -76,7 +76,7 @@ export function RegisterRoutes(app: any) {
     {{#if useSecurity}}
     function authenticateMiddleware(name: string, scopes: string[] = []) {
         return (request: any, response: any, next: any) => {
-            expressAuthentication(request, name, scopes).then((user: any) => {
+            return expressAuthentication(request, name, scopes).then((user: any) => {
                 request['user'] = user;
                 next();
             })

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -86,7 +86,7 @@ export function RegisterRoutes(server: any) {
     {{#if useSecurity}}
     function authenticateMiddleware(name: string, scopes: string[] = []) {
       return (request: any, reply: any) => {
-            hapiAuthentication(request, name, scopes).then((user: any) => {
+            return hapiAuthentication(request, name, scopes).then((user: any) => {
                 request['user'] = user;
                 reply.continue();
             })

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -80,7 +80,7 @@ export function RegisterRoutes(router: any) {
   {{#if useSecurity}}
   function authenticateMiddleware(name: string, scopes: string[] = []) {
       return async (context: any, next: any) => {
-          koaAuthentication(context.request, name, scopes).then((user: any) => {
+          return koaAuthentication(context.request, name, scopes).then((user: any) => {
               context.request['user'] = user;
               next();
           })


### PR DESCRIPTION
I'm not sure why I didn't have this issue before when I was testing out security, but when using the `@Security` decorator, it is causing a 404 on that route. Through a lot of trial and error I narrowed it down to missing this return statement. I've tested it in Koa but am not familiar enough with Express/Hapi to test it there. 

Maybe this is some fluke on my end and this is not needed? I cannot get `@Security` to work otherwise.