### PR TITLE
BUGFIX: Issue #94 : getting the status into the promise then callback

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -64,11 +64,13 @@ export function RegisterRoutes(app: any) {
 
 
             const promise = controller.{{name}}.apply(controller, validatedArgs);
-            let statusCode: any;
-            if (controller instanceof Controller) {
-                statusCode = (controller as Controller).getStatus();
-            }
-            promiseHandler(promise, statusCode, response, next);
+                promise.then(() => {
+                let statusCode: any;
+                if (controller instanceof Controller) {
+                    statusCode = (controller as Controller).getStatus();
+                }
+                promiseHandler(promise, statusCode, response, next);
+            });
         });
     {{/each}}
     {{/each}}


### PR DESCRIPTION
As the controllers functions are all async you never get the status set into the function.
To fix that, you can get the status code into the then callback.
You cannot put "await" on the function call because of the apply.