### PR TITLE
allow multiple @security annotations on a method

### DIFF
--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -21,7 +21,7 @@ export namespace Tsoa {
     type: Type;
     tags?: string[];
     responses: Response[];
-    security?: Security;
+    security: Security[];
     summary?: string;
   }
 

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -101,7 +101,7 @@ export class RouteGenerator {
       iocModule,
       models: this.buildModels(),
       useSecurity: this.metadata.controllers.some(
-        controller => controller.methods.some(methods => methods.security !== undefined),
+        controller => controller.methods.some(method => !!method.security.length),
       ),
     });
   }

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -37,13 +37,10 @@ const models: TsoaRoute.Models = {
 export function RegisterRoutes(app: any) {
     {{#each controllers}}
     {{#each actions}}
-        app.{{method}}('{{../../basePath}}/{{../path}}{{path}}', 
-            {{#if security}} 
-            authenticateMiddleware('{{security.name}}'
-                {{#if security.scopes.length}} 
-                ,{{{json security.scopes}}}
-                {{/if}}), 
-            {{/if}} 
+        app.{{method}}('{{../../basePath}}/{{../path}}{{path}}',
+            {{#if security.length}}
+            authenticateMiddleware({{json security}}),
+            {{/if}}
             function (request: any, response: any, next: any) {
             const args = {
                 {{#each parameters}}
@@ -72,16 +69,28 @@ export function RegisterRoutes(app: any) {
     {{/each}}
 
     {{#if useSecurity}}
-    function authenticateMiddleware(name: string, scopes: string[] = []) {
+    function authenticateMiddleware(security: TsoaRoute.Security[] = []) {
         return (request: any, response: any, next: any) => {
-            return expressAuthentication(request, name, scopes).then((user: any) => {
-                request['user'] = user;
-                next();
-            })
-            .catch((error: any) => {
-                response.status(401);
-                next(error)
-            });
+            let responded = 0;
+            let success = false;
+            for (const secMethod of security) {
+                expressAuthentication(request, secMethod.name, secMethod.scopes).then((user: any) => {
+                    // only need to respond once
+                    if (!success) {
+                        success = true;
+                        responded++;
+                        request['user'] = user;
+                        next();
+                    }
+                })
+                .catch((error: any) => {
+                    responded++;
+                    if (responded == security.length && !success) {
+                        response.status(401);
+                        next(error)
+                    }
+                })
+            }
         }
     }
     {{/if}}

--- a/src/routeGeneration/tsoa-route.ts
+++ b/src/routeGeneration/tsoa-route.ts
@@ -27,4 +27,9 @@ export namespace TsoaRoute {
         name: string;
         in: string;
     }
+
+    export interface Security {
+        name: string;
+        scopes?: string[];
+    }
 }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -97,9 +97,15 @@ export class SpecGenerator {
       pathMethod.deprecated = method.deprecated;
     }
     if (method.security) {
-      const security: any = {};
-      security[method.security.name] = method.security.scopes ? method.security.scopes : [];
-      pathMethod.security = [security];
+
+      const methodSecurity: any[] = [];
+      for (const thisSecurity of method.security) {
+        const security: any = {};
+        security[thisSecurity.name] = thisSecurity.scopes ? thisSecurity.scopes : [];
+        methodSecurity.push(security);
+      }
+
+      pathMethod.security = methodSecurity;
     }
 
     pathMethod.parameters = method.parameters

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -83,6 +83,13 @@ export class MethodController extends Controller {
         return new ModelService().getModel();
     }
 
+    @Security('tsoa_auth', ['write:pets', 'read:pets'])
+    @Security('api_key')
+    @Get('OauthOrAPIkeySecurity')
+    public async oauthOrAPIkeySecurity(): Promise<TestModel> {
+        return new ModelService().getModel();
+    }
+
     /**
      * @deprecated
      */

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -29,4 +29,13 @@ export class SecurityTestController {
   public async GetWithSecurity( @Request() request: koa.Request): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
+
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Security('tsoa_auth', ['write:pets', 'read:pets'])
+  @Security('api_key')
+  @Get('OauthOrAPIkey')
+  public async GetWithDoubleSecurity( @Request() request: koa.Request): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
 }

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -1000,8 +1000,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/MethodTest/ApiSecurity',
-    authenticateMiddleware('api_key'
-    ),
+    authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1020,9 +1019,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/MethodTest/OauthSecurity',
-    authenticateMiddleware('tsoa_auth'
-      , ["write:pets", "read:pets"]
-    ),
+    authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1038,6 +1035,25 @@ export function RegisterRoutes(app: any) {
 
 
       const promise=controller.oauthSecurity.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.get('/v1/MethodTest/OauthOrAPIkeySecurity',
+    authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }]),
+    function(request: any, response: any, next: any) {
+      const args={
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new MethodController();
+
+
+      const promise=controller.oauthOrAPIkeySecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/MethodTest/DeprecatedMethod',
@@ -1419,8 +1435,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/SecurityTest',
-    authenticateMiddleware('api_key'
-    ),
+    authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
@@ -1440,8 +1455,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/SecurityTest/Koa',
-    authenticateMiddleware('api_key'
-    ),
+    authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
@@ -1461,9 +1475,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/SecurityTest/Oauth',
-    authenticateMiddleware('tsoa_auth'
-      , ["write:pets", "read:pets"]
-    ),
+    authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
@@ -1482,17 +1494,49 @@ export function RegisterRoutes(app: any) {
       const promise=controller.GetWithSecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.get('/v1/SecurityTest/OauthOrAPIkey',
+    authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }]),
+    function(request: any, response: any, next: any) {
+      const args={
+        request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
+      };
 
-  function authenticateMiddleware(name: string, scopes: string[]=[]) {
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new SecurityTestController();
+
+
+      const promise=controller.GetWithDoubleSecurity.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+
+  function authenticateMiddleware(security: TsoaRoute.Security[]=[]) {
     return (request: any, response: any, next: any) => {
-      expressAuthentication(request, name, scopes).then((user: any) => {
-        request['user']=user;
-        next();
-      })
-        .catch((error: any) => {
-          response.status(401);
-          next(error)
-        });
+      let responded=0;
+      let success=false;
+      for (const secMethod of security) {
+        expressAuthentication(request, secMethod.name, secMethod.scopes).then((user: any) => {
+          // only need to respond once
+          if (!success) {
+            success=true;
+            responded++;
+            request['user']=user;
+            next();
+          }
+        })
+          .catch((error: any) => {
+            responded++;
+            if (responded==security.length&&!success) {
+              response.status(401);
+              next(error)
+            }
+          })
+      }
     }
   }
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -18,7 +18,7 @@ describe('Metadata generation', () => {
     const controller = parameterMetadata.controllers[0];
     const definedMethods = [
       'getMethod', 'postMethod', 'patchMethod', 'putMethod', 'deleteMethod',
-      'description', 'tags', 'multiResponse', 'successResponse',
+      'description', 'tags', 'multiResponse', 'successResponse', 'oauthOrAPIkeySecurity',
       'apiSecurity', 'oauthSecurity', 'deprecatedMethod', 'summaryMethod', 'returnAnyType'];
 
     it('should only generate the defined methods', () => {
@@ -146,7 +146,7 @@ describe('Metadata generation', () => {
         throw new Error('Security decorator not defined!');
       }
 
-      expect(method.security.name).to.equal('api_key');
+      expect(method.security[0].name).to.equal('api_key');
     });
 
     it('should generate oauth2 security', () => {
@@ -158,8 +158,24 @@ describe('Metadata generation', () => {
       if (!method.security) {
         throw new Error('Security decorator not defined!');
       }
-      expect(method.security.name).to.equal('tsoa_auth');
-      expect(method.security.scopes).to.deep.equal(['write:pets', 'read:pets']);
+      expect(method.security[0].name).to.equal('tsoa_auth');
+      expect(method.security[0].scopes).to.deep.equal(['write:pets', 'read:pets']);
+    });
+
+
+    it('should generate oauth2 and api key security', () => {
+
+      const method = controller.methods.find(m => m.name === 'oauthOrAPIkeySecurity');
+      if (!method) {
+        throw new Error('Method OauthOrAPIkeySecurity not defined!');
+      }
+
+      if (!method.security) {
+        throw new Error('Security decorator not defined!');
+      }
+      expect(method.security[0].name).to.equal('tsoa_auth');
+      expect(method.security[0].scopes).to.deep.equal(['write:pets', 'read:pets']);
+      expect(method.security[1].name).to.equal('api_key');
     });
 
     it('should generate deprecated method true', () => {


### PR DESCRIPTION
our api is mostly secured via oAuth, but certain methods can also be called using an api key. the swagger spec supports having multiple methods of authenticating an endpoint. in the swagger.json it looks something like:
```
"security": [
  {
    "oauth": []
  },
  {
    "api_key": []
  }
]
```

this PR should enable this. I think I found all the examples/templates/etc that needed to be updated, and added a test case for it.