### PR TITLE
@Hidden decorator to entirely hide an method from documentation

### DIFF
--- a/src/decorators/route.ts
+++ b/src/decorators/route.ts
@@ -1,3 +1,10 @@
 export function Route(name?: string): any {
   return () => { return; };
 }
+
+/**
+ * can be used to entirely hide an method from documentation
+ */
+export function Hidden(): any {
+  return () => { return; };
+}

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -41,6 +41,7 @@ export class MethodGenerator {
     return {
       deprecated: isExistJSDocTag(this.node, (tag) => tag.tagName.text === 'deprecated'),
       description: getJSDocDescription(this.node),
+      isHidden: this.getIsHidden(),
       method: this.method,
       name: (this.node.name as ts.Identifier).text,
       parameters: this.buildParameters(),
@@ -215,6 +216,18 @@ export class MethodGenerator {
       tags.push(...this.parentTags);
     }
     return tags;
+  }
+
+  private getIsHidden() {
+    const hiddenDecorators = getDecorators(this.node, (identifier) => identifier.text === 'Hidden');
+    if (!hiddenDecorators || !hiddenDecorators.length) {
+      return false;
+    }
+    if (hiddenDecorators.length > 1) {
+      throw new GenerateMetadataError(`Only one Hidden decorator allowed in '${this.getCurrentLocation}' method.`);
+    }
+
+    return true;
   }
 
   private getSecurity(): Tsoa.Security[] {

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -23,6 +23,8 @@ export namespace Tsoa {
     responses: Response[];
     security: Security[];
     summary?: string;
+    isHidden: boolean;
+
   }
 
   export interface Parameter {

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -77,7 +77,8 @@ export class SpecGenerator {
     const paths: { [pathName: string]: Swagger.Path } = {};
 
     this.metadata.controllers.forEach(controller => {
-      controller.methods.forEach(method => {
+      // construct documentation using all methods except @Hidden
+      controller.methods.filter(method => !method.isHidden).forEach(method => {
         const path = `${controller.path ? `/${controller.path}` : ''}${method.path}`;
         paths[path] = paths[path] || {};
         this.buildMethod(controller.name, method, paths[path]);

--- a/tests/fixtures/controllers/hiddenMethodController.ts
+++ b/tests/fixtures/controllers/hiddenMethodController.ts
@@ -1,0 +1,21 @@
+import {
+    Controller, Get, Hidden, Post, Route,
+} from '../../../src';
+import { TestModel } from '../../fixtures/testModel';
+import { ModelService } from '../services/modelService';
+
+@Route('Controller')
+export class HiddenMethodController extends Controller {
+
+    @Get('normalGetMethod')
+    public async normalGetMethod(): Promise<TestModel> {
+        return Promise.resolve(new ModelService().getModel());
+    }
+
+    @Get('hiddenGetMethod')
+    @Hidden()
+    public async hiddenGetMethod(): Promise<TestModel> {
+        return Promise.resolve(new ModelService().getModel());
+    }
+
+}

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -435,4 +435,31 @@ describe('Metadata generation', () => {
       expect(parameter.required).to.be.true;
     });
   });
+
+  describe('HiddenMethodGenerator', () => {
+    const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/hiddenMethodController.ts').Generate();
+    const controller = parameterMetadata.controllers[0];
+
+    it('should generate methods visible by default', () => {
+      const method = controller.methods.find(m => m.name === 'normalGetMethod');
+      if (!method) {
+        throw new Error('Method normalGetMethod not defined!');
+      }
+
+      expect(method.method).to.equal('get');
+      expect(method.path).to.equal('/normalGetMethod');
+      expect(method.isHidden).to.equal(false);
+    });
+
+    it('should generate hidden methods', () => {
+      const method = controller.methods.find(m => m.name === 'hiddenGetMethod');
+      if (!method) {
+        throw new Error('Method hiddenGetMethod not defined!');
+      }
+
+      expect(method.method).to.equal('get');
+      expect(method.path).to.equal('/hiddenGetMethod');
+      expect(method.isHidden).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
Allows user to exclude some private methods from swagger documenations by using  @Hidden decorator