### PR TITLE
Fix for typo in route templates

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -110,9 +110,9 @@ export function RegisterRoutes(app: any) {
                 }
 
                 if (data) {
-                    response.status(statusCode | 200).json(data);
+                    response.status(statusCode || 200).json(data);
                 } else {
-                    response.status(statusCode | 204).end();
+                    response.status(statusCode || 204).end();
                 }
             })
             .catch((error: any) => next(error));

--- a/tests/fixtures/custom/custom-tsoa-template.ts
+++ b/tests/fixtures/custom/custom-tsoa-template.ts
@@ -110,9 +110,9 @@ export function RegisterRoutes(app: any) {
                 }
 
                 if (data) {
-                    response.status(statusCode | 200).json(data);
+                    response.status(statusCode || 200).json(data);
                 } else {
-                    response.status(statusCode | 204).end();
+                    response.status(statusCode || 204).end();
                 }
             })
             .catch((error: any) => next(error));

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -1555,9 +1555,9 @@ export function RegisterRoutes(app: any) {
         }
 
         if (data) {
-          response.status(statusCode|200).json(data);
+          response.status(statusCode||200).json(data);
         } else {
-          response.status(statusCode|204).end();
+          response.status(statusCode||204).end();
         }
       })
       .catch((error: any) => next(error));

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1850,9 +1850,9 @@ export function RegisterRoutes(app: any) {
         }
 
         if (data) {
-          response.status(statusCode|200).json(data);
+          response.status(statusCode||200).json(data);
         } else {
-          response.status(statusCode|204).end();
+          response.status(statusCode||204).end();
         }
       })
       .catch((error: any) => next(error));

--- a/tests/fixtures/inversify/routes.ts
+++ b/tests/fixtures/inversify/routes.ts
@@ -140,9 +140,9 @@ export function RegisterRoutes(app: any) {
         }
 
         if (data) {
-          response.status(statusCode|200).json(data);
+          response.status(statusCode||200).json(data);
         } else {
-          response.status(statusCode|204).end();
+          response.status(statusCode||204).end();
         }
       })
       .catch((error: any) => next(error));


### PR DESCRIPTION
This recently introduced typo was detected by TypeScript's compiler in my project (strictNullChecks on). It looks like it would cause response status codes to be incorrect.

Thanks for this project!