### PR TITLE
Minor bugfixes

### DIFF
--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -47,7 +47,7 @@ export class ControllerGenerator {
       .map(d => d.expression as ts.CallExpression)
       .filter(expression => {
         const subExpression = expression.expression as ts.Identifier;
-        return subExpression.text === decoratorName;
+        return (subExpression && subExpression.text) === decoratorName; // <-- fix
       });
 
     if (!matchedAttributes.length) { return undefined; }

--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -199,21 +199,22 @@ function getReferenceType(type: ts.EntityName, genericTypes?: ts.TypeNode[]): Re
     inProgressTypes[typeNameWithGenerics] = true;
 
     const modelTypeDeclaration = getModelTypeDeclaration(type);
+    const extendedProperties = getInheritedProperties(modelTypeDeclaration);
 
     const properties = getModelTypeProperties(modelTypeDeclaration, genericTypes);
     const additionalProperties = getModelTypeAdditionalProperties(modelTypeDeclaration);
 
     const referenceType: ReferenceType = {
       description: getModelDescription(modelTypeDeclaration),
-      properties: properties,
+      properties: extendedProperties || [],
       typeName: typeNameWithGenerics,
     };
+    
+    referenceType.properties = referenceType.properties.concat(properties);
+
     if (additionalProperties) {
       referenceType.additionalProperties = additionalProperties;
     }
-
-    const extendedProperties = getInheritedProperties(modelTypeDeclaration);
-    referenceType.properties = referenceType.properties.concat(extendedProperties);
 
     localReferenceTypeCache[typeNameWithGenerics] = referenceType;
 

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
-import { ValidateParam, FieldErrors, ValidateError } from '../../../src/routeGeneration/templateHelpers';
-import { Controller } from '../../../src/interfaces/controller';
+import { ValidateParam, FieldErrors, ValidateError } from 'tsoa';
+import { Controller } from 'tsoa';
 import { PutTestController } from './../controllers/putController';
 import { PostTestController } from './../controllers/postController';
 import { PatchTestController } from './../controllers/patchController';
@@ -239,7 +239,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PutTestController();
 
-
       const promise = controller.putModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -261,7 +260,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PutTestController();
 
-
       const promise = controller.putModelAtLocation.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -282,7 +280,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PutTestController();
-
 
       const promise = controller.putWithMultiReturn.apply(controller, validatedArgs);
       let statusCode: any;
@@ -306,7 +303,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PutTestController();
 
-
       const promise = controller.putWithId.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -328,7 +324,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PostTestController();
-
 
       const promise = controller.postModel.apply(controller, validatedArgs);
       let statusCode: any;
@@ -352,7 +347,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PostTestController();
 
-
       const promise = controller.updateModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -375,7 +369,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PostTestController();
 
-
       const promise = controller.postClassModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -396,7 +389,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PostTestController();
-
 
       const promise = controller.postModelAtLocation.apply(controller, validatedArgs);
       let statusCode: any;
@@ -419,7 +411,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PostTestController();
 
-
       const promise = controller.postWithMultiReturn.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -441,7 +432,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PostTestController();
-
 
       const promise = controller.postWithId.apply(controller, validatedArgs);
       let statusCode: any;
@@ -466,7 +456,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PostTestController();
 
-
       const promise = controller.postWithBodyAndQueryParams.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -488,7 +477,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PostTestController();
-
 
       const promise = controller.getGenericRequest.apply(controller, validatedArgs);
       let statusCode: any;
@@ -512,7 +500,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PatchTestController();
 
-
       const promise = controller.patchModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -534,7 +521,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PatchTestController();
 
-
       const promise = controller.patchModelAtLocation.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -555,7 +541,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new PatchTestController();
-
 
       const promise = controller.patchWithMultiReturn.apply(controller, validatedArgs);
       let statusCode: any;
@@ -579,7 +564,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new PatchTestController();
 
-
       const promise = controller.patchWithId.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -600,7 +584,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getModel.apply(controller, validatedArgs);
       let statusCode: any;
@@ -623,7 +606,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getCurrentModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -645,7 +627,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getClassModel.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -666,7 +647,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getMultipleModels.apply(controller, validatedArgs);
       let statusCode: any;
@@ -696,7 +676,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getModelByParams.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -718,7 +697,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getResponseWithUnionTypeProperty.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -739,7 +717,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getUnionTypeResponse.apply(controller, validatedArgs);
       let statusCode: any;
@@ -763,7 +740,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getRequest.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -786,7 +762,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getByDataParam.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -808,7 +783,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getThrowsError.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -829,7 +803,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getGeneratesTags.apply(controller, validatedArgs);
       let statusCode: any;
@@ -853,7 +826,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getBuffer.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -874,7 +846,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getGenericModel.apply(controller, validatedArgs);
       let statusCode: any;
@@ -897,7 +868,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getGenericModelArray.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -918,7 +888,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new GetTestController();
-
 
       const promise = controller.getGenericPrimitive.apply(controller, validatedArgs);
       let statusCode: any;
@@ -941,7 +910,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new GetTestController();
 
-
       const promise = controller.getGenericPrimitiveArray.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -963,7 +931,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new DeleteTestController();
 
-
       const promise = controller.deleteWithReturnValue.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -984,7 +951,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new DeleteTestController();
-
 
       const promise = controller.deleteCurrent.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1013,7 +979,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new DeleteTestController();
 
-
       const promise = controller.getModelByParams.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1034,7 +999,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.getMethod.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1057,7 +1021,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.postMethod.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1078,7 +1041,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.patchMethod.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1101,7 +1063,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.putMethod.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1122,7 +1083,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.deleteMethod.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1145,7 +1105,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.description.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1166,7 +1125,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.tags.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1189,7 +1147,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.multiResponse.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1210,7 +1167,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.successResponse.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1234,7 +1190,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.apiSecurity.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1260,7 +1215,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.oauthSecurity.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1282,7 +1236,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new MethodController();
 
-
       const promise = controller.deprecatedMethod.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1303,7 +1256,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new MethodController();
-
 
       const promise = controller.summaryMethod.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1332,7 +1284,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ParameterController();
 
-
       const promise = controller.getQuery.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1359,7 +1310,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ParameterController();
-
 
       const promise = controller.getPath.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1388,7 +1338,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ParameterController();
 
-
       const promise = controller.getHeader.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1411,7 +1360,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ParameterController();
 
-
       const promise = controller.getRequest.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1433,7 +1381,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ParameterController();
-
 
       const promise = controller.getBody.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1462,7 +1409,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ParameterController();
 
-
       const promise = controller.getBodyProps.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1487,7 +1433,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new SecurityTestController();
 
-
       const promise = controller.GetWithApi.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1511,7 +1456,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new SecurityTestController();
-
 
       const promise = controller.GetWithApiForKoa.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1538,7 +1482,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new SecurityTestController();
 
-
       const promise = controller.GetWithSecurity.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1561,7 +1504,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ValidateController();
-
 
       const promise = controller.dateValidate.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1586,7 +1528,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ValidateController();
 
-
       const promise = controller.dateTimeValidate.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1609,7 +1550,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ValidateController();
-
 
       const promise = controller.longValidate.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1634,7 +1574,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ValidateController();
 
-
       const promise = controller.doubleValidate.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1656,7 +1595,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ValidateController();
-
 
       const promise = controller.booleanValidate.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1682,7 +1620,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ValidateController();
 
-
       const promise = controller.stringValidate.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1704,7 +1641,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new ValidateController();
-
 
       const promise = controller.customRequiredErrorMsg.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1728,7 +1664,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ValidateController();
 
-
       const promise = controller.customInvalidErrorMsg.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1751,7 +1686,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new ValidateController();
 
-
       const promise = controller.bodyValidate.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1772,7 +1706,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new TestController();
-
 
       const promise = controller.normalStatusCode.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1795,7 +1728,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new TestController();
 
-
       const promise = controller.customNomalStatusCode.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1816,7 +1748,6 @@ export function RegisterRoutes(app: any) {
       }
 
       const controller = new TestController();
-
 
       const promise = controller.noContentStatusCode.apply(controller, validatedArgs);
       let statusCode: any;
@@ -1839,7 +1770,6 @@ export function RegisterRoutes(app: any) {
 
       const controller = new TestController();
 
-
       const promise = controller.customNoContentStatusCode.apply(controller, validatedArgs);
       let statusCode: any;
       if (controller instanceof Controller) {
@@ -1850,7 +1780,7 @@ export function RegisterRoutes(app: any) {
 
   function authenticateMiddleware(name: string, scopes: string[] = []) {
     return (request: any, response: any, next: any) => {
-      expressAuthentication(request, name, scopes).then((user: any) => {
+      return expressAuthentication(request, name, scopes).then((user: any) => {
         request['user'] = user;
         next();
       })
@@ -1872,7 +1802,6 @@ export function RegisterRoutes(app: any) {
       })
       .catch((error: any) => next(error));
   }
-
 
   function getValidatedArgs(args: any, request: any): any[] {
     const fieldErrors: FieldErrors = {};


### PR DESCRIPTION
Two separate issues:

1. Original decorator parsing assumed all decorators were supplied by tsoa, which made parsing fail if you were using any other decorators (e.g. from other libs). Added a sanity check here to guard against trying to access fields on a null/undefined object.
1. Interface definitions for derived types/classes that overrode their parents' signatures were displayed incorrectly: the code would override the specific values with their more general inherited counterparts, rather than the other way around. This is now fixed.