### PR TITLE
Extended resolveType to better handle TypeLiteral and String TypeReference typeNodes

### DIFF
--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -81,6 +81,10 @@ export function resolveType(typeNode: ts.TypeNode, parentNode?: ts.Node, extract
     if (typeReference.typeName.text === 'Promise' && typeReference.typeArguments && typeReference.typeArguments.length === 1) {
       return resolveType(typeReference.typeArguments[0]);
     }
+
+    if (typeReference.typeName.text === 'String') {
+      return { dataType: 'string' } as Tsoa.Type;
+    }
   }
 
   if (!extractEnum) {

--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -57,6 +57,10 @@ export function resolveType(typeNode: ts.TypeNode, parentNode?: ts.Node, extract
     return { dataType: 'any' } as Tsoa.Type;
   }
 
+  if (typeNode.kind === ts.SyntaxKind.TypeLiteral) {
+    return { dataType: 'any' } as Tsoa.Type;
+  }
+
   if (typeNode.kind !== ts.SyntaxKind.TypeReference) {
     throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[typeNode.kind]}`);
   }

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -114,7 +114,9 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
+      "typeLiterals": { "dataType": "any", "default": { "booleanTypeLiteral": {}, "numberTypeLiteral": {}, "stringTypeLiteral": {} } },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
       "id": { "dataType": "double", "required": true },
@@ -1263,6 +1265,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/ParameterTest/ParamaterQueyArray',
+    function(request: any, response: any, next: any) {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/ParameterTest/ParamaterBodyAnyType',
     function(request: any, response: any, next: any) {
       const args={
@@ -1282,10 +1303,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTest/ParamaterBodyArrayType',
     function(request: any, response: any, next: any) {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1298,7 +1319,7 @@ export function RegisterRoutes(app: any) {
       const controller=new ParameterController();
 
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/ParameterTest/ParamaterImplicitString',

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -116,7 +116,9 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
+      "typeLiterals": { "dataType": "any", "default": { "booleanTypeLiteral": {}, "numberTypeLiteral": {}, "stringTypeLiteral": {} } },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
       "id": { "dataType": "double", "required": true },
@@ -1309,6 +1311,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/ParameterTest/ParamaterQueyArray',
+    function(request: any, response: any, next: any) {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/ParameterTest/ParamaterBodyAnyType',
     function(request: any, response: any, next: any) {
       const args={
@@ -1328,10 +1349,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTest/ParamaterBodyArrayType',
     function(request: any, response: any, next: any) {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1344,7 +1365,7 @@ export function RegisterRoutes(app: any) {
       const controller=new ParameterController();
 
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/ParameterTest/ParamaterImplicitString',

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -117,7 +117,9 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
+      "typeLiterals": { "dataType": "any", "default": { "booleanTypeLiteral": {}, "numberTypeLiteral": {}, "stringTypeLiteral": {} } },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
       "id": { "dataType": "double", "required": true },
@@ -231,7 +233,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -253,7 +255,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -275,7 +277,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double" },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string" },
@@ -303,7 +305,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -325,7 +327,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -347,7 +349,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -369,7 +371,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -391,7 +393,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double", "validators": { "isDouble": { "errorMsg": "numberPathParam" }, "minimum": { "value": 1 }, "maximum": { "value": 10 } } },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string", "validators": { "minLength": { "value": 1 }, "maxLength": { "value": 10 } } },
@@ -420,7 +422,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ResponseWithUnionTypeProperty',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -442,7 +444,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/UnionTypeResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -464,7 +466,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -487,7 +489,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/DateParam',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "in": "query", "name": "date", "required": true, "dataType": "datetime" },
         };
@@ -510,7 +512,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ThrowsError',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -532,7 +534,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GeneratesTags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -554,7 +556,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/HandleBufferType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           buffer: { "in": "query", "name": "buffer", "required": true, "dataType": "buffer" },
         };
@@ -577,7 +579,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -599,7 +601,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModelArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -621,7 +623,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitive',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -643,7 +645,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitiveArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -665,7 +667,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -688,7 +690,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -710,7 +712,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -732,7 +734,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -755,7 +757,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -778,7 +780,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -801,7 +803,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestClassModel" },
         };
@@ -824,7 +826,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -846,7 +848,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -868,7 +870,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -891,7 +893,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithBodyAndQueryParams',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
           query: { "in": "query", "name": "query", "required": true, "dataType": "string" },
@@ -915,7 +917,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/GenericBody',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           genericReq: { "in": "body", "name": "genericReq", "required": true, "ref": "GenericRequestTestModel" },
         };
@@ -938,7 +940,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -961,7 +963,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -983,7 +985,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1005,7 +1007,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -1028,7 +1030,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Get',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1050,7 +1052,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/MethodTest/Post',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1072,7 +1074,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/MethodTest/Patch',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1094,7 +1096,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/MethodTest/Put',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1116,7 +1118,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/MethodTest/Delete',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1138,7 +1140,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Description',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1160,7 +1162,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Tags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1182,7 +1184,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/MultiResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1204,7 +1206,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SuccessResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1231,7 +1233,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1258,7 +1260,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1285,7 +1287,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1307,7 +1309,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/DeprecatedMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1329,7 +1331,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SummaryMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1351,7 +1353,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/returnAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1373,7 +1375,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Query',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "query", "name": "last_name", "required": true, "dataType": "string" },
@@ -1401,7 +1403,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Path/{firstname}/{last_name}/{age}/{weight}/{human}/{gender}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "path", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "path", "name": "last_name", "required": true, "dataType": "string" },
@@ -1429,7 +1431,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Header',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "header", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "header", "name": "last_name", "required": true, "dataType": "string" },
@@ -1457,7 +1459,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1480,7 +1482,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/Body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ParameterTestModel" },
         };
@@ -1503,7 +1505,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/BodyProps',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "body-prop", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "body-prop", "name": "lastname", "required": true, "dataType": "string" },
@@ -1531,7 +1533,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterQueyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "in": "query", "name": "name", "required": true, "dataType": "any" },
         };
@@ -1552,9 +1554,32 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
+    path: '/v1/ParameterTest/ParamaterQueyArray',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.queyArray.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
     path: '/v1/ParameterTest/ParamaterBodyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "dataType": "any" },
         };
@@ -1575,11 +1600,11 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
-    path: '/v1/ParameterTest/ParamaterQueyArray',
+    path: '/v1/ParameterTest/ParamaterBodyArrayType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
-          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+          body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
         };
 
         let validatedArgs: any[]=[];
@@ -1591,7 +1616,7 @@ export function RegisterRoutes(server: any) {
 
         const controller=new ParameterController();
 
-        const promise=controller.queyArray.apply(controller, validatedArgs);
+        const promise=controller.bodyArrayType.apply(controller, validatedArgs);
         return promiseHandler(controller, promise, request, reply);
       }
     }
@@ -1600,7 +1625,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitString',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "default": "Iron man", "in": "query", "name": "name", "dataType": "string" },
         };
@@ -1623,7 +1648,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitNumber',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           age: { "default": 40, "in": "query", "name": "age", "dataType": "double" },
         };
@@ -1646,7 +1671,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitEnum',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           gender: { "in": "query", "name": "gender", "dataType": "enum", "enums": ["MALE", "FEMALE"] },
         };
@@ -1669,7 +1694,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitStringArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": ["V1", "V2"], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "string" } },
         };
@@ -1692,7 +1717,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitNumberArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": [1, 2, 3], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "double" } },
         };
@@ -1715,7 +1740,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDateTime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "default": "2017-01-01T00:00:00.000Z", "in": "query", "name": "date", "dataType": "datetime" },
         };
@@ -1738,7 +1763,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDate',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
         };
@@ -1766,7 +1791,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1794,7 +1819,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1822,7 +1847,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1850,7 +1875,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1873,7 +1898,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/normalStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1895,7 +1920,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/noContentStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1917,7 +1942,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1939,7 +1964,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customHeader',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1961,7 +1986,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/date',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01" } } },
@@ -1985,7 +2010,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/datetime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01T00:00:00" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01T00:00:00" } } },
@@ -2009,7 +2034,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/integer',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "minValue" }, "minimum": { "value": 5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "maxValue" }, "maximum": { "value": 3 } } },
@@ -2033,7 +2058,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/float',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "minValue" }, "minimum": { "value": 5.5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "maxValue" }, "maximum": { "value": 3.5 } } },
@@ -2057,7 +2082,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/boolean',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           boolValue: { "in": "query", "name": "boolValue", "required": true, "dataType": "boolean", "validators": { "isBoolean": { "errorMsg": "boolValue" } } },
         };
@@ -2080,7 +2105,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/string',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minLength: { "in": "query", "name": "minLength", "required": true, "dataType": "string", "validators": { "minLength": { "value": 5 } } },
           maxLength: { "in": "query", "name": "maxLength", "required": true, "dataType": "string", "validators": { "maxLength": { "value": 3 } } },
@@ -2105,7 +2130,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customRequiredErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Required long number." } } },
         };
@@ -2128,7 +2153,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customInvalidErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Invalid long number." } } },
         };
@@ -2151,7 +2176,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/Validate/body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ValidateModel" },
         };

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -116,7 +116,9 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
+      "typeLiterals": { "dataType": "any", "default": { "booleanTypeLiteral": {}, "numberTypeLiteral": {}, "stringTypeLiteral": {} } },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
       "id": { "dataType": "double", "required": true },
@@ -1366,6 +1368,26 @@ export function RegisterRoutes(router: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.post('/v1/ParameterTest/ParamaterQueyArray',
+    async (context, next) => {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.post('/v1/ParameterTest/ParamaterBodyAnyType',
     async (context, next) => {
       const args={
@@ -1386,10 +1408,10 @@ export function RegisterRoutes(router: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
-  router.post('/v1/ParameterTest/ParamaterQueyArray',
+  router.post('/v1/ParameterTest/ParamaterBodyArrayType',
     async (context, next) => {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1403,7 +1425,7 @@ export function RegisterRoutes(router: any) {
 
       const controller=new ParameterController();
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
   router.get('/v1/ParameterTest/ParamaterImplicitString',

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -267,6 +267,12 @@ export class TestClassModel extends TestClassBaseModel {
   stringProperty: string;
   protected protectedStringProperty: string;
 
+  public static typeLiterals = {
+    booleanTypeLiteral: { $type: Boolean },
+    numberTypeLiteral: { $type: Number },
+    stringTypeLiteral: { $type: String },
+  };
+
   /**
    * @param publicConstructorVar This is a description for publicConstructorVar
    */


### PR DESCRIPTION
Resolves "Error: No matching model found for referenced type String" when model contains a typeliteral reference of `String` type. I commented about this issue in https://github.com/lukeautry/tsoa/issues/79

- Improves resolveType handling of String typeReferences
- Improves resolveType handling of ts.SyntaxKind.TypeLiteral typeNodes.
- Added typeLiteral fields to TestClassModel

Please let me know if there's a better way to resolve, and any changes you'd like made on this PR