### PR TITLE
Bugfix for server error if base path is empty or `/`

### DIFF
--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { getDecorators } from './../utils/decoratorUtils';
-import { normalisePath } from './../utils/pathUtils';
 import { GenerateMetadataError } from './exceptions';
 import { MethodGenerator } from './methodGenerator';
 import { Tsoa } from './tsoa';
@@ -34,7 +33,7 @@ export class ControllerGenerator {
       location: sourceFile.fileName,
       methods: this.buildMethods(),
       name: this.node.name.text,
-      path: normalisePath(this.path as string, '/'),
+      path: this.path || '',
     };
   }
 

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -1,7 +1,6 @@
 import * as ts from 'typescript';
 import { getDecorators } from './../utils/decoratorUtils';
 import { getJSDocComment, getJSDocDescription, isExistJSDocTag } from './../utils/jsDocUtils';
-import { normalisePath } from './../utils/pathUtils';
 import { GenerateMetadataError } from './exceptions';
 import { MetadataGenerator } from './metadataGenerator';
 import { ParameterGenerator } from './parameterGenerator';
@@ -46,7 +45,7 @@ export class MethodGenerator {
       method: this.method,
       name: (this.node.name as ts.Identifier).text,
       parameters: this.buildParameters(),
-      path: normalisePath(this.path as string, '/'),
+      path: this.path,
       responses,
       security: this.getSecurity(),
       summary: getJSDocComment(this.node, 'summary'),

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -91,10 +91,7 @@ export class RouteGenerator {
             const normalisedMethodPath = pathTransformer(normalisePath(method.path, '/'));
 
             const normalisedFullPath = normalisePath(
-              normalisedBasePath + normalisedControllerPath + normalisedMethodPath,
-              '/',
-              '',
-              false,
+              `${normalisedBasePath}${normalisedControllerPath}${normalisedMethodPath}`, '/', '', false,
             );
 
             return {

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -73,19 +73,32 @@ export class RouteGenerator {
       canImportByAlias = false;
     }
 
+    const normalisedBasePath = normalisePath(this.options.basePath as string, '/');
+
     return routesTemplate({
       authenticationModule,
-      basePath: normalisePath(this.options.basePath as string, '/'),
+      basePath: normalisedBasePath,
       canImportByAlias,
       controllers: this.metadata.controllers.map(controller => {
+        const normalisedControllerPath = normalisePath(controller.path, '/');
+
         return {
           actions: controller.methods.map(method => {
             const parameterObjs: { [name: string]: TsoaRoute.ParameterSchema } = {};
             method.parameters.forEach(parameter => {
               parameterObjs[parameter.parameterName] = this.buildParameterSchema(parameter);
             });
+            const normalisedMethodPath = pathTransformer(normalisePath(method.path, '/'));
+
+            const normalisedFullPath = normalisePath(
+              normalisedBasePath + normalisedControllerPath + normalisedMethodPath,
+              '/',
+              '',
+              false,
+            );
 
             return {
+              fullPath: normalisedFullPath,
               method: method.method.toLowerCase(),
               name: method.name,
               parameters: parameterObjs,
@@ -95,7 +108,7 @@ export class RouteGenerator {
           }),
           modulePath: this.getRelativeImportPath(controller.location),
           name: controller.name,
-          path: controller.path,
+          path: normalisedControllerPath,
         };
       }),
       environment: process.env,

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -99,7 +99,7 @@ export class RouteGenerator {
               method: method.method.toLowerCase(),
               name: method.name,
               parameters: parameterObjs,
-              path: pathTransformer(method.path),
+              path: normalisedMethodPath,
               security: method.security,
             };
           }),

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -37,7 +37,7 @@ const models: TsoaRoute.Models = {
 export function RegisterRoutes(app: any) {
     {{#each controllers}}
     {{#each actions}}
-        app.{{method}}('{{../../basePath}}{{../path}}{{path}}',
+        app.{{method}}('{{fullPath}}',
             {{#if security.length}}
             authenticateMiddleware({{json security}}),
             {{/if}}

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -40,7 +40,7 @@ export function RegisterRoutes(server: any) {
     {{#each actions}}
         server.route({
             method: '{{method}}',
-            path: '{{../../basePath}}{{../path}}{{path}}',
+            path: '{{fullPath}}',
             config: {
                 {{#if security.length}}
                 pre: [

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -37,7 +37,7 @@ const models: TsoaRoute.Models = {
 export function RegisterRoutes(router: any) {
     {{#each controllers}}
     {{#each actions}}
-        router.{{method}}('{{../../basePath}}{{../path}}{{path}}',
+        router.{{method}}('{{fullPath}}',
             {{#if security.length}}
             authenticateMiddleware({{json security}}),
             {{/if}}

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -78,9 +78,11 @@ export class SpecGenerator {
     const paths: { [pathName: string]: Swagger.Path } = {};
 
     this.metadata.controllers.forEach(controller => {
+      const normalisedControllerPath = normalisePath(controller.path, '/');
       // construct documentation using all methods except @Hidden
       controller.methods.filter(method => !method.isHidden).forEach(method => {
-        const path = `${controller.path}${method.path}`;
+        const normalisedMethodPath = normalisePath(method.path, '/');
+        const path = normalisePath(`${normalisedControllerPath}${normalisedMethodPath}`, '/', '', false);
         paths[path] = paths[path] || {};
         this.buildMethod(controller.name, method, paths[path]);
       });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -4,7 +4,7 @@
  * Adds prefix and suffix if supplied
  */
 export function normalisePath(path: string, withPrefix?: string, withSuffix?: string, skipPrefixAndSuffixIfEmpty: boolean = true) {
-  if (!path && skipPrefixAndSuffixIfEmpty) {
+  if ((!path || path === '/') && skipPrefixAndSuffixIfEmpty) {
     return '';
   }
   if (!path || typeof path !== 'string') {
@@ -12,9 +12,9 @@ export function normalisePath(path: string, withPrefix?: string, withSuffix?: st
   }
   // normalise beginning and end of the path
   let normalised = path.replace(/^[/\\\s]+|[/\\\s]+$/g, '');
-  // normalise path between it's sections
-  normalised = normalised.replace(/[/\\\s]+|[/\\\s]+/g, '/');
   normalised = withPrefix ? withPrefix + normalised : normalised;
   normalised = withSuffix ? normalised + withSuffix : normalised;
+  // normalise / signs amount in all path
+  normalised = normalised.replace(/[/\\\s]+/g, '/');
   return normalised;
 }

--- a/tests/fixtures/controllers/rootController.ts
+++ b/tests/fixtures/controllers/rootController.ts
@@ -1,0 +1,20 @@
+import {
+    Controller, Get, Route,
+} from '../../../src';
+import { TestModel } from '../../fixtures/testModel';
+import { ModelService } from '../services/modelService';
+
+@Route()
+export class RootController extends Controller {
+
+    @Get()
+    public async rootHandler(): Promise<TestModel> {
+        return Promise.resolve(new ModelService().getModel());
+    }
+
+    @Get('rootControllerMethodWithPath')
+    public async rootControllerMethodWithPath(): Promise<TestModel> {
+      return Promise.resolve(new ModelService().getModel());
+    }
+
+}

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -114,6 +114,7 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -198,7 +199,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.deleteWithReturnValue.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.delete('/v1/DeleteTest/Current',
+  app.delete('/v1/DeleteTestCurrent',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -216,7 +217,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.deleteCurrent.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.delete('/v1/DeleteTest/:numberPathParam/:booleanPathParam/:stringPathParam',
+  app.delete('/v1/DeleteTest:numberPathParam/:booleanPathParam/:stringPathParam',
     function(request: any, response: any, next: any) {
       const args={
         numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double" },
@@ -258,7 +259,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/Current',
+  app.get('/v1/GetTestCurrent',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -276,7 +277,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getCurrentModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/ClassModel',
+  app.get('/v1/GetTestClassModel',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -294,7 +295,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getClassModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/Multi',
+  app.get('/v1/GetTestMulti',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -312,7 +313,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getMultipleModels.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/:numberPathParam/:booleanPathParam/:stringPathParam',
+  app.get('/v1/GetTest:numberPathParam/:booleanPathParam/:stringPathParam',
     function(request: any, response: any, next: any) {
       const args={
         numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double", "validators": { "isDouble": { "errorMsg": "numberPathParam" }, "minimum": { "value": 1 }, "maximum": { "value": 10 } } },
@@ -337,7 +338,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getModelByParams.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/ResponseWithUnionTypeProperty',
+  app.get('/v1/GetTestResponseWithUnionTypeProperty',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -355,7 +356,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getResponseWithUnionTypeProperty.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/UnionTypeResponse',
+  app.get('/v1/GetTestUnionTypeResponse',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -373,7 +374,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getUnionTypeResponse.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/Request',
+  app.get('/v1/GetTestRequest',
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
@@ -392,7 +393,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getRequest.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/DateParam',
+  app.get('/v1/GetTestDateParam',
     function(request: any, response: any, next: any) {
       const args={
         date: { "in": "query", "name": "date", "required": true, "dataType": "datetime" },
@@ -411,7 +412,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getByDataParam.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/ThrowsError',
+  app.get('/v1/GetTestThrowsError',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -429,7 +430,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getThrowsError.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/GeneratesTags',
+  app.get('/v1/GetTestGeneratesTags',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -447,7 +448,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getGeneratesTags.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/HandleBufferType',
+  app.get('/v1/GetTestHandleBufferType',
     function(request: any, response: any, next: any) {
       const args={
         buffer: { "in": "query", "name": "buffer", "required": true, "dataType": "buffer" },
@@ -466,7 +467,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getBuffer.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/GenericModel',
+  app.get('/v1/GetTestGenericModel',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -484,7 +485,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getGenericModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/GenericModelArray',
+  app.get('/v1/GetTestGenericModelArray',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -502,7 +503,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getGenericModelArray.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/GenericPrimitive',
+  app.get('/v1/GetTestGenericPrimitive',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -520,7 +521,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getGenericPrimitive.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/GetTest/GenericPrimitiveArray',
+  app.get('/v1/GetTestGenericPrimitiveArray',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -557,7 +558,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.patchModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.patch('/v1/PatchTest/Location',
+  app.patch('/v1/PatchTestLocation',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -575,7 +576,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.patchModelAtLocation.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.patch('/v1/PatchTest/Multi',
+  app.patch('/v1/PatchTestMulti',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -593,7 +594,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.patchWithMultiReturn.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.patch('/v1/PatchTest/WithId/:id',
+  app.patch('/v1/PatchTestWithId/:id',
     function(request: any, response: any, next: any) {
       const args={
         id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
@@ -650,7 +651,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.updateModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/WithClassModel',
+  app.post('/v1/PostTestWithClassModel',
     function(request: any, response: any, next: any) {
       const args={
         model: { "in": "body", "name": "model", "required": true, "ref": "TestClassModel" },
@@ -669,7 +670,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postClassModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/Location',
+  app.post('/v1/PostTestLocation',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -687,7 +688,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postModelAtLocation.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/Multi',
+  app.post('/v1/PostTestMulti',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -705,7 +706,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postWithMultiReturn.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/WithId/:id',
+  app.post('/v1/PostTestWithId/:id',
     function(request: any, response: any, next: any) {
       const args={
         id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
@@ -724,7 +725,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postWithId.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/WithBodyAndQueryParams',
+  app.post('/v1/PostTestWithBodyAndQueryParams',
     function(request: any, response: any, next: any) {
       const args={
         model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
@@ -744,7 +745,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postWithBodyAndQueryParams.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/PostTest/GenericBody',
+  app.post('/v1/PostTestGenericBody',
     function(request: any, response: any, next: any) {
       const args={
         genericReq: { "in": "body", "name": "genericReq", "required": true, "ref": "GenericRequestTestModel" },
@@ -782,7 +783,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.putModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.put('/v1/PutTest/Location',
+  app.put('/v1/PutTestLocation',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -800,7 +801,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.putModelAtLocation.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.put('/v1/PutTest/Multi',
+  app.put('/v1/PutTestMulti',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -818,7 +819,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.putWithMultiReturn.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.put('/v1/PutTest/WithId/:id',
+  app.put('/v1/PutTestWithId/:id',
     function(request: any, response: any, next: any) {
       const args={
         id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
@@ -837,7 +838,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.putWithId.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/Get',
+  app.get('/v1/MethodTestGet',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -855,7 +856,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/MethodTest/Post',
+  app.post('/v1/MethodTestPost',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -873,7 +874,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.postMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.patch('/v1/MethodTest/Patch',
+  app.patch('/v1/MethodTestPatch',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -891,7 +892,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.patchMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.put('/v1/MethodTest/Put',
+  app.put('/v1/MethodTestPut',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -909,7 +910,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.putMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.delete('/v1/MethodTest/Delete',
+  app.delete('/v1/MethodTestDelete',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -927,7 +928,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.deleteMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/Description',
+  app.get('/v1/MethodTestDescription',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -945,7 +946,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.description.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/Tags',
+  app.get('/v1/MethodTestTags',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -963,7 +964,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.tags.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/MultiResponse',
+  app.get('/v1/MethodTestMultiResponse',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -981,7 +982,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.multiResponse.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/SuccessResponse',
+  app.get('/v1/MethodTestSuccessResponse',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -999,7 +1000,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.successResponse.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/ApiSecurity',
+  app.get('/v1/MethodTestApiSecurity',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
@@ -1018,7 +1019,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.apiSecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/OauthSecurity',
+  app.get('/v1/MethodTestOauthSecurity',
     authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
@@ -1037,7 +1038,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.oauthSecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/OauthOrAPIkeySecurity',
+  app.get('/v1/MethodTestOauthOrAPIkeySecurity',
     authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
@@ -1056,7 +1057,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.oauthOrAPIkeySecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/DeprecatedMethod',
+  app.get('/v1/MethodTestDeprecatedMethod',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1074,7 +1075,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.deprecatedMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/SummaryMethod',
+  app.get('/v1/MethodTestSummaryMethod',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1092,7 +1093,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.summaryMethod.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/MethodTest/returnAnyType',
+  app.get('/v1/MethodTestreturnAnyType',
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1110,7 +1111,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.returnAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/Query',
+  app.get('/v1/ParameterTestQuery',
     function(request: any, response: any, next: any) {
       const args={
         firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
@@ -1134,7 +1135,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getQuery.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/Path/:firstname/:last_name/:age/:weight/:human/:gender',
+  app.get('/v1/ParameterTestPath/:firstname/:last_name/:age/:weight/:human/:gender',
     function(request: any, response: any, next: any) {
       const args={
         firstname: { "in": "path", "name": "firstname", "required": true, "dataType": "string" },
@@ -1158,7 +1159,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getPath.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/Header',
+  app.get('/v1/ParameterTestHeader',
     function(request: any, response: any, next: any) {
       const args={
         firstname: { "in": "header", "name": "firstname", "required": true, "dataType": "string" },
@@ -1182,7 +1183,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getHeader.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/Request',
+  app.get('/v1/ParameterTestRequest',
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
@@ -1201,7 +1202,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getRequest.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/Body',
+  app.post('/v1/ParameterTestBody',
     function(request: any, response: any, next: any) {
       const args={
         body: { "in": "body", "name": "body", "required": true, "ref": "ParameterTestModel" },
@@ -1220,7 +1221,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getBody.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/BodyProps',
+  app.post('/v1/ParameterTestBodyProps',
     function(request: any, response: any, next: any) {
       const args={
         firstname: { "in": "body-prop", "name": "firstname", "required": true, "dataType": "string" },
@@ -1244,7 +1245,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.getBodyProps.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/ParamaterQueyAnyType',
+  app.get('/v1/ParameterTestParamaterQueyAnyType',
     function(request: any, response: any, next: any) {
       const args={
         name: { "in": "query", "name": "name", "required": true, "dataType": "any" },
@@ -1263,26 +1264,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterBodyAnyType',
-    function(request: any, response: any, next: any) {
-      const args={
-        body: { "in": "body", "name": "body", "required": true, "dataType": "any" },
-      };
-
-      let validatedArgs: any[]=[];
-      try {
-        validatedArgs=getValidatedArgs(args, request);
-      } catch (err) {
-        return next(err);
-      }
-
-      const controller=new ParameterController();
-
-
-      const promise=controller.bodyAnyType.apply(controller, validatedArgs);
-      promiseHandler(controller, promise, response, next);
-    });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTestParamaterQueyArray',
     function(request: any, response: any, next: any) {
       const args={
         name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
@@ -1301,7 +1283,45 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queyArray.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/ParamaterImplicitString',
+  app.post('/v1/ParameterTestParamaterBodyAnyType',
+    function(request: any, response: any, next: any) {
+      const args={
+        body: { "in": "body", "name": "body", "required": true, "dataType": "any" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.bodyAnyType.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.post('/v1/ParameterTestParamaterBodyArrayType',
+    function(request: any, response: any, next: any) {
+      const args={
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.get('/v1/ParameterTestParamaterImplicitString',
     function(request: any, response: any, next: any) {
       const args={
         name: { "default": "Iron man", "in": "query", "name": "name", "dataType": "string" },
@@ -1320,7 +1340,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitString.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/ParamaterImplicitNumber',
+  app.get('/v1/ParameterTestParamaterImplicitNumber',
     function(request: any, response: any, next: any) {
       const args={
         age: { "default": 40, "in": "query", "name": "age", "dataType": "double" },
@@ -1339,7 +1359,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitNumber.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/ParamaterImplicitEnum',
+  app.get('/v1/ParameterTestParamaterImplicitEnum',
     function(request: any, response: any, next: any) {
       const args={
         gender: { "in": "query", "name": "gender", "dataType": "enum", "enums": ["MALE", "FEMALE"] },
@@ -1358,7 +1378,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitEnum.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/ParamaterImplicitStringArray',
+  app.get('/v1/ParameterTestParamaterImplicitStringArray',
     function(request: any, response: any, next: any) {
       const args={
         arr: { "default": ["V1", "V2"], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "string" } },
@@ -1377,7 +1397,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitStringArray.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/paramaterImplicitNumberArray',
+  app.get('/v1/ParameterTestparamaterImplicitNumberArray',
     function(request: any, response: any, next: any) {
       const args={
         arr: { "default": [1, 2, 3], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "double" } },
@@ -1396,7 +1416,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitNumberArray.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/paramaterImplicitDateTime',
+  app.get('/v1/ParameterTestparamaterImplicitDateTime',
     function(request: any, response: any, next: any) {
       const args={
         date: { "default": "2017-01-01T00:00:00.000Z", "in": "query", "name": "date", "dataType": "datetime" },
@@ -1415,10 +1435,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitDateTime.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/ParameterTest/paramaterImplicitDate',
+  app.get('/v1/ParameterTestparamaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -1454,7 +1474,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.GetWithApi.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/SecurityTest/Koa',
+  app.get('/v1/SecurityTestKoa',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={
@@ -1474,7 +1494,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.GetWithApiForKoa.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/SecurityTest/Oauth',
+  app.get('/v1/SecurityTestOauth',
     authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
@@ -1494,7 +1514,7 @@ export function RegisterRoutes(app: any) {
       const promise=controller.GetWithSecurity.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.get('/v1/SecurityTest/OauthOrAPIkey',
+  app.get('/v1/SecurityTestOauthOrAPIkey',
     authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }]),
     function(request: any, response: any, next: any) {
       const args={

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+import { RootController } from './../controllers/rootController';
 import { DeleteTestController } from './../controllers/deleteController';
 import { GetTestController } from './../controllers/getController';
 import { PatchTestController } from './../controllers/patchController';
@@ -116,6 +117,7 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -226,6 +228,42 @@ const models: TsoaRoute.Models={
 };
 
 export function RegisterRoutes(app: any) {
+  app.get('/v1',
+    function(request: any, response: any, next: any) {
+      const args={
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new RootController();
+
+
+      const promise=controller.rootHandler.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.get('/v1/rootControllerMethodWithPath',
+    function(request: any, response: any, next: any) {
+      const args={
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new RootController();
+
+
+      const promise=controller.rootControllerMethodWithPath.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.delete('/v1/DeleteTest',
     function(request: any, response: any, next: any) {
       const args={
@@ -1309,6 +1347,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/ParameterTest/ParamaterQueyArray',
+    function(request: any, response: any, next: any) {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/ParameterTest/ParamaterBodyAnyType',
     function(request: any, response: any, next: any) {
       const args={
@@ -1328,10 +1385,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTest/ParamaterBodyArrayType',
     function(request: any, response: any, next: any) {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1344,7 +1401,7 @@ export function RegisterRoutes(app: any) {
       const controller=new ParameterController();
 
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/ParameterTest/ParamaterImplicitString',
@@ -1464,7 +1521,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -1,6 +1,8 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as methodOverride from 'method-override';
+import '../controllers/rootController';
+
 import '../controllers/deleteController';
 import '../controllers/getController';
 import '../controllers/patchController';

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -1,6 +1,7 @@
 // TODO: Replace this with HAPI middleware stuff
 /* tslint:disable */
 import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+import { RootController } from './../controllers/rootController';
 import { DeleteTestController } from './../controllers/deleteController';
 import { GetTestController } from './../controllers/getController';
 import { PatchTestController } from './../controllers/patchController';
@@ -117,6 +118,7 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -228,10 +230,54 @@ const models: TsoaRoute.Models={
 
 export function RegisterRoutes(server: any) {
   server.route({
+    method: 'get',
+    path: '/v1',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new RootController();
+
+        const promise=controller.rootHandler.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
+    path: '/v1/rootControllerMethodWithPath',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new RootController();
+
+        const promise=controller.rootControllerMethodWithPath.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
     method: 'delete',
     path: '/v1/DeleteTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -253,7 +299,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -275,7 +321,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double" },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string" },
@@ -303,7 +349,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -325,7 +371,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -347,7 +393,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -369,7 +415,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -391,7 +437,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double", "validators": { "isDouble": { "errorMsg": "numberPathParam" }, "minimum": { "value": 1 }, "maximum": { "value": 10 } } },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string", "validators": { "minLength": { "value": 1 }, "maxLength": { "value": 10 } } },
@@ -420,7 +466,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ResponseWithUnionTypeProperty',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -442,7 +488,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/UnionTypeResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -464,7 +510,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -487,7 +533,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/DateParam',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "in": "query", "name": "date", "required": true, "dataType": "datetime" },
         };
@@ -510,7 +556,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ThrowsError',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -532,7 +578,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GeneratesTags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -554,7 +600,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/HandleBufferType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           buffer: { "in": "query", "name": "buffer", "required": true, "dataType": "buffer" },
         };
@@ -577,7 +623,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -599,7 +645,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModelArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -621,7 +667,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitive',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -643,7 +689,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitiveArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -665,7 +711,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -688,7 +734,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -710,7 +756,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -732,7 +778,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -755,7 +801,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -778,7 +824,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -801,7 +847,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestClassModel" },
         };
@@ -824,7 +870,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -846,7 +892,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -868,7 +914,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -891,7 +937,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithBodyAndQueryParams',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
           query: { "in": "query", "name": "query", "required": true, "dataType": "string" },
@@ -915,7 +961,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/GenericBody',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           genericReq: { "in": "body", "name": "genericReq", "required": true, "ref": "GenericRequestTestModel" },
         };
@@ -938,7 +984,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -961,7 +1007,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -983,7 +1029,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1005,7 +1051,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -1028,7 +1074,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Get',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1050,7 +1096,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/MethodTest/Post',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1072,7 +1118,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/MethodTest/Patch',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1094,7 +1140,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/MethodTest/Put',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1116,7 +1162,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/MethodTest/Delete',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1138,7 +1184,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Description',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1160,7 +1206,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Tags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1182,7 +1228,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/MultiResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1204,7 +1250,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SuccessResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1231,7 +1277,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1258,7 +1304,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1285,7 +1331,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1307,7 +1353,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/DeprecatedMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1329,7 +1375,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SummaryMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1351,7 +1397,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/returnAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1373,7 +1419,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Query',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "query", "name": "last_name", "required": true, "dataType": "string" },
@@ -1401,7 +1447,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Path/{firstname}/{last_name}/{age}/{weight}/{human}/{gender}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "path", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "path", "name": "last_name", "required": true, "dataType": "string" },
@@ -1429,7 +1475,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Header',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "header", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "header", "name": "last_name", "required": true, "dataType": "string" },
@@ -1457,7 +1503,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1480,7 +1526,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/Body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ParameterTestModel" },
         };
@@ -1503,7 +1549,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/BodyProps',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "body-prop", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "body-prop", "name": "lastname", "required": true, "dataType": "string" },
@@ -1531,7 +1577,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterQueyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "in": "query", "name": "name", "required": true, "dataType": "any" },
         };
@@ -1552,9 +1598,32 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
+    path: '/v1/ParameterTest/ParamaterQueyArray',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.queyArray.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
     path: '/v1/ParameterTest/ParamaterBodyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "dataType": "any" },
         };
@@ -1575,11 +1644,11 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
-    path: '/v1/ParameterTest/ParamaterQueyArray',
+    path: '/v1/ParameterTest/ParamaterBodyArrayType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
-          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+          body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
         };
 
         let validatedArgs: any[]=[];
@@ -1591,7 +1660,7 @@ export function RegisterRoutes(server: any) {
 
         const controller=new ParameterController();
 
-        const promise=controller.queyArray.apply(controller, validatedArgs);
+        const promise=controller.bodyArrayType.apply(controller, validatedArgs);
         return promiseHandler(controller, promise, request, reply);
       }
     }
@@ -1600,7 +1669,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitString',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "default": "Iron man", "in": "query", "name": "name", "dataType": "string" },
         };
@@ -1623,7 +1692,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitNumber',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           age: { "default": 40, "in": "query", "name": "age", "dataType": "double" },
         };
@@ -1646,7 +1715,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitEnum',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           gender: { "in": "query", "name": "gender", "dataType": "enum", "enums": ["MALE", "FEMALE"] },
         };
@@ -1669,7 +1738,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitStringArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": ["V1", "V2"], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "string" } },
         };
@@ -1692,7 +1761,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitNumberArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": [1, 2, 3], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "double" } },
         };
@@ -1715,7 +1784,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDateTime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "default": "2017-01-01T00:00:00.000Z", "in": "query", "name": "date", "dataType": "datetime" },
         };
@@ -1738,9 +1807,9 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDate',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
-          date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+          date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
         };
 
         let validatedArgs: any[]=[];
@@ -1766,7 +1835,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1794,7 +1863,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1822,7 +1891,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1850,7 +1919,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1873,7 +1942,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/normalStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1895,7 +1964,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/noContentStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1917,7 +1986,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1939,7 +2008,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customHeader',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1961,7 +2030,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/date',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01" } } },
@@ -1985,7 +2054,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/datetime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01T00:00:00" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01T00:00:00" } } },
@@ -2009,7 +2078,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/integer',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "minValue" }, "minimum": { "value": 5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "maxValue" }, "maximum": { "value": 3 } } },
@@ -2033,7 +2102,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/float',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "minValue" }, "minimum": { "value": 5.5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "maxValue" }, "maximum": { "value": 3.5 } } },
@@ -2057,7 +2126,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/boolean',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           boolValue: { "in": "query", "name": "boolValue", "required": true, "dataType": "boolean", "validators": { "isBoolean": { "errorMsg": "boolValue" } } },
         };
@@ -2080,7 +2149,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/string',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minLength: { "in": "query", "name": "minLength", "required": true, "dataType": "string", "validators": { "minLength": { "value": 5 } } },
           maxLength: { "in": "query", "name": "maxLength", "required": true, "dataType": "string", "validators": { "maxLength": { "value": 3 } } },
@@ -2105,7 +2174,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customRequiredErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Required long number." } } },
         };
@@ -2128,7 +2197,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customInvalidErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Invalid long number." } } },
         };
@@ -2151,7 +2220,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/Validate/body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ValidateModel" },
         };

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -1,4 +1,6 @@
 import * as hapi from 'hapi';
+import '../controllers/rootController';
+
 import '../controllers/deleteController';
 import '../controllers/getController';
 import '../controllers/patchController';

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+import { RootController } from './../controllers/rootController';
 import { DeleteTestController } from './../controllers/deleteController';
 import { GetTestController } from './../controllers/getController';
 import { PatchTestController } from './../controllers/patchController';
@@ -116,6 +117,7 @@ const models: TsoaRoute.Models={
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -226,6 +228,44 @@ const models: TsoaRoute.Models={
 };
 
 export function RegisterRoutes(router: any) {
+  router.get('/v1',
+    async (context, next) => {
+      const args={
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new RootController();
+
+      const promise=controller.rootHandler.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
+  router.get('/v1/rootControllerMethodWithPath',
+    async (context, next) => {
+      const args={
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new RootController();
+
+      const promise=controller.rootControllerMethodWithPath.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.delete('/v1/DeleteTest',
     async (context, next) => {
       const args={
@@ -1366,6 +1406,26 @@ export function RegisterRoutes(router: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.post('/v1/ParameterTest/ParamaterQueyArray',
+    async (context, next) => {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.post('/v1/ParameterTest/ParamaterBodyAnyType',
     async (context, next) => {
       const args={
@@ -1386,10 +1446,10 @@ export function RegisterRoutes(router: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
-  router.post('/v1/ParameterTest/ParamaterQueyArray',
+  router.post('/v1/ParameterTest/ParamaterBodyArrayType',
     async (context, next) => {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1403,7 +1463,7 @@ export function RegisterRoutes(router: any) {
 
       const controller=new ParameterController();
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
   router.get('/v1/ParameterTest/ParamaterImplicitString',
@@ -1529,7 +1589,7 @@ export function RegisterRoutes(router: any) {
   router.get('/v1/ParameterTest/paramaterImplicitDate',
     async (context, next) => {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -1,5 +1,7 @@
 import * as Koa from 'koa';
 import * as KoaRouter from 'koa-router';
+import '../controllers/rootController';
+
 import '../controllers/deleteController';
 import '../controllers/getController';
 import '../controllers/patchController';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -8,6 +8,20 @@ import { Gender, GenericModel, GenericRequest, ParameterTestModel, TestClassMode
 const basePath = '/v1';
 
 describe('Express Server', () => {
+  it('can handle get request to root controller`s path', () => {
+    return verifyGetRequest(basePath + '/', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  it('can handle get request to root controller`s method path', () => {
+    return verifyGetRequest(basePath + '/rootControllerMethodWithPath', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
   it('can handle get request with no path argument', () => {
     return verifyGetRequest(basePath + '/GetTest', (err, res) => {
       const model = res.body as TestModel;

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -8,7 +8,7 @@ const basePath = '/v1';
 
 describe('Hapi Server', () => {
   it('can handle get request to root controller`s path', () => {
-    return verifyGetRequest(basePath + '/', (err, res) => {
+    return verifyGetRequest(basePath, (err, res) => {
       const model = res.body as TestModel;
       expect(model.id).to.equal(1);
     });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -7,6 +7,20 @@ import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestCl
 const basePath = '/v1';
 
 describe('Hapi Server', () => {
+  it('can handle get request to root controller`s path', () => {
+    return verifyGetRequest(basePath + '/', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  it('can handle get request to root controller`s method path', () => {
+    return verifyGetRequest(basePath + '/rootControllerMethodWithPath', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
   it('can handle get request with no path argument', () => {
     return verifyGetRequest(basePath + '/GetTest', (err, res) => {
       const model = res.body as TestModel;

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -7,6 +7,20 @@ import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestCl
 const basePath = '/v1';
 
 describe('Koa Server', () => {
+  it('can handle get request to root controller`s path', () => {
+    return verifyGetRequest(basePath + '/', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  it('can handle get request to root controller`s method path', () => {
+    return verifyGetRequest(basePath + '/rootControllerMethodWithPath', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
   it('can handle get request with no path argument', () => {
     return verifyGetRequest(basePath + '/GetTest', (err, res) => {
       const model = res.body as TestModel;

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -8,7 +8,7 @@ const basePath = '/v1';
 
 describe('Koa Server', () => {
   it('can handle get request to root controller`s path', () => {
-    return verifyGetRequest(basePath + '/', (err, res) => {
+    return verifyGetRequest(basePath, (err, res) => {
       const model = res.body as TestModel;
       expect(model.id).to.equal(1);
     });

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import 'mocha';
-import {normalisePath} from '../../../../src/utils/pathUtils';
+import { normalisePath } from '../../../../src/utils/pathUtils';
 
 describe('Paths normalisation', () => {
   it('should remove all redundant symbols at the beginning and at the end', () => {
@@ -50,7 +50,7 @@ describe('Paths normalisation', () => {
     expect(normalisePath('path', null as any, null as any)).to.equal('path');
     expect(normalisePath('path', undefined as any, undefined as any)).to.equal('path');
     expect(normalisePath('path', 1 as any, 2 as any)).to.equal('1path2');
-    expect(normalisePath('path', {} as any, {} as any)).to.equal('[object Object]path[object Object]');
+    expect(normalisePath('path', {} as any, {} as any)).to.equal('[object/Object]path[object/Object]');
   });
 
   it('should handle empty path', () => {


### PR DESCRIPTION
Fix for the issue caused by [this](https://github.com/lukeautry/tsoa/pull/161) PR described in  [comment](https://github.com/lukeautry/tsoa/pull/161#issuecomment-338747127) by @ajmath.

The problem was in trying to normalise endpoint path by peaces (base, controller and method).

Looks like a lot of changed files but most of them are _auto-generated routes_ and _tests_.

Actual changes:
1) Moved all paths normalisation from metadata generators to route and spec generators.
https://github.com/lukeautry/tsoa/pull/173/files#diff-d107cbd1a26a9e3dbdf1db48ecdeac37R76
https://github.com/lukeautry/tsoa/pull/173/files#diff-d0ebfd6b9cb2fdea327d4f71b33a282eR81

2) Instead of normalising paths only by peaces (base, controller and method), now additionally normalising them after normalised peaces are concatenated to a single string.
https://github.com/lukeautry/tsoa/pull/173/files#diff-d107cbd1a26a9e3dbdf1db48ecdeac37R93

3) Instead of rendering path from peaces in template (`{{../../basePath}}{{../path}}{{path}}`) now  using the new `fullPath` property of `action` object, which contains normalised full endpoint path, so in template it looks like (`{{fullPath}}`)
https://github.com/lukeautry/tsoa/pull/173/files#diff-d107cbd1a26a9e3dbdf1db48ecdeac37R98
https://github.com/lukeautry/tsoa/pull/173/files#diff-ec8b224baa9060a807593128914f5adfR40

4) Added controller with empty path and tests for it.
https://github.com/lukeautry/tsoa/pull/173/files#diff-15c48bf30d8d99500ba77a5707ee4643R8

Additionally i can add tests for empty base path, but not sure whether it is needed.