### PR TITLE
Added Tags (Swagger.Tag[]) and Info (Swagger.Info) to SwaggerConfig #176

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,10 +58,12 @@ const validateCompilerOptions = (config?: ts.CompilerOptions): ts.CompilerOption
 const validateSwaggerConfig = (config: SwaggerConfig): SwaggerConfig => {
   if (!config.outputDirectory) { throw new Error('Missing outputDirectory: onfiguration most contain output directory'); }
   if (!config.entryFile) { throw new Error('Missing entryFile: Configuration must contain an entry point file.'); }
-  config.version = config.version || versionDefault;
-  config.name = config.name || nameDefault;
-  config.description = config.description || descriptionDefault;
-  config.license = config.license || licenseDefault;
+  config.info = config.info || {
+    description: descriptionDefault,
+    license: licenseDefault,
+    title: nameDefault,
+    version: versionDefault,
+  };
   config.basePath = config.basePath || '/';
 
   return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,11 @@ export interface SwaggerConfig {
   outputDirectory: string;
 
   /**
+   * Swagger Spec Info of your API
+   */
+  info: Swagger.Info;
+
+  /**
    * The entry point to your API
    */
   entryFile: string;
@@ -41,26 +46,6 @@ export interface SwaggerConfig {
    * API host, expressTemplate.g. localhost:3000 or https://myapi.com
    */
   host?: string;
-
-  /**
-   * API version number; defaults to npm package version
-   */
-  version?: string;
-
-  /**
-   * API name; defaults to npm package name
-   */
-  name?: string;
-
-  /**
-   * 'API description; defaults to npm package description
-   */
-  description?: string;
-
-  /**
-   * API license; defaults to npm package license
-   */
-  license?: string;
 
   /**
    * Base API path; e.g. the 'v1' in https://myapi.com/v1
@@ -92,6 +77,11 @@ export interface SwaggerConfig {
   securityDefinitions?: {
     [name: string]: Swagger.Secuirty,
   };
+
+  /**
+   * Swagger Tags Information for your API
+   */
+  tags?: Swagger.Tag[];
 
   yaml?: boolean;
 }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -11,6 +11,7 @@ export class SpecGenerator {
       basePath: normalisePath(this.config.basePath as string, '/'),
       consumes: ['application/json'],
       definitions: this.buildDefinitions(),
+      info: this.config.info,
       paths: this.buildPaths(),
       produces: ['application/json'],
       swagger: '2.0',

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -11,9 +11,6 @@ export class SpecGenerator {
       basePath: normalisePath(this.config.basePath as string, '/'),
       consumes: ['application/json'],
       definitions: this.buildDefinitions(),
-      info: {
-        title: '',
-      },
       paths: this.buildPaths(),
       produces: ['application/json'],
       swagger: '2.0',
@@ -23,11 +20,9 @@ export class SpecGenerator {
       ? this.config.securityDefinitions
       : {};
 
-    if (this.config.name) { spec.info.title = this.config.name; }
-    if (this.config.version) { spec.info.version = this.config.version; }
+    if (this.config.info) { spec.info = this.config.info; }
     if (this.config.host) { spec.host = this.config.host; }
-    if (this.config.description) { spec.info.description = this.config.description; }
-    if (this.config.license) { spec.info.license = { name: this.config.license }; }
+    if (this.config.tags) { spec.tags = this.config.tags; }
     if (this.config.spec) {
       this.config.specMerging = this.config.specMerging || 'immediate';
       const mergeFuncs: { [key: string]: any } = {


### PR DESCRIPTION
Add Tags to `SwaggerConfig` to be able to have `Tags` with `description`. Info to keep the consistency between `SwaggerConfig` and `Swagger.Spec`. 

#176 

You can now have this in your global tsoa config file: 
[{config-name}.json](https://i.imgur.com/8V8Vgj2.png)

and here's the SwaggerUI:
[SwaggerUI](https://i.imgur.com/ArD6IBd.png)