### PR TITLE
fixed for ts 2.7.x / issue #190

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "merge": "^1.2.0",
     "minimatch": "^3.0.4",
     "moment": "^2.18.1",
-    "typescript": "^2.5.2",
-    "typescript-formatter": "^5.2.0",
+    "typescript": "^2.7.1",
+    "typescript-formatter": "^7.0.1",
     "validator": "^8.0.0",
     "yamljs": "^0.3.0",
     "yargs": "^8.0.2"

--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -162,7 +162,7 @@ export class ParameterGenerator {
     const symbol = MetadataGenerator.current.typeChecker.getSymbolAtLocation(node.name);
     if (!symbol) { return undefined; }
 
-    const comments = symbol.getDocumentationComment();
+    const comments = symbol.getDocumentationComment(undefined);
     if (comments.length) { return ts.displayPartsToString(comments); }
 
     return undefined;

--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -660,7 +660,7 @@ function getNodeDescription(node: UsableDeclaration | ts.PropertyDeclaration | t
     symbol.flags = 0;
   }
 
-  const comments = symbol.getDocumentationComment();
+  const comments = symbol.getDocumentationComment(undefined);
   if (comments.length) { return ts.displayPartsToString(comments); }
 
   return undefined;

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -109,11 +109,18 @@ const models: TsoaRoute.Models={
       "value3": { "dataType": "string", "required": true },
     },
   },
+  "Account": {
+    "properties": {
+      "id": { "dataType": "double", "required": true },
+    },
+  },
   "TestClassModel": {
     "properties": {
+      "account": { "ref": "Account", "required": true },
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -165,8 +172,8 @@ const models: TsoaRoute.Models={
     "properties": {
       "firstname": { "dataType": "string", "required": true },
       "lastname": { "dataType": "string", "required": true },
-      "age": { "dataType": "integer", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
-      "weight": { "dataType": "float", "required": true },
+      "age": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
+      "weight": { "dataType": "double", "required": true },
       "human": { "dataType": "boolean", "required": true },
       "gender": { "ref": "Gender", "required": true },
     },
@@ -1263,6 +1270,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/ParameterTest/ParamaterQueyArray',
+    function(request: any, response: any, next: any) {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/ParameterTest/ParamaterBodyAnyType',
     function(request: any, response: any, next: any) {
       const args={
@@ -1282,10 +1308,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTest/ParamaterBodyArrayType',
     function(request: any, response: any, next: any) {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1298,7 +1324,7 @@ export function RegisterRoutes(app: any) {
       const controller=new ParameterController();
 
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/ParameterTest/ParamaterImplicitString',
@@ -1418,7 +1444,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -111,11 +111,18 @@ const models: TsoaRoute.Models={
       "value3": { "dataType": "string", "required": true },
     },
   },
+  "Account": {
+    "properties": {
+      "id": { "dataType": "double", "required": true },
+    },
+  },
   "TestClassModel": {
     "properties": {
+      "account": { "ref": "Account", "required": true },
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -167,8 +174,8 @@ const models: TsoaRoute.Models={
     "properties": {
       "firstname": { "dataType": "string", "required": true },
       "lastname": { "dataType": "string", "required": true },
-      "age": { "dataType": "integer", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
-      "weight": { "dataType": "float", "required": true },
+      "age": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
+      "weight": { "dataType": "double", "required": true },
       "human": { "dataType": "boolean", "required": true },
       "gender": { "ref": "Gender", "required": true },
     },
@@ -207,11 +214,11 @@ const models: TsoaRoute.Models={
     "properties": {
       "floatValue": { "dataType": "float", "required": true, "validators": { "isFloat": { "errorMsg": "Invalid float error message." } } },
       "doubleValue": { "dataType": "double", "required": true, "validators": { "isDouble": { "errorMsg": "Invalid double error message." } } },
-      "intValue": { "dataType": "integer", "required": true },
+      "intValue": { "dataType": "double", "required": true },
       "longValue": { "dataType": "long", "required": true, "validators": { "isLong": { "errorMsg": "Custom Required long number." } } },
       "booleanValue": { "dataType": "boolean", "required": true },
       "arrayValue": { "dataType": "array", "array": { "dataType": "double" }, "required": true },
-      "dateValue": { "dataType": "date", "required": true },
+      "dateValue": { "dataType": "datetime", "required": true },
       "datetimeValue": { "dataType": "datetime", "required": true },
       "numberMax10": { "dataType": "double", "required": true, "validators": { "maximum": { "value": 10 } } },
       "numberMin5": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 5 } } },
@@ -1309,6 +1316,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/ParameterTest/ParamaterQueyArray',
+    function(request: any, response: any, next: any) {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/ParameterTest/ParamaterBodyAnyType',
     function(request: any, response: any, next: any) {
       const args={
@@ -1328,10 +1354,10 @@ export function RegisterRoutes(app: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
-  app.post('/v1/ParameterTest/ParamaterQueyArray',
+  app.post('/v1/ParameterTest/ParamaterBodyArrayType',
     function(request: any, response: any, next: any) {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1344,7 +1370,7 @@ export function RegisterRoutes(app: any) {
       const controller=new ParameterController();
 
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/ParameterTest/ParamaterImplicitString',
@@ -1464,7 +1490,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -112,11 +112,18 @@ const models: TsoaRoute.Models={
       "value3": { "dataType": "string", "required": true },
     },
   },
+  "Account": {
+    "properties": {
+      "id": { "dataType": "double", "required": true },
+    },
+  },
   "TestClassModel": {
     "properties": {
+      "account": { "ref": "Account", "required": true },
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -168,8 +175,8 @@ const models: TsoaRoute.Models={
     "properties": {
       "firstname": { "dataType": "string", "required": true },
       "lastname": { "dataType": "string", "required": true },
-      "age": { "dataType": "integer", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
-      "weight": { "dataType": "float", "required": true },
+      "age": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
+      "weight": { "dataType": "double", "required": true },
       "human": { "dataType": "boolean", "required": true },
       "gender": { "ref": "Gender", "required": true },
     },
@@ -208,11 +215,11 @@ const models: TsoaRoute.Models={
     "properties": {
       "floatValue": { "dataType": "float", "required": true, "validators": { "isFloat": { "errorMsg": "Invalid float error message." } } },
       "doubleValue": { "dataType": "double", "required": true, "validators": { "isDouble": { "errorMsg": "Invalid double error message." } } },
-      "intValue": { "dataType": "integer", "required": true },
+      "intValue": { "dataType": "double", "required": true },
       "longValue": { "dataType": "long", "required": true, "validators": { "isLong": { "errorMsg": "Custom Required long number." } } },
       "booleanValue": { "dataType": "boolean", "required": true },
       "arrayValue": { "dataType": "array", "array": { "dataType": "double" }, "required": true },
-      "dateValue": { "dataType": "date", "required": true },
+      "dateValue": { "dataType": "datetime", "required": true },
       "datetimeValue": { "dataType": "datetime", "required": true },
       "numberMax10": { "dataType": "double", "required": true, "validators": { "maximum": { "value": 10 } } },
       "numberMin5": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 5 } } },
@@ -231,7 +238,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -253,7 +260,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -275,7 +282,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/DeleteTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double" },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string" },
@@ -303,7 +310,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -325,7 +332,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Current',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -347,7 +354,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -369,7 +376,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -391,7 +398,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/{numberPathParam}/{booleanPathParam}/{stringPathParam}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           numberPathParam: { "in": "path", "name": "numberPathParam", "required": true, "dataType": "double", "validators": { "isDouble": { "errorMsg": "numberPathParam" }, "minimum": { "value": 1 }, "maximum": { "value": 10 } } },
           stringPathParam: { "in": "path", "name": "stringPathParam", "required": true, "dataType": "string", "validators": { "minLength": { "value": 1 }, "maxLength": { "value": 10 } } },
@@ -420,7 +427,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ResponseWithUnionTypeProperty',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -442,7 +449,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/UnionTypeResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -464,7 +471,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -487,7 +494,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/DateParam',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "in": "query", "name": "date", "required": true, "dataType": "datetime" },
         };
@@ -510,7 +517,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/ThrowsError',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -532,7 +539,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GeneratesTags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -554,7 +561,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/HandleBufferType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           buffer: { "in": "query", "name": "buffer", "required": true, "dataType": "buffer" },
         };
@@ -577,7 +584,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -599,7 +606,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericModelArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -621,7 +628,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitive',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -643,7 +650,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/GetTest/GenericPrimitiveArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -665,7 +672,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -688,7 +695,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -710,7 +717,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -732,7 +739,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PatchTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -755,7 +762,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -778,7 +785,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/PostTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -801,7 +808,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithClassModel',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestClassModel" },
         };
@@ -824,7 +831,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -846,7 +853,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -868,7 +875,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -891,7 +898,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/WithBodyAndQueryParams',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
           query: { "in": "query", "name": "query", "required": true, "dataType": "string" },
@@ -915,7 +922,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/PostTest/GenericBody',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           genericReq: { "in": "body", "name": "genericReq", "required": true, "ref": "GenericRequestTestModel" },
         };
@@ -938,7 +945,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
         };
@@ -961,7 +968,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Location',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -983,7 +990,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/Multi',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1005,7 +1012,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/PutTest/WithId/{id}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           id: { "in": "path", "name": "id", "required": true, "dataType": "double" },
         };
@@ -1028,7 +1035,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Get',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1050,7 +1057,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/MethodTest/Post',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1072,7 +1079,7 @@ export function RegisterRoutes(server: any) {
     method: 'patch',
     path: '/v1/MethodTest/Patch',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1094,7 +1101,7 @@ export function RegisterRoutes(server: any) {
     method: 'put',
     path: '/v1/MethodTest/Put',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1116,7 +1123,7 @@ export function RegisterRoutes(server: any) {
     method: 'delete',
     path: '/v1/MethodTest/Delete',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1138,7 +1145,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Description',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1160,7 +1167,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/Tags',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1182,7 +1189,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/MultiResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1204,7 +1211,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SuccessResponse',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1231,7 +1238,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1258,7 +1265,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1285,7 +1292,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1307,7 +1314,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/DeprecatedMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1329,7 +1336,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/SummaryMethod',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1351,7 +1358,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/MethodTest/returnAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1373,7 +1380,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Query',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "query", "name": "last_name", "required": true, "dataType": "string" },
@@ -1401,7 +1408,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Path/{firstname}/{last_name}/{age}/{weight}/{human}/{gender}',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "path", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "path", "name": "last_name", "required": true, "dataType": "string" },
@@ -1429,7 +1436,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Header',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "header", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "header", "name": "last_name", "required": true, "dataType": "string" },
@@ -1457,7 +1464,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/Request',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1480,7 +1487,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/Body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ParameterTestModel" },
         };
@@ -1503,7 +1510,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/ParameterTest/BodyProps',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           firstname: { "in": "body-prop", "name": "firstname", "required": true, "dataType": "string" },
           lastname: { "in": "body-prop", "name": "lastname", "required": true, "dataType": "string" },
@@ -1531,7 +1538,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterQueyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "in": "query", "name": "name", "required": true, "dataType": "any" },
         };
@@ -1552,9 +1559,32 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
+    path: '/v1/ParameterTest/ParamaterQueyArray',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.queyArray.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
     path: '/v1/ParameterTest/ParamaterBodyAnyType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "dataType": "any" },
         };
@@ -1575,11 +1605,11 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'post',
-    path: '/v1/ParameterTest/ParamaterQueyArray',
+    path: '/v1/ParameterTest/ParamaterBodyArrayType',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
-          name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+          body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
         };
 
         let validatedArgs: any[]=[];
@@ -1591,7 +1621,7 @@ export function RegisterRoutes(server: any) {
 
         const controller=new ParameterController();
 
-        const promise=controller.queyArray.apply(controller, validatedArgs);
+        const promise=controller.bodyArrayType.apply(controller, validatedArgs);
         return promiseHandler(controller, promise, request, reply);
       }
     }
@@ -1600,7 +1630,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitString',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           name: { "default": "Iron man", "in": "query", "name": "name", "dataType": "string" },
         };
@@ -1623,7 +1653,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitNumber',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           age: { "default": 40, "in": "query", "name": "age", "dataType": "double" },
         };
@@ -1646,7 +1676,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitEnum',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           gender: { "in": "query", "name": "gender", "dataType": "enum", "enums": ["MALE", "FEMALE"] },
         };
@@ -1669,7 +1699,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/ParamaterImplicitStringArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": ["V1", "V2"], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "string" } },
         };
@@ -1692,7 +1722,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitNumberArray',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           arr: { "default": [1, 2, 3], "in": "query", "name": "arr", "dataType": "array", "array": { "dataType": "double" } },
         };
@@ -1715,7 +1745,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDateTime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           date: { "default": "2017-01-01T00:00:00.000Z", "in": "query", "name": "date", "dataType": "datetime" },
         };
@@ -1738,9 +1768,9 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/ParameterTest/paramaterImplicitDate',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
-          date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+          date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
         };
 
         let validatedArgs: any[]=[];
@@ -1766,7 +1796,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1794,7 +1824,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1822,7 +1852,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1850,7 +1880,7 @@ export function RegisterRoutes(server: any) {
           method: authenticateMiddleware([{ "name": "tsoa_auth", "scopes": ["write:pets", "read:pets"] }, { "name": "api_key" }])
         }
       ],
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           request: { "in": "request", "name": "request", "required": true, "dataType": "object" },
         };
@@ -1873,7 +1903,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/normalStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1895,7 +1925,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/noContentStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1917,7 +1947,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customStatusCode',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1939,7 +1969,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Controller/customHeader',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
         };
 
@@ -1961,7 +1991,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/date',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "date", "validators": { "isDate": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01" } } },
@@ -1985,7 +2015,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/datetime',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minDateValue: { "in": "query", "name": "minDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "minDateValue" }, "minDate": { "value": "2018-01-01T00:00:00" } } },
           maxDateValue: { "in": "query", "name": "maxDateValue", "required": true, "dataType": "datetime", "validators": { "isDateTime": { "errorMsg": "maxDateValue" }, "maxDate": { "value": "2016-01-01T00:00:00" } } },
@@ -2009,7 +2039,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/integer',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "minValue" }, "minimum": { "value": 5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "integer", "validators": { "isInt": { "errorMsg": "maxValue" }, "maximum": { "value": 3 } } },
@@ -2033,7 +2063,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/float',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minValue: { "in": "query", "name": "minValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "minValue" }, "minimum": { "value": 5.5 } } },
           maxValue: { "in": "query", "name": "maxValue", "required": true, "dataType": "float", "validators": { "isFloat": { "errorMsg": "maxValue" }, "maximum": { "value": 3.5 } } },
@@ -2057,7 +2087,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/boolean',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           boolValue: { "in": "query", "name": "boolValue", "required": true, "dataType": "boolean", "validators": { "isBoolean": { "errorMsg": "boolValue" } } },
         };
@@ -2080,7 +2110,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/string',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           minLength: { "in": "query", "name": "minLength", "required": true, "dataType": "string", "validators": { "minLength": { "value": 5 } } },
           maxLength: { "in": "query", "name": "maxLength", "required": true, "dataType": "string", "validators": { "maxLength": { "value": 3 } } },
@@ -2105,7 +2135,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customRequiredErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Required long number." } } },
         };
@@ -2128,7 +2158,7 @@ export function RegisterRoutes(server: any) {
     method: 'get',
     path: '/v1/Validate/parameter/customInvalidErrorMsg',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           longValue: { "in": "query", "name": "longValue", "required": true, "dataType": "long", "validators": { "isLong": { "errorMsg": "Invalid long number." } } },
         };
@@ -2151,7 +2181,7 @@ export function RegisterRoutes(server: any) {
     method: 'post',
     path: '/v1/Validate/body',
     config: {
-      handler: (request: any, reply) => {
+      handler: (request: any, reply: any) => {
         const args={
           body: { "in": "body", "name": "body", "required": true, "ref": "ValidateModel" },
         };

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -111,11 +111,18 @@ const models: TsoaRoute.Models={
       "value3": { "dataType": "string", "required": true },
     },
   },
+  "Account": {
+    "properties": {
+      "id": { "dataType": "double", "required": true },
+    },
+  },
   "TestClassModel": {
     "properties": {
+      "account": { "ref": "Account", "required": true },
       "defaultValue2": { "dataType": "string", "default": "Default Value 2" },
       "publicStringProperty": { "dataType": "string", "required": true, "validators": { "minLength": { "value": 3 }, "maxLength": { "value": 20 }, "pattern": { "value": "^[a-zA-Z]+$" } } },
       "optionalPublicStringProperty": { "dataType": "string", "validators": { "minLength": { "value": 0 }, "maxLength": { "value": 10 } } },
+      "emailPattern": { "dataType": "string", "validators": { "pattern": { "value": "^[a-zA-Z0-9_.+-]+" } } },
       "stringProperty": { "dataType": "string", "required": true },
       "publicConstructorVar": { "dataType": "string", "required": true },
       "optionalPublicConstructorVar": { "dataType": "string" },
@@ -167,8 +174,8 @@ const models: TsoaRoute.Models={
     "properties": {
       "firstname": { "dataType": "string", "required": true },
       "lastname": { "dataType": "string", "required": true },
-      "age": { "dataType": "integer", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
-      "weight": { "dataType": "float", "required": true },
+      "age": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 1 }, "maximum": { "value": 100 } } },
+      "weight": { "dataType": "double", "required": true },
       "human": { "dataType": "boolean", "required": true },
       "gender": { "ref": "Gender", "required": true },
     },
@@ -207,11 +214,11 @@ const models: TsoaRoute.Models={
     "properties": {
       "floatValue": { "dataType": "float", "required": true, "validators": { "isFloat": { "errorMsg": "Invalid float error message." } } },
       "doubleValue": { "dataType": "double", "required": true, "validators": { "isDouble": { "errorMsg": "Invalid double error message." } } },
-      "intValue": { "dataType": "integer", "required": true },
+      "intValue": { "dataType": "double", "required": true },
       "longValue": { "dataType": "long", "required": true, "validators": { "isLong": { "errorMsg": "Custom Required long number." } } },
       "booleanValue": { "dataType": "boolean", "required": true },
       "arrayValue": { "dataType": "array", "array": { "dataType": "double" }, "required": true },
-      "dateValue": { "dataType": "date", "required": true },
+      "dateValue": { "dataType": "datetime", "required": true },
       "datetimeValue": { "dataType": "datetime", "required": true },
       "numberMax10": { "dataType": "double", "required": true, "validators": { "maximum": { "value": 10 } } },
       "numberMin5": { "dataType": "double", "required": true, "validators": { "minimum": { "value": 5 } } },
@@ -1366,6 +1373,26 @@ export function RegisterRoutes(router: any) {
       const promise=controller.queryAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.post('/v1/ParameterTest/ParamaterQueyArray',
+    async (context, next) => {
+      const args={
+        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.queyArray.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.post('/v1/ParameterTest/ParamaterBodyAnyType',
     async (context, next) => {
       const args={
@@ -1386,10 +1413,10 @@ export function RegisterRoutes(router: any) {
       const promise=controller.bodyAnyType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
-  router.post('/v1/ParameterTest/ParamaterQueyArray',
+  router.post('/v1/ParameterTest/ParamaterBodyArrayType',
     async (context, next) => {
       const args={
-        name: { "in": "query", "name": "name", "required": true, "dataType": "array", "array": { "dataType": "string" } },
+        body: { "in": "body", "name": "body", "required": true, "dataType": "array", "array": { "ref": "ParameterTestModel" } },
       };
 
       let validatedArgs: any[]=[];
@@ -1403,7 +1430,7 @@ export function RegisterRoutes(router: any) {
 
       const controller=new ParameterController();
 
-      const promise=controller.queyArray.apply(controller, validatedArgs);
+      const promise=controller.bodyArrayType.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
   router.get('/v1/ParameterTest/ParamaterImplicitString',
@@ -1529,7 +1556,7 @@ export function RegisterRoutes(router: any) {
   router.get('/v1/ParameterTest/paramaterImplicitDate',
     async (context, next) => {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];


### PR DESCRIPTION
Works with 2.7.x. 

A test is broken in all backends:

expect(body.fields['body.intValue'].message).to.equal('invalid integer number');