### PR TITLE
Fix #112. Non "tsoa" decorator that has no expression defined fails routes and swagger generation

### DIFF
--- a/src/utils/decoratorUtils.ts
+++ b/src/utils/decoratorUtils.ts
@@ -5,10 +5,26 @@ export function getDecorators(node: ts.Node, isMatching: (identifier: ts.Identif
   const decorators = node.decorators;
   if (!decorators || !decorators.length) { return []; }
 
-  return decorators
-    .map(d => d.expression as ts.CallExpression)
-    .map(e => e.expression as ts.Identifier)
-    .filter(isMatching);
+
+  let identifiers : ts.Identifier[] = [];
+  // filter and transform decorators in a single loop
+  decorators.forEach((d: ts.Decorator) => {
+    let expression = d.expression as ts.CallExpression;
+    let identifier = expression.expression as ts.Identifier;
+
+    // filter out decorators without expression
+    if(!identifier) {
+      return;
+    }
+
+    // check if identifier matches
+    if(isMatching(identifier)) {
+      // and push to it to resulting array
+      identifiers.push(identifier)
+    }
+  });
+
+  return identifiers;
 }
 
 export function getDecoratorName(node: ts.Node, isMatching: (identifier: ts.Identifier) => boolean) {


### PR DESCRIPTION
Usecase: when tsoa is used with other libraries that are also using decorators (e.g. sequelize-typescript) and no expression is defined swagger/routes generation fails with error stated in #112 

E.g. tsoa will currently fail on following code:

```javascript
import {Table, Column, Model} from 'sequelize-typescript';

@Table
class Person extends Model<Person> {
  @Column
  name: string;
}
```