### PR TITLE
Add custom parameters defined by a provided function on how to get it…

### DIFF
--- a/src/decorators/custom.ts
+++ b/src/decorators/custom.ts
@@ -1,0 +1,32 @@
+const METADATA_KEY = `tsoa_custom_parameter`;
+
+export function CustomParameter(getParam: (req: any) => any) {
+  return (target: object, key: string | symbol, index: number) =>  {
+    if (!target[METADATA_KEY]) {
+      target[METADATA_KEY] = {};
+    }
+
+    const details = {
+      getParam,
+      index,
+    };
+    if (target[METADATA_KEY][key]) {
+      target[METADATA_KEY][key].push(details);
+    } else {
+      target[METADATA_KEY][key] = [details];
+    }
+  };
+}
+
+export function CustomParameters() {
+  return (target: object, key: string | symbol, descriptor: any) =>  {
+    const originalMethod = descriptor.value;
+    descriptor.value = function(...args: any[]) {
+      target[METADATA_KEY][key].forEach(({ getParam, index }) => {
+        args[index] = getParam(args[index]);
+      });
+      return originalMethod.apply(this, args);
+    };
+    return descriptor;
+  };
+}

--- a/src/decorators/custom.ts
+++ b/src/decorators/custom.ts
@@ -21,10 +21,11 @@ export function CustomParameter(getParam: (req: any) => any) {
 export function CustomParameters() {
   return (target: object, key: string | symbol, descriptor: any) =>  {
     const originalMethod = descriptor.value;
-    descriptor.value = function(...args: any[]) {
-      target[METADATA_KEY][key].forEach(({ getParam, index }) => {
-        args[index] = getParam(args[index]);
-      });
+    descriptor.value = async function(...args: any[]) {
+      const customParams = target[METADATA_KEY][key];
+      for (const {getParam, index} of customParams) {
+        args[index] = await getParam(args[index]);
+      }
       return originalMethod.apply(this, args);
     };
     return descriptor;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference path="hapi.d.ts" />
 /// <reference path="koa.d.ts" />
 
+export * from './decorators/custom';
 export * from './decorators/example';
 export * from './decorators/parameter';
 export * from './decorators/methods';

--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -29,6 +29,8 @@ export class ParameterGenerator {
         return this.getQueryParameter(this.parameter);
       case 'Path':
         return this.getPathParameter(this.parameter);
+      case 'CustomParameter':
+        return this.getRequestParameter(this.parameter);
       default:
         return this.getPathParameter(this.parameter);
     }
@@ -173,7 +175,7 @@ export class ParameterGenerator {
   }
 
   private supportParameterDecorator(decoratorName: string) {
-    return ['header', 'query', 'parem', 'body', 'bodyprop', 'request'].some((d) => d === decoratorName.toLocaleLowerCase());
+    return ['header', 'query', 'parem', 'body', 'bodyprop', 'request', 'customparameter'].some((d) => d === decoratorName.toLocaleLowerCase());
   }
 
   private supportPathDataType(parameterType: Tsoa.Type) {

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -247,4 +247,11 @@ export class ParameterController {
     ) {
       return { method, firstname, url };
     }
+
+
+    @Get('CustomParameterAsync')
+    @CustomParameters()
+    public async customParameterAsync( @CustomParameter(req => Promise.resolve(req.method.toLowerCase())) method: string) {
+      return { method }
+    }
 }

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -1,6 +1,8 @@
 import {
   Body,
   BodyProp,
+  CustomParameter,
+  CustomParameters,
   Get,
   Header,
   Path,
@@ -230,4 +232,19 @@ export class ParameterController {
     //
   }
 
+    @Get('CustomParameter')
+    @CustomParameters()
+    public async customParameter( @CustomParameter(req => req.method.toLowerCase()) method: string) {
+      return { method };
+    }
+
+    @Get('CustomParameters')
+    @CustomParameters()
+    public async customParameters(
+      @CustomParameter(req => req.method.toLowerCase()) method: string,
+      @Query() firstname: string,
+      @CustomParameter(req => typeof req.url === 'string' ? req.url : req.url.path) url: string,
+    ) {
+      return { method, firstname, url };
+    }
 }

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -1461,6 +1461,46 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitDate.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.get('/v1/ParameterTest/CustomParameter',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameter.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.get('/v1/ParameterTest/CustomParameters',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+        firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
+        url: { "in": "request", "name": "url", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameters.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -1501,6 +1501,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.customParameters.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.get('/v1/ParameterTest/CustomParameterAsync',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameterAsync.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1584,6 +1584,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.customParameters.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.get('/v1/ParameterTest/CustomParameterAsync',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameterAsync.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1544,6 +1544,46 @@ export function RegisterRoutes(app: any) {
       const promise=controller.implicitDate.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.get('/v1/ParameterTest/CustomParameter',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameter.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.get('/v1/ParameterTest/CustomParameters',
+    function(request: any, response: any, next: any) {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+        firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
+        url: { "in": "request", "name": "url", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ParameterController();
+
+
+      const promise=controller.customParameters.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     function(request: any, response: any, next: any) {

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -1883,6 +1883,29 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'get',
+    path: '/v1/ParameterTest/CustomParameterAsync',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.customParameterAsync.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
     path: '/v1/SecurityTest',
     config: {
       pre: [

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -1835,6 +1835,54 @@ export function RegisterRoutes(server: any) {
   });
   server.route({
     method: 'get',
+    path: '/v1/ParameterTest/CustomParameter',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.customParameter.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
+    path: '/v1/ParameterTest/CustomParameters',
+    config: {
+      handler: (request: any, reply: any) => {
+        const args={
+          method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+          firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
+          url: { "in": "request", "name": "url", "required": true, "dataType": "object" },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return reply(err).code(err.status||500);
+        }
+
+        const controller=new ParameterController();
+
+        const promise=controller.customParameters.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, reply);
+      }
+    }
+  });
+  server.route({
+    method: 'get',
     path: '/v1/SecurityTest',
     config: {
       pre: [

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -1613,6 +1613,48 @@ export function RegisterRoutes(router: any) {
       const promise=controller.implicitDate.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.get('/v1/ParameterTest/CustomParameter',
+    async (context, next) => {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.customParameter.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
+  router.get('/v1/ParameterTest/CustomParameters',
+    async (context, next) => {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+        firstname: { "in": "query", "name": "firstname", "required": true, "dataType": "string" },
+        url: { "in": "request", "name": "url", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.customParameters.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     async (context, next) => {

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -1655,6 +1655,26 @@ export function RegisterRoutes(router: any) {
       const promise=controller.customParameters.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.get('/v1/ParameterTest/CustomParameterAsync',
+    async (context, next) => {
+      const args={
+        method: { "in": "request", "name": "method", "required": true, "dataType": "object" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new ParameterController();
+
+      const promise=controller.customParameterAsync.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.get('/v1/SecurityTest',
     authenticateMiddleware([{ "name": "api_key" }]),
     async (context, next) => {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -620,6 +620,25 @@ describe('Express Server', () => {
         expect(model.id).to.equal(1);
       });
     });
+
+    it('can handle a custom parameter', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameter', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
+
+    it('can handle a custom parameters', () => {
+      const url: string = basePath + '/ParameterTest/CustomParameters?firstname=Tony';
+      return verifyGetRequest(url, (err, res) => {
+        expect(res.body).to.eql({
+          firstname: 'Tony',
+          method: 'get',
+          url,
+        });
+      });
+    });
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -639,6 +639,14 @@ describe('Express Server', () => {
         });
       });
     });
+
+    it('can handle custom parameters with async callbacks', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameterAsync', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -607,6 +607,25 @@ describe('Hapi Server', () => {
         expect(model.id).to.equal(1);
       });
     });
+
+    it('can handle a custom parameter', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameter', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
+
+    it('can handle a custom parameters', () => {
+      const url: string = basePath + '/ParameterTest/CustomParameters?firstname=Tony';
+      return verifyGetRequest(url, (err, res) => {
+        expect(res.body).to.eql({
+          firstname: 'Tony',
+          method: 'get',
+          url,
+        });
+      });
+    });
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -626,6 +626,14 @@ describe('Hapi Server', () => {
         });
       });
     });
+
+    it('can handle custom parameters with async callbacks', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameterAsync', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -603,6 +603,14 @@ describe('Koa Server', () => {
         });
       });
     });
+
+    it('can handle custom parameters with async callbacks', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameterAsync', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
   });
 
   it('shutdown server', () => server.close());

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -584,6 +584,25 @@ describe('Koa Server', () => {
         expect(model.id).to.equal(1);
       });
     });
+
+    it('can handle a custom parameter', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/CustomParameter', (err, res) => {
+        expect(res.body).to.eql({
+          method: 'get',
+        });
+      });
+    });
+
+    it('can handle a custom parameters', () => {
+      const url: string = basePath + '/ParameterTest/CustomParameters?firstname=Tony';
+      return verifyGetRequest(url, (err, res) => {
+        expect(res.body).to.eql({
+          firstname: 'Tony',
+          method: 'get',
+          url,
+        });
+      });
+    });
   });
 
   it('shutdown server', () => server.close());


### PR DESCRIPTION
… from the request

This addresses https://github.com/lukeautry/tsoa/issues/187 and extensibility without forcing people to change how routes are generated. 

The `@CustomParameter` parameter decorator takes in a function that defines how to get your custom parameter from the request. The `@CustomParameters` method decorator is placed on a controller method has use custom parameters. It is what actually manipulates the arguments by doing the mapping of the request to the given custom parameter.

Let me know if there are any additional tests or changes to the readme needed.  