### PR TITLE
Resetting controller status when it's singleton

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -57,6 +57,9 @@ export function RegisterRoutes(app: any) {
 
             {{#if ../../iocModule}}
             const controller = iocContainer.get<{{../name}}>({{../name}});
+            if (typeof controller['setStatus'] === 'function') {
+                (<any>controller).setStatus(undefined);
+            }
             {{else}}
             const controller = new {{../name}}();
             {{/if}}


### PR DESCRIPTION
Previously when having IoC and setting a response status it is remembered to the next request