### PR TITLE
Fix required parameter error message.

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -9,7 +9,7 @@ export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, ge
 
   if (value === undefined || value === null) {
     if (property.required) {
-      let message = `'${name}' is a required`;
+      let message = `'${name}' is required`;
       if (property.validators) {
         const validators = property.validators;
         Object.keys(validators).forEach((key: string) => {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -64,7 +64,7 @@ describe('Express Server', () => {
   it('returns error if missing required query parameter', () => {
     return verifyGetRequest(basePath + `/GetTest/${1}/${true}/test?booleanParam=true&stringParam=test1234`, (err: any, res: any) => {
       const body = JSON.parse(err.text);
-      expect(body.fields.numberParam.message).to.equal(`'numberParam' is a required`);
+      expect(body.fields.numberParam.message).to.equal(`'numberParam' is required`);
     }, 400);
   });
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -55,7 +55,7 @@ describe('Hapi Server', () => {
   it('returns error if missing required query parameter', () => {
     return verifyGetRequest(basePath + `/GetTest/${1}/${true}/test?booleanParam=true&stringParam=test1234`, (err: any, res: any) => {
       const body = JSON.parse(err.text);
-      expect(body.fields.numberParam.message).to.equal(`'numberParam' is a required`);
+      expect(body.fields.numberParam.message).to.equal(`'numberParam' is required`);
     }, 400);
   });
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -55,7 +55,7 @@ describe('Koa Server', () => {
   it('returns error if missing required query parameter', () => {
     return verifyGetRequest(basePath + `/GetTest/${1}/${true}/test?booleanParam=true&stringParam=test1234`, (err: any, res: any) => {
       const body = JSON.parse(err.text);
-      expect(body.fields.numberParam.message).to.equal(`'numberParam' is a required`);
+      expect(body.fields.numberParam.message).to.equal(`'numberParam' is required`);
     }, 400);
   });
 


### PR DESCRIPTION
Not sure if the error message was initially meant to be `is a required query parameter`, for example.