### PR TITLE
Add "schemes" option into configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export interface SwaggerConfig {
   entryFile: string;
 
   /**
-   * API host, expressTemplate.g. localhost:3000 or https://myapi.com
+   * API host, expressTemplate.g. localhost:3000 or myapi.com
    */
   host?: string;
 
@@ -94,6 +94,8 @@ export interface SwaggerConfig {
   };
 
   yaml?: boolean;
+
+  schemes?: Swagger.Protocol [];
 }
 
 export interface RoutesConfig {

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -37,6 +37,7 @@ export class SpecGenerator {
 
       spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);
     }
+    if (this.config.schemes) { spec.schemes = this.config.schemes; }
 
     return spec;
   }

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -26,6 +26,9 @@ describe('Schema details generation', () => {
   it('should set API host if provided', () => {
     expect(spec.host).to.equal(getDefaultOptions().host);
   });
+  it('should set API schemes if provided', () => {
+    expect(spec.schemes).to.equal(getDefaultOptions().schemes);
+  });
 
   const license = spec.info.license;
   if (!license) { throw new Error('No license.'); }


### PR DESCRIPTION
The protocol ( https | http )cannot be in the host, when importing to swagger hub with Swagger 2.0.  It needs a schemes option at the same level of "host".