### PR TITLE
Adds routeTo method for HATEOAS support

### DIFF
--- a/src/decorators/methods.ts
+++ b/src/decorators/methods.ts
@@ -1,19 +1,56 @@
+export const keys = {
+  baseRoute: '__base_route',
+  controllerClass: '__controller_class',
+  pathExpression: '__pathExpression',
+};
+
+export function routeTo(handler, args?: object) {
+  const baseRoute = handler[keys.controllerClass][keys.baseRoute];
+  let pathValue: string = handler[keys.pathExpression] || '';
+  if (args && pathValue) {
+    const argProps = Object.getOwnPropertyNames(args);
+    for (const argProp of argProps) {
+      pathValue = pathValue.replace('{' + argProp + '}', args[argProp]);
+    }
+  }
+  return (
+    '/' + baseRoute + '/' + encodeURI(pathValue)
+  );
+}
+
+// const saveRoute =
+
 export function Get(value?: string): any {
-  return () => { return; };
+  return (target: any, propertyKey: string) => {
+    target[propertyKey][keys.controllerClass] = target.constructor;
+    target[propertyKey][keys.pathExpression] = value;
+  };
 }
 
 export function Post(value?: string): any {
-  return () => { return; };
+  return (target: any, propertyKey: string) => {
+    target[propertyKey][keys.controllerClass] = target.constructor;
+    target[propertyKey][keys.pathExpression] = value;
+  };
 }
 
 export function Put(value?: string): any {
-  return () => { return; };
+  return (target: any, propertyKey: string) => {
+    target[propertyKey][keys.controllerClass] = target.constructor;
+    target[propertyKey][keys.pathExpression] = value;
+  };
 }
 
 export function Patch(value?: string): any {
-  return () => { return; };
+  return (target: any, propertyKey: string) => {
+    target[propertyKey][keys.controllerClass] = target.constructor;
+    target[propertyKey][keys.pathExpression] = value;
+  };
 }
 
 export function Delete(value?: string): any {
-  return () => { return; };
+  return (target: any, propertyKey: string) => {
+    target[propertyKey][keys.controllerClass] = target.constructor;
+    target[propertyKey][keys.pathExpression] = value;
+  };
 }


### PR DESCRIPTION
Addresses #225 . 

Sorry, I wasn't sure how to organize tests for this. Happy to update it w/ some guidance.

This makes it easy to add HATEOAS style links to response models.

Example: 

```typescript
@Get('{parentId}')
async getParent(parentId: string): Promise<Parent> {
  const result = {
    id: parentId,
    name: "Daddy",
    links: [
      { 
        rel: 'children',
        href: routeTo(ChildrenController.prototype.getChildren, {
            parentId: parentId
          })
      }
    ]
  }
}
```