### PR TITLE
Allow interfaces to be documented via @example

### DIFF
--- a/src/metadataGeneration/resolveType.ts
+++ b/src/metadataGeneration/resolveType.ts
@@ -304,6 +304,7 @@ function getReferenceType(type: ts.EntityName, extractEnum = true, genericTypes?
     const properties = getModelProperties(modelType, genericTypes);
     const additionalProperties = getModelAdditionalProperties(modelType);
     const inheritedProperties = getModelInheritedProperties(modelType) || [];
+    const example = getNodeExample(modelType);
 
     const referenceType = {
       additionalProperties,
@@ -316,6 +317,9 @@ function getReferenceType(type: ts.EntityName, extractEnum = true, genericTypes?
     referenceType.properties = (referenceType.properties as Tsoa.Property[]).concat(properties);
     localReferenceTypeCache[refNameWithGenerics] = referenceType;
 
+    if (example) {
+      referenceType.example = example;
+    }
     return referenceType;
   } catch (err) {
     // tslint:disable-next-line:no-console
@@ -709,4 +713,14 @@ function getNodeDescription(node: UsableDeclaration | ts.PropertyDeclaration | t
 
 function getNodeFormat(node: UsableDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration | ts.EnumDeclaration) {
   return getJSDocComment(node, 'format');
+}
+
+function getNodeExample(node: UsableDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration | ts.EnumDeclaration) {
+  const example = getJSDocComment(node, 'example');
+
+  if (example) {
+    return JSON.parse(example);
+  } else {
+    return undefined;
+  }
 }

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -85,6 +85,7 @@ export namespace Tsoa {
     properties?: Property[];
     additionalProperties?: Type;
     enums?: string[];
+    example?: any;
   }
 
   export interface ReferenceTypeMap {

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -60,6 +60,10 @@ export class SpecGenerator {
         if (referenceType.additionalProperties) {
           definitions[referenceType.refName].additionalProperties = this.buildAdditionalProperties(referenceType.additionalProperties);
         }
+
+        if (referenceType.example) {
+          definitions[referenceType.refName].example = referenceType.example;
+        }
       }
 
       // Enum definition

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -1,6 +1,25 @@
 /**
  * This is a description of a model
  * @tsoaModel
+ * @example
+ * {
+ *   "boolArray": [true, false],
+ *   "boolValue": true,
+ *   "dateValue": "2018-06-25T15:45:00Z",
+ *   "id": 2,
+ *   "modelValue": {
+ *     "id": 3,
+ *     "email": "test(at)example.com"
+ *   },
+ *   "modelsArray": [],
+ *   "numberArray": [1, 2, 3],
+ *   "numberValue": 1,
+ *   "optionalString": "optional string",
+ *   "strLiteralArr": ["Foo", "Bar"],
+ *   "strLiteralVal": "Foo",
+ *   "stringArray": ["string one", "string two"],
+ *   "stringValue": "a string"
+ * }
  */
 export interface TestModel extends Model {
   /**

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -65,6 +65,17 @@ describe('Definition generation', () => {
       expect(property.format).to.equal('password');
     });
 
+    it('should generate an example from a jsdoc comment', () => {
+      const definition = getValidatedDefinition('TestModel');
+      if (!definition.example) { throw new Error('Definition has no example.'); }
+
+      const example = definition.example as any;
+      if (!example) { throw new Error('No json example.'); }
+
+      expect(example.id).to.equal(2);
+      expect(example.modelValue.id).to.equal(3);
+    });
+
     it('should generate properties from extended interface', () => {
       const definition = getValidatedDefinition('TestModel');
       if (!definition.properties) { throw new Error('Definition has no properties.'); }


### PR DESCRIPTION
Unfortunately this way we cannot use special characters like `@` or execute code like we do with `new Date()` in the `Example` annotation. It still seems to be the best option when using interfaces. Did I miss something?

ping @jamestharpe @AmazingTurtle 