### PR TITLE
Allow setting status and headers in controllers that do not extend Controller

### DIFF
--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -98,18 +98,21 @@ export function RegisterRoutes(app: any) {
     }
     {{/if}}
 
+    function isController(object: any): object is Controller {
+        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
+    }
+
     function promiseHandler(controllerObj: any, promise: any, response: any, next: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 let statusCode;
-                if (controllerObj instanceof Controller) {
-                    const controller = controllerObj as Controller
-                    const headers = controller.getHeaders();
+                if (isController(controllerObj)) {
+                    const headers = controllerObj.getHeaders();
                     Object.keys(headers).forEach((name: string) => {
                         response.set(name, headers[name]);
                     });
 
-                    statusCode = controller.getStatus();
+                    statusCode = controllerObj.getStatus();
                 }
 
                 if (data || data === false) { // === false allows boolean result

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -103,19 +103,22 @@ export function RegisterRoutes(server: any) {
     }
     {{/if}}
 
+    function isController(object: any): object is Controller {
+        return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
+    }
+
     function promiseHandler(controllerObj: any, promise: any, request: any, reply: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
                 const response = (data || data === false) ? reply(data).code(200) : reply("").code(204);
 
-                if (controllerObj instanceof Controller) {
-                    const controller = controllerObj as Controller
-                    const headers = controller.getHeaders();
+                if (isController(controllerObj)) {
+                    const headers = controllerObj.getHeaders();
                     Object.keys(headers).forEach((name: string) => {
                         response.header(name, headers[name]);
                     });
 
-                    const statusCode = controller.getStatus();
+                    const statusCode = controllerObj.getStatus();
                     if (statusCode) {
                         response.code(statusCode);
                     }

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -97,6 +97,10 @@ export function RegisterRoutes(router: any) {
   }
   {{/if}}
 
+  function isController(object: any): object is Controller {
+      return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
+  }
+
   function promiseHandler(controllerObj: any, promise: Promise<any>, context: any, next: () => Promise<any>) {
       return Promise.resolve(promise)
         .then((data: any) => {
@@ -107,14 +111,13 @@ export function RegisterRoutes(router: any) {
                 context.status = 204;
             }
 
-            if (controllerObj instanceof Controller) {
-                const controller = controllerObj as Controller
-                const headers = controller.getHeaders();
+            if (isController(controllerObj)) {
+                const headers = controllerObj.getHeaders();
                 Object.keys(headers).forEach((name: string) => {
                     context.set(name, headers[name]);
                 });
 
-                const statusCode = controller.getStatus();
+                const statusCode = controllerObj.getStatus();
                 if (statusCode) {
                     context.status = statusCode;
                 }

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -6,6 +6,20 @@ import { GenericRequest, TestClassModel, TestModel } from '../testModel';
 
 @Route('PostTest')
 export class PostTestController {
+  private statusCode?: number = undefined;
+
+  public setStatus(statusCode: number) {
+    this.statusCode = statusCode;
+  }
+
+  public getStatus() {
+    return this.statusCode;
+  }
+
+  public getHeaders() {
+    return [];
+  }
+
   @Post()
   public async postModel( @Body() model: TestModel): Promise<TestModel> {
     return model;
@@ -14,6 +28,12 @@ export class PostTestController {
   @Patch()
   public async updateModel( @Body() model: TestModel): Promise<TestModel> {
     return await new ModelService().getModel();
+  }
+
+  @Post('WithDifferentReturnCode')
+  public async postWithDifferentReturnCode( @Body() model: TestModel): Promise<TestModel> {
+    this.setStatus(201);
+    return model;
   }
 
   @Post('WithClassModel')

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -658,6 +658,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.updateModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/PostTest/WithDifferentReturnCode',
+    function(request: any, response: any, next: any) {
+      const args={
+        model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new PostTestController();
+
+
+      const promise=controller.postWithDifferentReturnCode.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/PostTest/WithClassModel',
     function(request: any, response: any, next: any) {
       const args={
@@ -1445,7 +1464,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -741,6 +741,25 @@ export function RegisterRoutes(app: any) {
       const promise=controller.updateModel.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
+  app.post('/v1/PostTest/WithDifferentReturnCode',
+    function(request: any, response: any, next: any) {
+      const args={
+        model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new PostTestController();
+
+
+      const promise=controller.postWithDifferentReturnCode.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
   app.post('/v1/PostTest/WithClassModel',
     function(request: any, response: any, next: any) {
       const args={
@@ -1528,7 +1547,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -1917,18 +1936,21 @@ export function RegisterRoutes(app: any) {
     }
   }
 
+  function isController(object: any): object is Controller {
+    return 'getHeaders' in object&&'getStatus' in object&&'setStatus' in object;
+  }
+
   function promiseHandler(controllerObj: any, promise: any, response: any, next: any) {
     return Promise.resolve(promise)
       .then((data: any) => {
         let statusCode;
-        if (controllerObj instanceof Controller) {
-          const controller=controllerObj as Controller
-          const headers=controller.getHeaders();
+        if (isController(controllerObj)) {
+          const headers=controllerObj.getHeaders();
           Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
           });
 
-          statusCode=controller.getStatus();
+          statusCode=controllerObj.getStatus();
         }
 
         if (data||data===false) { // === false allows boolean result

--- a/tests/fixtures/inversify/routes.ts
+++ b/tests/fixtures/inversify/routes.ts
@@ -128,18 +128,21 @@ export function RegisterRoutes(app: any) {
     });
 
 
+  function isController(object: any): object is Controller {
+    return 'getHeaders' in object&&'getStatus' in object&&'setStatus' in object;
+  }
+
   function promiseHandler(controllerObj: any, promise: any, response: any, next: any) {
     return Promise.resolve(promise)
       .then((data: any) => {
         let statusCode;
-        if (controllerObj instanceof Controller) {
-          const controller=controllerObj as Controller
-          const headers=controller.getHeaders();
+        if (isController(controllerObj)) {
+          const headers=controllerObj.getHeaders();
           Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
           });
 
-          statusCode=controller.getStatus();
+          statusCode=controllerObj.getStatus();
         }
 
         if (data||data===false) { // === false allows boolean result

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -768,6 +768,26 @@ export function RegisterRoutes(router: any) {
       const promise=controller.updateModel.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
+  router.post('/v1/PostTest/WithDifferentReturnCode',
+    async (context, next) => {
+      const args={
+        model: { "in": "body", "name": "model", "required": true, "ref": "TestModel" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status||500;
+        context.body=error;
+        return next();
+      }
+
+      const controller=new PostTestController();
+
+      const promise=controller.postWithDifferentReturnCode.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
   router.post('/v1/PostTest/WithClassModel',
     async (context, next) => {
       const args={
@@ -1596,7 +1616,7 @@ export function RegisterRoutes(router: any) {
   router.get('/v1/ParameterTest/paramaterImplicitDate',
     async (context, next) => {
       const args={
-        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -2005,6 +2025,10 @@ export function RegisterRoutes(router: any) {
     }
   }
 
+  function isController(object: any): object is Controller {
+    return 'getHeaders' in object&&'getStatus' in object&&'setStatus' in object;
+  }
+
   function promiseHandler(controllerObj: any, promise: Promise<any>, context: any, next: () => Promise<any>) {
     return Promise.resolve(promise)
       .then((data: any) => {
@@ -2015,14 +2039,13 @@ export function RegisterRoutes(router: any) {
           context.status=204;
         }
 
-        if (controllerObj instanceof Controller) {
-          const controller=controllerObj as Controller
-          const headers=controller.getHeaders();
+        if (isController(controllerObj)) {
+          const headers=controllerObj.getHeaders();
           Object.keys(headers).forEach((name: string) => {
             context.set(name, headers[name]);
           });
 
-          const statusCode=controller.getStatus();
+          const statusCode=controllerObj.getStatus();
           if (statusCode) {
             context.status=statusCode;
           }

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -111,6 +111,12 @@ describe('Express Server', () => {
     });
   });
 
+  it('correctly returns status code', () => {
+    const data = getFakeModel();
+    const path = basePath + '/PostTest/WithDifferentReturnCode';
+    return verifyPostRequest(path, data, (err, res) => { return; }, 201);
+  });
+
   it('parses class model as body parameter', () => {
     const data = getFakeClassModel();
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -98,6 +98,12 @@ describe('Hapi Server', () => {
     });
   });
 
+  it('correctly returns status code', () => {
+    const data = getFakeModel();
+    const path = basePath + '/PostTest/WithDifferentReturnCode';
+    return verifyPostRequest(path, data, (err, res) => { return; }, 201);
+  });
+
   it('parses class model as body parameter', () => {
     const data = getFakeClassModel();
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -75,6 +75,12 @@ describe('Koa Server', () => {
     });
   });
 
+  it('correctly returns status code', () => {
+    const data = getFakeModel();
+    const path = basePath + '/PostTest/WithDifferentReturnCode';
+    return verifyPostRequest(path, data, (err, res) => { return; }, 201);
+  });
+
   it('parses class model as body parameter', () => {
     const data = getFakeClassModel();
 


### PR DESCRIPTION
The reason for this change is that I have difficulty extending my controllers from `Controller` when using `inversify` as then I would need to somehow be able to inject into the `Controller`-constructor. After this change it doesn't matter if controllers extend `Controller`, it only checks for the necessary methods. Does that make sense?

ping @AmazingTurtle @jamestharpe @abmohan