### PR TITLE
change decorator return type to Function for no-unsafe-any tslint rule.

### DIFF
--- a/src/decorators/example.ts
+++ b/src/decorators/example.ts
@@ -1,3 +1,3 @@
-export function Example<T>(exampleModel: T): any {
+export function Example<T>(exampleModel: T): Function {
   return () => { return; };
 }

--- a/src/decorators/example.ts
+++ b/src/decorators/example.ts
@@ -1,3 +1,5 @@
-export function Example<T>(exampleModel: T): Function {
+import { MethodDecoratorReturn } from '../interfaces/decorator-return';
+
+export function Example<T>(exampleModel: T): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/methods.ts
+++ b/src/decorators/methods.ts
@@ -1,19 +1,21 @@
-export function Get(value?: string): Function {
+import { MethodDecoratorReturn } from '../interfaces/decorator-return';
+
+export function Get(value?: string): MethodDecoratorReturn {
   return () => { return; };
 }
 
-export function Post(value?: string): Function {
+export function Post(value?: string): MethodDecoratorReturn {
   return () => { return; };
 }
 
-export function Put(value?: string): Function {
+export function Put(value?: string): MethodDecoratorReturn {
   return () => { return; };
 }
 
-export function Patch(value?: string): Function {
+export function Patch(value?: string): MethodDecoratorReturn {
   return () => { return; };
 }
 
-export function Delete(value?: string): Function {
+export function Delete(value?: string): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/methods.ts
+++ b/src/decorators/methods.ts
@@ -1,19 +1,19 @@
-export function Get(value?: string): any {
+export function Get(value?: string): Function {
   return () => { return; };
 }
 
-export function Post(value?: string): any {
+export function Post(value?: string): Function {
   return () => { return; };
 }
 
-export function Put(value?: string): any {
+export function Put(value?: string): Function {
   return () => { return; };
 }
 
-export function Patch(value?: string): any {
+export function Patch(value?: string): Function {
   return () => { return; };
 }
 
-export function Delete(value?: string): any {
+export function Delete(value?: string): Function {
   return () => { return; };
 }

--- a/src/decorators/parameter.ts
+++ b/src/decorators/parameter.ts
@@ -2,7 +2,7 @@
  * Inject http Body
  *  @param {string} [name] properties name in body object
  */
-export function Body(): any {
+export function Body(): Function {
   return () => { return; };
 }
 
@@ -11,14 +11,14 @@ export function Body(): any {
  *
  * @param {string} [name] The name of the body parameter
  */
-export function BodyProp(name?: string): any {
+export function BodyProp(name?: string): Function {
   return () => { return; };
 }
 
 /**
  * Inject http request
  */
-export function Request(): any {
+export function Request(): Function {
   return () => { return; };
 }
 
@@ -27,7 +27,7 @@ export function Request(): any {
  *
  * @param {string} [name] The name of the path parameter
  */
-export function Path(name?: string): any {
+export function Path(name?: string): Function {
   return () => { return; };
 }
 
@@ -36,7 +36,7 @@ export function Path(name?: string): any {
  *
  * @param {string} [name] The name of the query parameter
  */
-export function Query(name?: string): any {
+export function Query(name?: string): Function {
   return () => { return; };
 }
 
@@ -45,6 +45,6 @@ export function Query(name?: string): any {
  *
  * @param {string} [name] The name of the header parameter
  */
-export function Header(name?: string): any {
+export function Header(name?: string): Function {
   return () => { return; };
 }

--- a/src/decorators/parameter.ts
+++ b/src/decorators/parameter.ts
@@ -1,8 +1,10 @@
+import { ParameterDecoratorReturn } from '../interfaces/decorator-return';
+
 /**
  * Inject http Body
  *  @param {string} [name] properties name in body object
  */
-export function Body(): Function {
+export function Body(): ParameterDecoratorReturn {
   return () => { return; };
 }
 
@@ -11,14 +13,14 @@ export function Body(): Function {
  *
  * @param {string} [name] The name of the body parameter
  */
-export function BodyProp(name?: string): Function {
+export function BodyProp(name?: string): ParameterDecoratorReturn {
   return () => { return; };
 }
 
 /**
  * Inject http request
  */
-export function Request(): Function {
+export function Request(): ParameterDecoratorReturn {
   return () => { return; };
 }
 
@@ -27,7 +29,7 @@ export function Request(): Function {
  *
  * @param {string} [name] The name of the path parameter
  */
-export function Path(name?: string): Function {
+export function Path(name?: string): ParameterDecoratorReturn {
   return () => { return; };
 }
 
@@ -36,8 +38,8 @@ export function Path(name?: string): Function {
  *
  * @param {string} [name] The name of the query parameter
  */
-export function Query(name?: string): Function {
-  return () => { return; };
+export function Query(name?: string): ParameterDecoratorReturn {
+  return (ParameterDecoratorReturn) => { return; };
 }
 
 /**
@@ -45,6 +47,6 @@ export function Query(name?: string): Function {
  *
  * @param {string} [name] The name of the header parameter
  */
-export function Header(name?: string): Function {
+export function Header(name?: string): ParameterDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/response.ts
+++ b/src/decorators/response.ts
@@ -1,7 +1,7 @@
-export function SuccessResponse(name: string | number, description?: string): any {
+export function SuccessResponse(name: string | number, description?: string): Function {
   return () => { return; };
 }
 
-export function Response<T>(name: string | number, description?: string, example?: T): any {
+export function Response<T>(name: string | number, description?: string, example?: T): Function {
   return () => { return; };
 }

--- a/src/decorators/response.ts
+++ b/src/decorators/response.ts
@@ -1,7 +1,9 @@
-export function SuccessResponse(name: string | number, description?: string): Function {
+import { MethodDecoratorReturn } from '../interfaces/decorator-return';
+
+export function SuccessResponse(name: string | number, description?: string): MethodDecoratorReturn {
   return () => { return; };
 }
 
-export function Response<T>(name: string | number, description?: string, example?: T): Function {
+export function Response<T>(name: string | number, description?: string, example?: T): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/route.ts
+++ b/src/decorators/route.ts
@@ -1,10 +1,10 @@
-export function Route(name?: string): any {
+export function Route(name?: string): Function {
   return () => { return; };
 }
 
 /**
  * can be used to entirely hide an method from documentation
  */
-export function Hidden(): any {
+export function Hidden(): Function {
   return () => { return; };
 }

--- a/src/decorators/route.ts
+++ b/src/decorators/route.ts
@@ -1,10 +1,12 @@
-export function Route(name?: string): Function {
+import { ClassDecoratorReturn, MethodDecoratorReturn } from '../interfaces/decorator-return';
+
+export function Route(name?: string): ClassDecoratorReturn {
   return () => { return; };
 }
 
 /**
  * can be used to entirely hide an method from documentation
  */
-export function Hidden(): Function {
+export function Hidden(): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/security.ts
+++ b/src/decorators/security.ts
@@ -1,6 +1,6 @@
 /**
  * @param {name} security name from securityDefinitions
  */
-export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): any {
+export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): Function {
   return () => { return; };
 }

--- a/src/decorators/security.ts
+++ b/src/decorators/security.ts
@@ -1,6 +1,8 @@
+import { MethodDecoratorReturn } from '../interfaces/decorator-return';
+
 /**
  * @param {name} security name from securityDefinitions
  */
-export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): Function {
+export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/decorators/tags.ts
+++ b/src/decorators/tags.ts
@@ -1,3 +1,3 @@
-export function Tags(...values: string[]): any {
+export function Tags(...values: string[]): Function {
   return () => { return; };
 }

--- a/src/decorators/tags.ts
+++ b/src/decorators/tags.ts
@@ -1,3 +1,5 @@
-export function Tags(...values: string[]): Function {
+import { MethodDecoratorReturn } from '../interfaces/decorator-return';
+
+export function Tags(...values: string[]): MethodDecoratorReturn {
   return () => { return; };
 }

--- a/src/interfaces/decorator-return.ts
+++ b/src/interfaces/decorator-return.ts
@@ -1,0 +1,3 @@
+export type MethodDecoratorReturn = (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void;
+export type ClassDecoratorReturn = (constructor: any) => void;
+export type ParameterDecoratorReturn = (target: object, propertyKey: string | symbol, parameterIndex: number) => void;

--- a/tests/fixtures/controllers/hiddenMethodController.ts
+++ b/tests/fixtures/controllers/hiddenMethodController.ts
@@ -1,5 +1,5 @@
 import {
-    Controller, Get, Hidden, Post, Route,
+    Controller, Get, Hidden, Route,
 } from '../../../src';
 import { TestModel } from '../../fixtures/testModel';
 import { ModelService } from '../services/modelService';

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -91,8 +91,8 @@ export class MethodController extends Controller {
     }
 
     @Security({
-      tsoa_auth: ['write:pets', 'read:pets'],
       api_key: [],
+      tsoa_auth: ['write:pets', 'read:pets'],
     })
     @Get('OauthAndAPIkeySecurity')
     public async oauthAndAPIkeySecurity(): Promise<TestModel> {

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -39,8 +39,8 @@ export class SecurityTestController {
 
   @Response<ErrorResponseModel>('404', 'Not Found')
   @Security({
-    tsoa_auth: ['write:pets', 'read:pets'],
     api_key: [],
+    tsoa_auth: ['write:pets', 'read:pets'],
   })
   @Get('OauthAndAPIkey')
   public async GetWithAndSecurity(@Request() request: express.Request): Promise<UserResponseModel> {

--- a/tests/fixtures/custom/routes.ts
+++ b/tests/fixtures/custom/routes.ts
@@ -1084,7 +1084,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/MethodTest/OauthAndAPIkeySecurity',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1483,7 +1483,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -1580,7 +1580,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/SecurityTest/OauthAndAPIkey',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -1167,7 +1167,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/MethodTest/OauthAndAPIkeySecurity',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
       };
@@ -1566,7 +1566,7 @@ export function RegisterRoutes(app: any) {
   app.get('/v1/ParameterTest/paramaterImplicitDate',
     function(request: any, response: any, next: any) {
       const args={
-        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -1663,7 +1663,7 @@ export function RegisterRoutes(app: any) {
       promiseHandler(controller, promise, response, next);
     });
   app.get('/v1/SecurityTest/OauthAndAPIkey',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     function(request: any, response: any, next: any) {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -1385,7 +1385,7 @@ export function RegisterRoutes(server: any) {
     config: {
       pre: [
         {
-          method: authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }])
+          method: authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }])
         }
       ],
       handler: (request: any, reply: any) => {
@@ -1866,7 +1866,7 @@ export function RegisterRoutes(server: any) {
     config: {
       handler: (request: any, reply: any) => {
         const args={
-          date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+          date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
         };
 
         let validatedArgs: any[]=[];
@@ -2001,7 +2001,7 @@ export function RegisterRoutes(server: any) {
     config: {
       pre: [
         {
-          method: authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }])
+          method: authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }])
         }
       ],
       handler: (request: any, reply: any) => {

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -1217,7 +1217,7 @@ export function RegisterRoutes(router: any) {
       return promiseHandler(controller, promise, context, next);
     });
   router.get('/v1/MethodTest/OauthAndAPIkeySecurity',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     async (context, next) => {
       const args={
       };
@@ -1636,7 +1636,7 @@ export function RegisterRoutes(router: any) {
   router.get('/v1/ParameterTest/paramaterImplicitDate',
     async (context, next) => {
       const args={
-        date: { "default": "2018-01-14", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
+        date: { "default": "2018-01-15", "in": "query", "name": "date", "dataType": "date", "validators": { "isDate": { "errorMsg": "date" } } },
       };
 
       let validatedArgs: any[]=[];
@@ -1738,7 +1738,7 @@ export function RegisterRoutes(router: any) {
       return promiseHandler(controller, promise, context, next);
     });
   router.get('/v1/SecurityTest/OauthAndAPIkey',
-    authenticateMiddleware([{ "tsoa_auth": ["write:pets", "read:pets"], "api_key": [] }]),
+    authenticateMiddleware([{ "api_key": [], "tsoa_auth": ["write:pets", "read:pets"] }]),
     async (context, next) => {
       const args={
         request: { "in": "request", "name": "request", "required": true, "dataType": "object" },

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -174,7 +174,7 @@ describe('Definition generation', () => {
       expect(definition.description).to.equal('This is a description of TestClassModel');
     });
 
-    it("should generate a property format from a property jsdoc comment", () => {
+    it('should generate a property format from a property jsdoc comment', () => {
       const propertyName = 'emailPattern';
 
       const property = properties[propertyName];

--- a/tests/unit/swagger/pathGeneration/securityRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/securityRoutes.spec.ts
@@ -42,8 +42,8 @@ describe('Security route generation', () => {
     if (!path.get) { throw new Error('No get operation.'); }
 
     expect(path.get.security).to.deep.equal([{
-      tsoa_auth: [ 'write:pets', 'read:pets' ],
       api_key: [],
+      tsoa_auth: [ 'write:pets', 'read:pets' ],
     }]);
   });
 

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
   ],
   "rules": {
     "arrow-parens": false,
-    "ban-types": false,
     "trailing-comma": [
       true,
       {

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "arrow-parens": false,
+    "ban-types": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
fixes #266

Turned decorator return types to Function.

Also fixed some unrelated tslint errors on initial pull (minor things like alphabetizing and double-quotes vs single-quotes).