### PR TITLE
fix install package from github directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf dist && rimraf tests/fixtures/*/routes.ts",
     "lint": "tslint --exclude ./node_modules/** ./src/**/*.ts ./tests/**/*.ts",
     "format": "tsfmt -r",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "deploy": "npm version patch -m \"Release v%s\" && npm publish",
     "preversion": "npm test",
     "postversion": "git push origin master && git push --follow-tags",


### PR DESCRIPTION
The `prepublish` doesn't run when installing the package directly from Github. The solution is to use `prepare` hook. [NPM issue](https://github.com/npm/npm/issues/3055)