### PR TITLE
[#176] Add a description for tags.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -527,6 +527,31 @@ The according swagger definition can be merge-overwritten inside `tsoa.json`. He
 }
 ```
 
+### Tags
+
+If you have a project that needs a description and/or external docs for tags, you can configure the internal generators to use the correct tags definitions and external docs by providing a tags property to swagger property in tsoa.json.
+
+```json
+{
+  "swagger": {
+    "tags":  [
+      {
+        "name": "User",
+        "description": "Operations about users",
+        "externalDocs": {
+          "description": "Find out more about users",
+          "url": "http://swagger.io"
+        }
+      }
+    ],
+    ...
+  },
+  "routes": {
+    ...
+  }
+}
+```
+
 ### Use awesome Swagger tools
 
 Now that you have a swagger spec (swagger.json), you can use all kinds of amazing tools that [generate documentation, client SDKs, and more](http://swagger.io/).
@@ -554,6 +579,31 @@ or having to pass all of them (AND):
 })
 @Get('OauthAndAPIkey')
 public async GetWithAndSecurity(@Request() request: express.Request): Promise<any> {
+}
+```
+
+### Tags
+
+Tags are defined with the `@Tags('tag1', 'tag2', ...)` decorator in the controllers and/or in the methods like in the following examples.
+
+```ts
+import { Get, Route, Response, Tags } from 'tsoa';
+
+@Route('user')
+@Tags('User')
+export class UserController {
+    @Response<ErrorResponseModel>('Unexpected error')
+    @Get('UserInfo')
+    @Tags('Info', 'Get')
+    public async userInfo(@Request() request: any): Promise<UserResponseModel> {
+        return Promise.resolve(request.user);
+    }
+
+    @Get('EditUser')
+    @Tags('Edit')
+    public async userInfo(@Request() request: any): Promise<string> {
+        // Do something here
+    }
 }
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,11 @@ export interface SwaggerConfig {
     [name: string]: Swagger.Security,
   };
 
+  /**
+   * Swagger Tags Information for your API
+   */
+  tags?: Swagger.Tag[];
+
   yaml?: boolean;
 
   schemes?: Swagger.Protocol [];

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -28,6 +28,7 @@ export class SpecGenerator {
     if (this.config.host) { spec.host = this.config.host; }
     if (this.config.description) { spec.info.description = this.config.description; }
     if (this.config.license) { spec.info.license = { name: this.config.license }; }
+    if (this.config.tags) { spec.tags = this.config.tags; }
     if (this.config.spec) {
       this.config.specMerging = this.config.specMerging || 'immediate';
       const mergeFuncs: { [key: string]: any } = {


### PR DESCRIPTION
- Add tags for swagger config
- Add documentation for tags in the README.MD

This PR resolves the #176 issue. It permits to generate this part inside the root of the swagger.json : 
```
"tags": [
    {
        "name": "User",
        "description": "Operations about users",
        "externalDocs": {
            "description": "Find out more about users",
            "url": "http://swagger.io"
        }
    }
]
```

Close #176 