### PR TITLE
Removed handlebars-helpers (- 200 dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "license": "MIT",
   "dependencies": {
     "handlebars": "^4.0.11",
-    "handlebars-helpers": "^0.9.8",
     "lodash.indexof": "^4.0.5",
     "lodash.map": "^4.6.0",
     "merge": "^1.2.0",

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as handlebars from 'handlebars';
-import * as handlebarsHelpers from 'handlebars-helpers';
 import * as path from 'path';
 import * as tsfmt from 'typescript-formatter';
 import { Tsoa } from '../metadataGeneration/tsoa';
@@ -57,10 +56,6 @@ export class RouteGenerator {
   private buildContent(middlewareTemplate: string, pathTransformer: (path: string) => string) {
     handlebars.registerHelper('json', (context: any) => {
       return JSON.stringify(context);
-    });
-
-    handlebarsHelpers.comparison({
-      handlebars,
     });
 
     const routesTemplate = handlebars.compile(middlewareTemplate, { noEscape: true });


### PR DESCRIPTION
Hello,

Handlebars-helpers is a package used in a single file, in a single line of code:
```js
handlebarsHelpers.comparison({
  handlebars,
});
```
This function, in the original source ([here](https://github.com/helpers/handlebars-helpers/blob/master/lib/comparison.js), at `comparison.default`), just checks that its parameters aren't null. It returns an empty string if they're null, so as far as I can tell, since you didn't even check `handlebarsHelpers.comparison`'s return value, this entire call is fairly useless.

Removing `handlebars-helpers` causes a fresh install of `tsoa` to install around 367 packages instead of 554, meaning by removing this one function call we're removing around 190 dependencies from this project. This is good for everyone involved, and there are no drawbacks that I can think of, unless i've misunderstood this function call. Even if I have, the entirety of `handlebars-helpers` is extremely simple functions which we could reimplement in `tsoa` directly and which would, again, make the installation experience much better for users.