### PR TITLE
Validating falsy values

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,22 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "--compilers", "ts:ts-node/register",
+                "${workspaceFolder}/**/*.spec.ts"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
             "name": "Generate",
             "type": "node",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,22 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Mocha Tests",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "-u",
-                "tdd",
-                "--timeout",
-                "999999",
-                "--colors",
-                "--compilers", "ts:ts-node/register",
-                "${workspaceFolder}/**/*.spec.ts"
-            ],
-            "internalConsoleOptions": "openOnSessionStart"
-        },
-        {
             "name": "Generate",
             "type": "node",
             "request": "launch",

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export interface SwaggerConfig {
 
   yaml?: boolean;
 
-  schemes?: Swagger.Protocol [];
+  schemes?: Swagger.Protocol[];
 }
 
 export interface RoutesConfig {

--- a/src/express.d.ts
+++ b/src/express.d.ts
@@ -1,6 +1,6 @@
 import 'express';
 declare module 'express' {
-    export interface Request {
-        user?: any;
-    }
+  export interface Request {
+    user?: any;
+  }
 }

--- a/src/hapi.d.ts
+++ b/src/hapi.d.ts
@@ -1,6 +1,6 @@
 import 'hapi';
 declare module 'hapi' {
-    interface Request {
-        user?: any;
-    }
+  interface Request {
+    user?: any;
+  }
 }

--- a/src/koa.d.ts
+++ b/src/koa.d.ts
@@ -1,6 +1,6 @@
 import 'koa';
 declare module 'koa' {
-    interface Request {
-        user?: any;
-    }
+  interface Request {
+    user?: any;
+  }
 }

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -25,7 +25,11 @@ export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, ge
       };
       return;
     } else {
-      return property.default;
+      if (property.dataType === 'any') {
+        return property.default !== undefined ? property.default : value;
+      } else {
+        return property.default;
+      }
     }
   }
 

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -371,7 +371,7 @@ function validateModel(name: string, value: any, refName: string, fieldErrors: F
     if (additionalProperties) {
       Object.keys(value).forEach((key: string) => {
         const validatedValue = ValidateParam(additionalProperties, value[key], models, key, fieldErrors, parent);
-        if (validatedValue) {
+        if (validatedValue !== undefined) {
           value[key] = validatedValue;
         } else {
           fieldErrors[parent + '.' + key] = {

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -25,11 +25,7 @@ export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, ge
       };
       return;
     } else {
-      if (property.dataType === 'any') {
-        return property.default !== undefined ? property.default : value;
-      } else {
-        return property.default;
-      }
+      return property.default !== undefined ? property.default : value;
     }
   }
 

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -240,7 +240,7 @@ export class SpecGenerator {
           });
       }
 
-      if (!property.required)  {
+      if (!property.required) {
         swaggerType['x-nullable'] = true;
       }
 

--- a/tests/fixtures/controllers/validateController.ts
+++ b/tests/fixtures/controllers/validateController.ts
@@ -2,7 +2,7 @@ import {
   Body, Get, Post, Query, Route,
 } from './../../../src';
 import {
-  ValidateMapStringToNumber, ValidateModel,
+  ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel,
 } from './../testModel';
 
 export interface ValidateDateResponse {
@@ -149,6 +149,11 @@ export class ValidateController {
 
   @Post('map')
   public async getNumberBodyRequest(@Body() map: ValidateMapStringToNumber): Promise<number[]> {
+    return Object.keys(map).map((key) => map[key]);
+  }
+
+  @Post('mapAny')
+  public async getDictionaryRequest(@Body() map: ValidateMapStringToAny): Promise<any[]> {
     return Object.keys(map).map((key) => map[key]);
   }
 }

--- a/tests/fixtures/controllers/validateController.ts
+++ b/tests/fixtures/controllers/validateController.ts
@@ -2,7 +2,7 @@ import {
   Body, Get, Post, Query, Route,
 } from './../../../src';
 import {
-  ValidateModel,
+  ValidateMapStringToNumber, ValidateModel,
 } from './../testModel';
 
 export interface ValidateDateResponse {
@@ -145,5 +145,10 @@ export class ValidateController {
   @Post('body')
   public bodyValidate( @Body() body: ValidateModel): Promise<ValidateModel> {
     return Promise.resolve(body);
+  }
+
+  @Post('map')
+  public async getNumberBodyRequest(@Body() map: ValidateMapStringToNumber): Promise<number[]> {
+    return Object.keys(map).map((key) => map[key]);
   }
 }

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -233,6 +233,9 @@ const models: TsoaRoute.Models={
       "arrayUniqueItem": { "dataType": "array", "array": { "dataType": "double" }, "required": true, "validators": { "uniqueItems": {} } },
     },
   },
+  "ValidateMapStringToNumber": {
+    "additionalProperties": { "dataType": "double" },
+  },
 };
 
 export function RegisterRoutes(app: any) {
@@ -2046,6 +2049,25 @@ export function RegisterRoutes(app: any) {
 
 
       const promise=controller.bodyValidate.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.post('/v1/Validate/map',
+    function(request: any, response: any, next: any) {
+      const args={
+        map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToNumber" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ValidateController();
+
+
+      const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
 

--- a/tests/fixtures/express/routes.ts
+++ b/tests/fixtures/express/routes.ts
@@ -236,6 +236,9 @@ const models: TsoaRoute.Models={
   "ValidateMapStringToNumber": {
     "additionalProperties": { "dataType": "double" },
   },
+  "ValidateMapStringToAny": {
+    "additionalProperties": { "dataType": "any" },
+  },
 };
 
 export function RegisterRoutes(app: any) {
@@ -2068,6 +2071,25 @@ export function RegisterRoutes(app: any) {
 
 
       const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
+      promiseHandler(controller, promise, response, next);
+    });
+  app.post('/v1/Validate/mapAny',
+    function(request: any, response: any, next: any) {
+      const args={
+        map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToAny" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, request);
+      } catch (err) {
+        return next(err);
+      }
+
+      const controller=new ValidateController();
+
+
+      const promise=controller.getDictionaryRequest.apply(controller, validatedArgs);
       promiseHandler(controller, promise, response, next);
     });
 

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -233,6 +233,9 @@ const models: TsoaRoute.Models={
       "arrayUniqueItem": { "dataType": "array", "array": { "dataType": "double" }, "required": true, "validators": { "uniqueItems": {} } },
     },
   },
+  "ValidateMapStringToNumber": {
+    "additionalProperties": { "dataType": "double" },
+  },
 };
 
 export function RegisterRoutes(server: any) {
@@ -2586,6 +2589,31 @@ export function RegisterRoutes(server: any) {
         const controller=new ValidateController();
 
         const promise=controller.bodyValidate.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, h);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
+    path: '/v1/Validate/map',
+    options: {
+      handler: (request: any, h: any) => {
+        const args={
+          map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToNumber" },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return h
+            .response(err)
+            .code(err.status||500);
+        }
+
+        const controller=new ValidateController();
+
+        const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
         return promiseHandler(controller, promise, request, h);
       }
     }

--- a/tests/fixtures/hapi/routes.ts
+++ b/tests/fixtures/hapi/routes.ts
@@ -236,6 +236,9 @@ const models: TsoaRoute.Models={
   "ValidateMapStringToNumber": {
     "additionalProperties": { "dataType": "double" },
   },
+  "ValidateMapStringToAny": {
+    "additionalProperties": { "dataType": "any" },
+  },
 };
 
 export function RegisterRoutes(server: any) {
@@ -2614,6 +2617,31 @@ export function RegisterRoutes(server: any) {
         const controller=new ValidateController();
 
         const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
+        return promiseHandler(controller, promise, request, h);
+      }
+    }
+  });
+  server.route({
+    method: 'post',
+    path: '/v1/Validate/mapAny',
+    options: {
+      handler: (request: any, h: any) => {
+        const args={
+          map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToAny" },
+        };
+
+        let validatedArgs: any[]=[];
+        try {
+          validatedArgs=getValidatedArgs(args, request);
+        } catch (err) {
+          return h
+            .response(err)
+            .code(err.status||500);
+        }
+
+        const controller=new ValidateController();
+
+        const promise=controller.getDictionaryRequest.apply(controller, validatedArgs);
         return promiseHandler(controller, promise, request, h);
       }
     }

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -233,6 +233,9 @@ const models: TsoaRoute.Models={
       "arrayUniqueItem": { "dataType": "array", "array": { "dataType": "double" }, "required": true, "validators": { "uniqueItems": {} } },
     },
   },
+  "ValidateMapStringToNumber": {
+    "additionalProperties": { "dataType": "double" },
+  },
 };
 
 export function RegisterRoutes(router: any) {
@@ -2141,6 +2144,26 @@ export function RegisterRoutes(router: any) {
       const controller=new ValidateController();
 
       const promise=controller.bodyValidate.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
+  router.post('/v1/Validate/map',
+    async (context, next) => {
+      const args={
+        map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToNumber" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status;
+        context.throw(error.status, JSON.stringify({ fields: error.fields }));
+        return next();
+      }
+
+      const controller=new ValidateController();
+
+      const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
 

--- a/tests/fixtures/koa/routes.ts
+++ b/tests/fixtures/koa/routes.ts
@@ -236,6 +236,9 @@ const models: TsoaRoute.Models={
   "ValidateMapStringToNumber": {
     "additionalProperties": { "dataType": "double" },
   },
+  "ValidateMapStringToAny": {
+    "additionalProperties": { "dataType": "any" },
+  },
 };
 
 export function RegisterRoutes(router: any) {
@@ -2164,6 +2167,26 @@ export function RegisterRoutes(router: any) {
       const controller=new ValidateController();
 
       const promise=controller.getNumberBodyRequest.apply(controller, validatedArgs);
+      return promiseHandler(controller, promise, context, next);
+    });
+  router.post('/v1/Validate/mapAny',
+    async (context, next) => {
+      const args={
+        map: { "in": "body", "name": "map", "required": true, "ref": "ValidateMapStringToAny" },
+      };
+
+      let validatedArgs: any[]=[];
+      try {
+        validatedArgs=getValidatedArgs(args, context);
+      } catch (error) {
+        context.status=error.status;
+        context.throw(error.status, JSON.stringify({ fields: error.fields }));
+        return next();
+      }
+
+      const controller=new ValidateController();
+
+      const promise=controller.getDictionaryRequest.apply(controller, validatedArgs);
       return promiseHandler(controller, promise, context, next);
     });
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -247,6 +247,10 @@ export class ValidateModel {
   public ignoredProperty: string;
 }
 
+export interface ValidateMapStringToNumber {
+  [key: string]: number;
+}
+
 /**
  * Gender msg
  */

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -251,6 +251,10 @@ export interface ValidateMapStringToNumber {
   [key: string]: number;
 }
 
+export interface ValidateMapStringToAny {
+  [key: string]: any;
+}
+
 /**
  * Gender msg
  */

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -488,19 +488,6 @@ describe('Express Server', () => {
       });
     });
 
-    // TODO: explicitly nullable fields
-    // it('should reject string-to-number dictionary body with nulls', () => {
-    //   const data: object = {
-    //     key1: 0,
-    //     key2: 1,
-    //     key3: null,
-    //   };
-    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-    //     const body = JSON.parse(err.text);
-    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-    //   }, 400);
-    // });
-
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import * as request from 'supertest';
 import { base64image } from '../fixtures/base64image';
 import { app } from '../fixtures/express/server';
-import { Gender, GenericModel, GenericRequest, ParameterTestModel, TestClassModel, TestModel, UserResponseModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, ParameterTestModel, TestClassModel, TestModel, UserResponseModel, ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -490,14 +490,41 @@ describe('Express Server', () => {
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
-        key1: '0',
-        key2: '1',
-        key3: '-1',
+        key1: 'val0',
+        key2: 'val1',
+        key3: '-val1',
       };
       return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
         const body = JSON.parse(err.text);
         expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
       }, 400);
+    });
+
+    it('should validate string-to-any dictionary body', () => {
+      const data: ValidateMapStringToAny = {
+        key1: '0',
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([-1, '0', 1]);
+      });
+    });
+
+    it('should validate string-to-any dictionary body with falsy values', () => {
+      const data: ValidateMapStringToAny = {
+        arrayItem: [],
+        falseItem: false,
+        nullItem: null,
+        stringItem: '',
+        undefinedItem: undefined,
+        zeroItem: 0,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+      });
     });
 
   });

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import * as request from 'supertest';
 import { base64image } from '../fixtures/base64image';
 import { app } from '../fixtures/express/server';
-import { Gender, GenericModel, GenericRequest, ParameterTestModel, TestClassModel, TestModel, UserResponseModel, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, ParameterTestModel, TestClassModel, TestModel, UserResponseModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -473,6 +473,30 @@ describe('Express Server', () => {
       return verifyGetRequest(basePath + `/Validate/parameter/custominvalidErrorMsg?longValue=${value}`, (err, res) => {
         const body = JSON.parse(err.text);
         expect(body.fields.longValue.message).to.equal('Invalid long number.');
+      }, 400);
+    });
+
+    it('should validate string-to-number dictionary body', () => {
+      const data: ValidateMapStringToNumber = {
+        key1: 0,
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const response = res.body as number[];
+        expect(response.sort()).to.eql([-1, 0, 1]);
+      });
+    });
+
+    it('should reject string-to-string dictionary body', () => {
+      const data: object = {
+        key1: '0',
+        key2: '1',
+        key3: '-1',
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
       }, 400);
     });
 

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -488,17 +488,18 @@ describe('Express Server', () => {
       });
     });
 
-    it('should reject string-to-number dictionary body with nulls', () => {
-      const data: object = {
-        key1: 0,
-        key2: 1,
-        key3: null,
-      };
-      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-        const body = JSON.parse(err.text);
-        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-      }, 400);
-    });
+    // TODO: explicitly nullable fields
+    // it('should reject string-to-number dictionary body with nulls', () => {
+    //   const data: object = {
+    //     key1: 0,
+    //     key2: 1,
+    //     key3: null,
+    //   };
+    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+    //     const body = JSON.parse(err.text);
+    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+    //   }, 400);
+    // });
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -488,6 +488,18 @@ describe('Express Server', () => {
       });
     });
 
+    it('should reject string-to-number dictionary body with nulls', () => {
+      const data: object = {
+        key1: 0,
+        key2: 1,
+        key3: null,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+      }, 400);
+    });
+
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',
@@ -514,16 +526,15 @@ describe('Express Server', () => {
 
     it('should validate string-to-any dictionary body with falsy values', () => {
       const data: ValidateMapStringToAny = {
-        arrayItem: [],
-        falseItem: false,
-        nullItem: null,
-        stringItem: '',
-        undefinedItem: undefined,
-        zeroItem: 0,
+        array: [],
+        false: false,
+        null: null,
+        string: '',
+        zero: 0,
       };
       return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
         const response = res.body as any[];
-        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+        expect(response.sort()).to.eql([ [], '', 0, false, null ]);
       });
     });
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -474,17 +474,18 @@ describe('Hapi Server', () => {
       });
     });
 
-    it('should reject string-to-number dictionary body with nulls', () => {
-      const data: object = {
-        key1: 0,
-        key2: 1,
-        key3: null,
-      };
-      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-        const body = JSON.parse(err.text);
-        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-      }, 400);
-    });
+    // TODO: explicitly nullable fields
+    // it('should reject string-to-number dictionary body with nulls', () => {
+    //   const data: object = {
+    //     key1: 0,
+    //     key2: 1,
+    //     key3: null,
+    //   };
+    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+    //     const body = JSON.parse(err.text);
+    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+    //   }, 400);
+    // });
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -474,19 +474,6 @@ describe('Hapi Server', () => {
       });
     });
 
-    // TODO: explicitly nullable fields
-    // it('should reject string-to-number dictionary body with nulls', () => {
-    //   const data: object = {
-    //     key1: 0,
-    //     key2: 1,
-    //     key3: null,
-    //   };
-    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-    //     const body = JSON.parse(err.text);
-    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-    //   }, 400);
-    // });
-
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -474,6 +474,18 @@ describe('Hapi Server', () => {
       });
     });
 
+    it('should reject string-to-number dictionary body with nulls', () => {
+      const data: object = {
+        key1: 0,
+        key2: 1,
+        key3: null,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+      }, 400);
+    });
+
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',
@@ -500,16 +512,15 @@ describe('Hapi Server', () => {
 
     it('should validate string-to-any dictionary body with falsy values', () => {
       const data: ValidateMapStringToAny = {
-        arrayItem: [],
-        falseItem: false,
-        nullItem: null,
-        stringItem: '',
-        undefinedItem: undefined,
-        zeroItem: 0,
+        array: [],
+        false: false,
+        null: null,
+        string: '',
+        zero: 0,
       };
       return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
         const response = res.body as any[];
-        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+        expect(response.sort()).to.eql([ [], '', 0, false, null ]);
       });
     });
   });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/hapi/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -462,6 +462,29 @@ describe('Hapi Server', () => {
       }, 400);
     });
 
+    it('should validate string-to-number dictionary body', () => {
+      const data: ValidateMapStringToNumber = {
+        key1: 0,
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const response = res.body as number[];
+        expect(response.sort()).to.eql([-1, 0, 1]);
+      });
+    });
+
+    it('should reject string-to-string dictionary body', () => {
+      const data: object = {
+        key1: '0',
+        key2: '1',
+        key3: '-1',
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
+      }, 400);
+    });
   });
 
   describe('Security', () => {

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/hapi/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -476,14 +476,41 @@ describe('Hapi Server', () => {
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
-        key1: '0',
-        key2: '1',
-        key3: '-1',
+        key1: 'val0',
+        key2: 'val1',
+        key3: '-val1',
       };
       return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
         const body = JSON.parse(err.text);
         expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
       }, 400);
+    });
+
+    it('should validate string-to-any dictionary body', () => {
+      const data: ValidateMapStringToAny = {
+        key1: '0',
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([-1, '0', 1]);
+      });
+    });
+
+    it('should validate string-to-any dictionary body with falsy values', () => {
+      const data: ValidateMapStringToAny = {
+        arrayItem: [],
+        falseItem: false,
+        nullItem: null,
+        stringItem: '',
+        undefinedItem: undefined,
+        zeroItem: 0,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+      });
     });
   });
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -451,19 +451,6 @@ describe('Koa Server', () => {
       });
     });
 
-    // TODO: explicitly nullable fields
-    // it('should reject string-to-number dictionary body with nulls', () => {
-    //   const data: object = {
-    //     key1: 0,
-    //     key2: 1,
-    //     key3: null,
-    //   };
-    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-    //     const body = JSON.parse(err.text);
-    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-    //   }, 400);
-    // });
-
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -451,17 +451,18 @@ describe('Koa Server', () => {
       });
     });
 
-    it('should reject string-to-number dictionary body with nulls', () => {
-      const data: object = {
-        key1: 0,
-        key2: 1,
-        key3: null,
-      };
-      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
-        const body = JSON.parse(err.text);
-        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
-      }, 400);
-    });
+    // TODO: explicitly nullable fields
+    // it('should reject string-to-number dictionary body with nulls', () => {
+    //   const data: object = {
+    //     key1: 0,
+    //     key2: 1,
+    //     key3: null,
+    //   };
+    //   return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+    //     const body = JSON.parse(err.text);
+    //     expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+    //   }, 400);
+    // });
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/koa/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -453,14 +453,41 @@ describe('Koa Server', () => {
 
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
-        key1: '0',
-        key2: '1',
-        key3: '-1',
+        key1: 'val0',
+        key2: 'val1',
+        key3: '-val1',
       };
       return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
         const body = JSON.parse(err.text);
         expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
       }, 400);
+    });
+
+    it('should validate string-to-any dictionary body', () => {
+      const data: ValidateMapStringToAny = {
+        key1: '0',
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([-1, '0', 1]);
+      });
+    });
+
+    it('should validate string-to-any dictionary body with falsy values', () => {
+      const data: ValidateMapStringToAny = {
+        arrayItem: [],
+        falseItem: false,
+        nullItem: null,
+        stringItem: '',
+        undefinedItem: undefined,
+        zeroItem: 0,
+      };
+      return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
+        const response = res.body as any[];
+        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+      });
     });
   });
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -451,6 +451,18 @@ describe('Koa Server', () => {
       });
     });
 
+    it('should reject string-to-number dictionary body with nulls', () => {
+      const data: object = {
+        key1: 0,
+        key2: 1,
+        key3: null,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key3'].message).to.eql('No matching model found in additionalProperties to validate key3');
+      }, 400);
+    });
+
     it('should reject string-to-string dictionary body', () => {
       const data: object = {
         key1: 'val0',
@@ -477,16 +489,15 @@ describe('Koa Server', () => {
 
     it('should validate string-to-any dictionary body with falsy values', () => {
       const data: ValidateMapStringToAny = {
-        arrayItem: [],
-        falseItem: false,
-        nullItem: null,
-        stringItem: '',
-        undefinedItem: undefined,
-        zeroItem: 0,
+        array: [],
+        false: false,
+        null: null,
+        string: '',
+        zero: 0,
       };
       return verifyPostRequest(basePath + '/Validate/mapAny', data, (err, res) => {
         const response = res.body as any[];
-        expect(response.sort()).to.eql([ [], '', 0, false, null, undefined ]);
+        expect(response.sort()).to.eql([ [], '', 0, false, null ]);
       });
     });
   });

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/koa/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateModel } from '../fixtures/testModel';
+import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -439,6 +439,29 @@ describe('Koa Server', () => {
       }, 400);
     });
 
+    it('should validate string-to-number dictionary body', () => {
+      const data: ValidateMapStringToNumber = {
+        key1: 0,
+        key2: 1,
+        key3: -1,
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const response = res.body as number[];
+        expect(response.sort()).to.eql([-1, 0, 1]);
+      });
+    });
+
+    it('should reject string-to-string dictionary body', () => {
+      const data: object = {
+        key1: '0',
+        key2: '1',
+        key3: '-1',
+      };
+      return verifyPostRequest(basePath + '/Validate/map', data, (err, res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['map..key1'].message).to.eql('No matching model found in additionalProperties to validate key1');
+      }, 400);
+    });
   });
 
   describe('Security', () => {


### PR DESCRIPTION
Currently this lib is not able to correctly validate dictionaries (i.e. models with additional properties), if the values of the incoming object is falsy. For example, it rejects the following request body:

```
interface Model {
    [index: string]: number;
}
const body: Model {
    key: 0;
}
```

because `key` is `0` and coerces to `false`. Furthermore, it treats `null` values of `any` type as undefined, while they could be entirely valid even without default value.

This pull-request added the following:
- correct check for validity of additional properties;
- different handling of `null` values for type `any`;
- tests for both cases mentioned.

Hope that helps!