### PR TITLE
[#296] Paremeter validation : check if there is a property.default before returning it

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -24,8 +24,10 @@ export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, ge
         value,
       };
       return;
-    } else {
+    } else if (property.hasOwnProperty('default')) {
       return property.default;
+    } else {
+      return value;
     }
   }
 


### PR DESCRIPTION
#296 
This change aims to prevent replacing `null` values by `undefined` in parameter validation, by checking there is a default value defined in the `PropertySchema` of the parameter to validate before returning it.