### PR TITLE
explicitly set any types for context, next in koa route generation

### DIFF
--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -41,7 +41,7 @@ export function RegisterRoutes(router: any) {
             {{#if security.length}}
             authenticateMiddleware({{json security}}),
             {{/if}}
-            async (context, next) => {
+            async (context: any, next: any) => {
             const args = {
                 {{#each parameters}}
                     {{@key}}: {{{json this}}},


### PR DESCRIPTION
Quick fix to definitively fix #292. Explicitly set context and next types to `any`. Tested by editing the templates in `node_modules/tsoa/dist` with the same change on a stub project of mine, doesn't seem to complain.