### PR TITLE
Per swagger.io docs basePath should always start with a leading slash

### DIFF
--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -8,7 +8,7 @@ export class SpecGenerator {
 
   public GetSpec() {
     let spec: Swagger.Spec = {
-      basePath: normalisePath(this.config.basePath as string, '/'),
+      basePath: normalisePath(this.config.basePath as string, '/', undefined, false),
       consumes: ['application/json'],
       definitions: this.buildDefinitions(),
       info: {


### PR DESCRIPTION
See https://swagger.io/docs/specification/2-0/api-host-and-base-path/

basePath is the URL prefix for all API paths, relative to the host root. **It must start with a leading slash**

This is causing an issue with our microservice APIs which have no basePath. Even though we specify "/" in tsoa.json, this line removes that slash when the swagger.json is generated. Then when we attempt to consume the API with tools inside of Azure, we get errors because the basePath is empty.