### PR TITLE
Fix for #314

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import * as validator from 'validator';
 import { TsoaRoute } from './tsoa-route';
 
-let models: TsoaRoute.Models = {};
+export let models: TsoaRoute.Models = {};
 
 export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, generatedModels: TsoaRoute.Models, name = '', fieldErrors: FieldErrors, parent = '') {
   models = generatedModels;
@@ -355,7 +355,7 @@ function validateBuffer(name: string, value: string) {
   return new Buffer(value);
 }
 
-function validateModel(name: string, value: any, refName: string, fieldErrors: FieldErrors, parent = ''): any {
+export function validateModel(name: string, value: any, refName: string, fieldErrors: FieldErrors, parent = ''): any {
   const modelDefinition = models[refName];
 
   if (modelDefinition) {

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -2,394 +2,399 @@ import * as moment from 'moment';
 import * as validator from 'validator';
 import { TsoaRoute } from './tsoa-route';
 
-export let models: TsoaRoute.Models = {};
-
+// for backwards compatability with custom templates
 export function ValidateParam(property: TsoaRoute.PropertySchema, value: any, generatedModels: TsoaRoute.Models, name = '', fieldErrors: FieldErrors, parent = '') {
-  models = generatedModels;
+  return new ValidationService(generatedModels).ValidateParam(property, value, name, fieldErrors, parent);
+}
 
-  if (value === undefined || value === null) {
-    if (property.required) {
-      let message = `'${name}' is required`;
-      if (property.validators) {
-        const validators = property.validators;
-        Object.keys(validators).forEach((key: string) => {
-          const errorMsg = validators[key].errorMsg;
-          if (key.startsWith('is') && errorMsg) {
-            message = errorMsg;
-          }
-        });
+export class ValidationService {
+  constructor(private readonly models: TsoaRoute.Models) {}
+
+  public ValidateParam(property: TsoaRoute.PropertySchema, value: any, name = '', fieldErrors: FieldErrors, parent = '') {
+    if (value === undefined || value === null) {
+      if (property.required) {
+        let message = `'${name}' is required`;
+        if (property.validators) {
+          const validators = property.validators;
+          Object.keys(validators).forEach((key: string) => {
+            const errorMsg = validators[key].errorMsg;
+            if (key.startsWith('is') && errorMsg) {
+              message = errorMsg;
+            }
+          });
+        }
+        fieldErrors[parent + name] = {
+          message,
+          value,
+        };
+        return;
+      } else {
+        return property.default !== undefined ? property.default : value;
+      }
+    }
+
+    switch (property.dataType) {
+      case 'string':
+        return this.validateString(name, value, fieldErrors, property.validators, parent);
+      case 'boolean':
+        return this.validateBool(name, value, fieldErrors, property.validators, parent);
+      case 'integer':
+      case 'long':
+        return this.validateInt(name, value, fieldErrors, property.validators, parent);
+      case 'float':
+      case 'double':
+        return this.validateFloat(name, value, fieldErrors, property.validators, parent);
+      case 'enum':
+        return this.validateEnum(name, value, fieldErrors, property.enums, parent);
+      case 'array':
+        return this.validateArray(name, value, fieldErrors, property.array, property.validators, parent);
+      case 'date':
+        return this.validateDate(name, value, fieldErrors, property.validators, parent);
+      case 'datetime':
+        return this.validateDateTime(name, value, fieldErrors, property.validators, parent);
+      case 'buffer':
+        return this.validateBuffer(name, value);
+      case 'any':
+        return value;
+      default:
+        if (property.ref) {
+          return this.validateModel(name, value, property.ref, fieldErrors, parent);
+        }
+        return value;
+    }
+  }
+
+  public validateInt(name: string, value: any, fieldErrors: FieldErrors, validators?: IntegerValidator, parent = '') {
+    if (!validator.isInt(String(value))) {
+      let message = `invalid integer number`;
+      if (validators) {
+        if (validators.isInt && validators.isInt.errorMsg) {
+          message = validators.isInt.errorMsg;
+        }
+        if (validators.isLong && validators.isLong.errorMsg) {
+          message = validators.isLong.errorMsg;
+        }
       }
       fieldErrors[parent + name] = {
         message,
         value,
       };
       return;
-    } else {
-      return property.default !== undefined ? property.default : value;
     }
-  }
 
-  switch (property.dataType) {
-    case 'string':
-      return validateString(name, value, fieldErrors, property.validators, parent);
-    case 'boolean':
-      return validateBool(name, value, fieldErrors, property.validators, parent);
-    case 'integer':
-    case 'long':
-      return validateInt(name, value, fieldErrors, property.validators, parent);
-    case 'float':
-    case 'double':
-      return validateFloat(name, value, fieldErrors, property.validators, parent);
-    case 'enum':
-      return validateEnum(name, value, fieldErrors, property.enums, parent);
-    case 'array':
-      return validateArray(name, value, fieldErrors, property.array, property.validators, parent);
-    case 'date':
-      return validateDate(name, value, fieldErrors, property.validators, parent);
-    case 'datetime':
-      return validateDateTime(name, value, fieldErrors, property.validators, parent);
-    case 'buffer':
-      return validateBuffer(name, value);
-    case 'any':
-      return value;
-    default:
-      if (property.ref) {
-        return validateModel(name, value, property.ref, fieldErrors, parent);
-      }
-      return value;
-  }
-}
-
-export function validateInt(name: string, value: any, fieldErrors: FieldErrors, validators?: IntegerValidator, parent = '') {
-  if (!validator.isInt(String(value))) {
-    let message = `invalid integer number`;
-    if (validators) {
-      if (validators.isInt && validators.isInt.errorMsg) {
-        message = validators.isInt.errorMsg;
-      }
-      if (validators.isLong && validators.isLong.errorMsg) {
-        message = validators.isLong.errorMsg;
+    const numberValue = validator.toInt(String(value), 10);
+    if (!validators) { return numberValue; }
+    if (validators.minimum && validators.minimum.value !== undefined) {
+      if (validators.minimum.value > numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.minimum.errorMsg || `min ${validators.minimum.value}`,
+          value,
+        };
+        return;
       }
     }
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
-  }
-
-  const numberValue = validator.toInt(String(value), 10);
-  if (!validators) { return numberValue; }
-  if (validators.minimum && validators.minimum.value !== undefined) {
-    if (validators.minimum.value > numberValue) {
-      fieldErrors[parent + name] = {
-        message: validators.minimum.errorMsg || `min ${validators.minimum.value}`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.maximum && validators.maximum.value !== undefined) {
-    if (validators.maximum.value < numberValue) {
-      fieldErrors[parent + name] = {
-        message: validators.maximum.errorMsg || `max ${validators.maximum.value}`,
-        value,
-      };
-      return;
-    }
-  }
-  return numberValue;
-}
-
-export function validateFloat(name: string, value: any, fieldErrors: FieldErrors, validators?: FloatValidator, parent = '') {
-  if (!validator.isFloat(String(value))) {
-    let message = 'invalid float number';
-    if (validators) {
-      if (validators.isFloat && validators.isFloat.errorMsg) {
-        message = validators.isFloat.errorMsg;
-      }
-      if (validators.isDouble && validators.isDouble.errorMsg) {
-        message = validators.isDouble.errorMsg;
+    if (validators.maximum && validators.maximum.value !== undefined) {
+      if (validators.maximum.value < numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.maximum.errorMsg || `max ${validators.maximum.value}`,
+          value,
+        };
+        return;
       }
     }
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
+    return numberValue;
   }
 
-  const numberValue = validator.toFloat(String(value));
-  if (!validators) { return numberValue; }
-  if (validators.minimum && validators.minimum.value !== undefined) {
-    if (validators.minimum.value > numberValue) {
+  public validateFloat(name: string, value: any, fieldErrors: FieldErrors, validators?: FloatValidator, parent = '') {
+    if (!validator.isFloat(String(value))) {
+      let message = 'invalid float number';
+      if (validators) {
+        if (validators.isFloat && validators.isFloat.errorMsg) {
+          message = validators.isFloat.errorMsg;
+        }
+        if (validators.isDouble && validators.isDouble.errorMsg) {
+          message = validators.isDouble.errorMsg;
+        }
+      }
       fieldErrors[parent + name] = {
-        message: validators.minimum.errorMsg || `min ${validators.minimum.value}`,
+        message,
         value,
       };
       return;
     }
+
+    const numberValue = validator.toFloat(String(value));
+    if (!validators) { return numberValue; }
+    if (validators.minimum && validators.minimum.value !== undefined) {
+      if (validators.minimum.value > numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.minimum.errorMsg || `min ${validators.minimum.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maximum && validators.maximum.value !== undefined) {
+      if (validators.maximum.value < numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.maximum.errorMsg || `max ${validators.maximum.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    return numberValue;
   }
-  if (validators.maximum && validators.maximum.value !== undefined) {
-    if (validators.maximum.value < numberValue) {
+
+  public validateEnum(name: string, value: any, fieldErrors: FieldErrors, members?: string[], parent = ''): any {
+    if (!members || members.length === 0) {
       fieldErrors[parent + name] = {
-        message: validators.maximum.errorMsg || `max ${validators.maximum.value}`,
+        message: 'no member',
         value,
       };
       return;
     }
-  }
-  return numberValue;
-}
-
-export function validateEnum(name: string, value: any, fieldErrors: FieldErrors, members?: string[], parent = ''): any {
-  if (!members || members.length === 0) {
-    fieldErrors[parent + name] = {
-      message: 'no member',
-      value,
-    };
-    return;
-  }
-  const enumValue = members.find(member => {
-    return member === String(value);
-  });
-  if (!enumValue) {
-    fieldErrors[parent + name] = {
-      message: `should be one of the following; ['${members.join(`', '`)}']`,
-      value,
-    };
-    return;
-  }
-  return value;
-}
-
-export function validateDate(name: string, value: any, fieldErrors: FieldErrors, validators?: DateValidator, parent = '') {
-  const momentDate = moment(String(value), moment.ISO_8601, true);
-  if (!momentDate.isValid()) {
-    const message = (validators && validators.isDate && validators.isDate.errorMsg) ? validators.isDate.errorMsg : `invalid ISO 8601 date format, i.e. YYYY-MM-DD`;
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
-  }
-
-  const dateValue = new Date(String(value));
-  if (!validators) { return dateValue; }
-  if (validators.minDate && validators.minDate.value) {
-    const minDate = new Date(validators.minDate.value);
-    if (minDate.getTime() > dateValue.getTime()) {
-      fieldErrors[parent + name] = {
-        message: validators.minDate.errorMsg || `minDate '${validators.minDate.value}'`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.maxDate && validators.maxDate.value) {
-    const maxDate = new Date(validators.maxDate.value);
-    if (maxDate.getTime() < dateValue.getTime()) {
-      fieldErrors[parent + name] = {
-        message: validators.maxDate.errorMsg || `maxDate '${validators.maxDate.value}'`,
-        value,
-      };
-      return;
-    }
-  }
-  return dateValue;
-}
-
-export function validateDateTime(name: string, value: any, fieldErrors: FieldErrors, validators?: DateTimeValidator, parent = '') {
-  const momentDateTime = moment(String(value), moment.ISO_8601, true);
-  if (!momentDateTime.isValid()) {
-    const message = (validators && validators.isDateTime && validators.isDateTime.errorMsg) ? validators.isDateTime.errorMsg : `invalid ISO 8601 datetime format, i.e. YYYY-MM-DDTHH:mm:ss`;
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
-  }
-
-  const datetimeValue = new Date(String(value));
-  if (!validators) { return datetimeValue; }
-  if (validators.minDate && validators.minDate.value) {
-    const minDate = new Date(validators.minDate.value);
-    if (minDate.getTime() > datetimeValue.getTime()) {
-      fieldErrors[parent + name] = {
-        message: validators.minDate.errorMsg || `minDate '${validators.minDate.value}'`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.maxDate && validators.maxDate.value) {
-    const maxDate = new Date(validators.maxDate.value);
-    if (maxDate.getTime() < datetimeValue.getTime()) {
-      fieldErrors[parent + name] = {
-        message: validators.maxDate.errorMsg || `maxDate '${validators.maxDate.value}'`,
-        value,
-      };
-      return;
-    }
-  }
-  return datetimeValue;
-}
-
-export function validateString(name: string, value: any, fieldErrors: FieldErrors, validators?: StringValidator, parent = '') {
-  if (typeof value !== 'string') {
-    const message = (validators && validators.isString && validators.isString.errorMsg) ? validators.isString.errorMsg : `invalid string value`;
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
-  }
-
-  const stringValue = String(value);
-  if (!validators) { return stringValue; }
-  if (validators.minLength && validators.minLength.value !== undefined) {
-    if (validators.minLength.value > stringValue.length) {
-      fieldErrors[parent + name] = {
-        message: validators.minLength.errorMsg || `minLength ${validators.minLength.value}`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.maxLength && validators.maxLength.value !== undefined) {
-    if (validators.maxLength.value < stringValue.length) {
-      fieldErrors[parent + name] = {
-        message: validators.maxLength.errorMsg || `maxLength ${validators.maxLength.value}`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.pattern && validators.pattern.value) {
-    if (!validator.matches(String(stringValue), validators.pattern.value)) {
-      fieldErrors[parent + name] = {
-        message: validators.pattern.errorMsg || `Not match in '${validators.pattern.value}'`,
-        value,
-      };
-      return;
-    }
-  }
-  return stringValue;
-}
-
-export function validateBool(name: string, value: any, fieldErrors: FieldErrors, validators?: BooleanValidator, parent = '') {
-  if (value === undefined || value === null) {
-    return false;
-  }
-  if (value === true || value === false) { return value; }
-  if (String(value).toLowerCase() === 'true') { return true; }
-  if (String(value).toLowerCase() === 'false') { return false; }
-
-  const message = (validators && validators.isArray && validators.isArray.errorMsg) ? validators.isArray.errorMsg : `invalid boolean value`;
-  fieldErrors[parent + name] = {
-    message,
-    value,
-  };
-  return;
-}
-
-export function validateArray(name: string, value: any[], fieldErrors: FieldErrors, schema?: TsoaRoute.PropertySchema, validators?: ArrayValidator, parent = '') {
-  if (!schema || value === undefined || value === null) {
-    const message = (validators && validators.isArray && validators.isArray.errorMsg) ? validators.isArray.errorMsg : `invalid array`;
-    fieldErrors[parent + name] = {
-      message,
-      value,
-    };
-    return;
-  }
-
-  let arrayValue = [] as any[];
-  if (Array.isArray(value)) {
-    arrayValue = value.map((elementValue, index) => {
-      return ValidateParam(schema, elementValue, models, `$${index}`, fieldErrors, name + '.');
+    const enumValue = members.find(member => {
+      return member === String(value);
     });
-  } else {
-    arrayValue = [
-      ValidateParam(schema, value, models, '$0', fieldErrors, name + '.'),
-    ];
+    if (!enumValue) {
+      fieldErrors[parent + name] = {
+        message: `should be one of the following; ['${members.join(`', '`)}']`,
+        value,
+      };
+      return;
+    }
+    return value;
   }
 
-  if (!validators) {
+  public validateDate(name: string, value: any, fieldErrors: FieldErrors, validators?: DateValidator, parent = '') {
+    const momentDate = moment(String(value), moment.ISO_8601, true);
+    if (!momentDate.isValid()) {
+      const message = (validators && validators.isDate && validators.isDate.errorMsg) ? validators.isDate.errorMsg : `invalid ISO 8601 date format, i.e. YYYY-MM-DD`;
+      fieldErrors[parent + name] = {
+        message,
+        value,
+      };
+      return;
+    }
+
+    const dateValue = new Date(String(value));
+    if (!validators) { return dateValue; }
+    if (validators.minDate && validators.minDate.value) {
+      const minDate = new Date(validators.minDate.value);
+      if (minDate.getTime() > dateValue.getTime()) {
+        fieldErrors[parent + name] = {
+          message: validators.minDate.errorMsg || `minDate '${validators.minDate.value}'`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maxDate && validators.maxDate.value) {
+      const maxDate = new Date(validators.maxDate.value);
+      if (maxDate.getTime() < dateValue.getTime()) {
+        fieldErrors[parent + name] = {
+          message: validators.maxDate.errorMsg || `maxDate '${validators.maxDate.value}'`,
+          value,
+        };
+        return;
+      }
+    }
+    return dateValue;
+  }
+
+  public validateDateTime(name: string, value: any, fieldErrors: FieldErrors, validators?: DateTimeValidator, parent = '') {
+    const momentDateTime = moment(String(value), moment.ISO_8601, true);
+    if (!momentDateTime.isValid()) {
+      const message = (validators && validators.isDateTime && validators.isDateTime.errorMsg) ? validators.isDateTime.errorMsg : `invalid ISO 8601 datetime format, i.e. YYYY-MM-DDTHH:mm:ss`;
+      fieldErrors[parent + name] = {
+        message,
+        value,
+      };
+      return;
+    }
+
+    const datetimeValue = new Date(String(value));
+    if (!validators) { return datetimeValue; }
+    if (validators.minDate && validators.minDate.value) {
+      const minDate = new Date(validators.minDate.value);
+      if (minDate.getTime() > datetimeValue.getTime()) {
+        fieldErrors[parent + name] = {
+          message: validators.minDate.errorMsg || `minDate '${validators.minDate.value}'`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maxDate && validators.maxDate.value) {
+      const maxDate = new Date(validators.maxDate.value);
+      if (maxDate.getTime() < datetimeValue.getTime()) {
+        fieldErrors[parent + name] = {
+          message: validators.maxDate.errorMsg || `maxDate '${validators.maxDate.value}'`,
+          value,
+        };
+        return;
+      }
+    }
+    return datetimeValue;
+  }
+
+  public validateString(name: string, value: any, fieldErrors: FieldErrors, validators?: StringValidator, parent = '') {
+    if (typeof value !== 'string') {
+      const message = (validators && validators.isString && validators.isString.errorMsg) ? validators.isString.errorMsg : `invalid string value`;
+      fieldErrors[parent + name] = {
+        message,
+        value,
+      };
+      return;
+    }
+
+    const stringValue = String(value);
+    if (!validators) { return stringValue; }
+    if (validators.minLength && validators.minLength.value !== undefined) {
+      if (validators.minLength.value > stringValue.length) {
+        fieldErrors[parent + name] = {
+          message: validators.minLength.errorMsg || `minLength ${validators.minLength.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maxLength && validators.maxLength.value !== undefined) {
+      if (validators.maxLength.value < stringValue.length) {
+        fieldErrors[parent + name] = {
+          message: validators.maxLength.errorMsg || `maxLength ${validators.maxLength.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.pattern && validators.pattern.value) {
+      if (!validator.matches(String(stringValue), validators.pattern.value)) {
+        fieldErrors[parent + name] = {
+          message: validators.pattern.errorMsg || `Not match in '${validators.pattern.value}'`,
+          value,
+        };
+        return;
+      }
+    }
+    return stringValue;
+  }
+
+  public validateBool(name: string, value: any, fieldErrors: FieldErrors, validators?: BooleanValidator, parent = '') {
+    if (value === undefined || value === null) {
+      return false;
+    }
+    if (value === true || value === false) { return value; }
+    if (String(value).toLowerCase() === 'true') { return true; }
+    if (String(value).toLowerCase() === 'false') { return false; }
+
+    const message = (validators && validators.isArray && validators.isArray.errorMsg) ? validators.isArray.errorMsg : `invalid boolean value`;
+    fieldErrors[parent + name] = {
+      message,
+      value,
+    };
+    return;
+  }
+
+  public validateArray(name: string, value: any[], fieldErrors: FieldErrors, schema?: TsoaRoute.PropertySchema, validators?: ArrayValidator, parent = '') {
+    if (!schema || value === undefined || value === null) {
+      const message = (validators && validators.isArray && validators.isArray.errorMsg) ? validators.isArray.errorMsg : `invalid array`;
+      fieldErrors[parent + name] = {
+        message,
+        value,
+      };
+      return;
+    }
+
+    let arrayValue = [] as any[];
+    if (Array.isArray(value)) {
+      arrayValue = value.map((elementValue, index) => {
+        return this.ValidateParam(schema, elementValue, `$${index}`, fieldErrors, name + '.');
+      });
+    } else {
+      arrayValue = [
+        this.ValidateParam(schema, value, '$0', fieldErrors, name + '.'),
+      ];
+    }
+
+    if (!validators) {
+      return arrayValue;
+    }
+    if (validators.minItems && validators.minItems.value) {
+      if (validators.minItems.value > arrayValue.length) {
+        fieldErrors[parent + name] = {
+          message: validators.minItems.errorMsg || `minItems ${validators.minItems.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maxItems && validators.maxItems.value) {
+      if (validators.maxItems.value < arrayValue.length) {
+        fieldErrors[parent + name] = {
+          message: validators.maxItems.errorMsg || `maxItems ${validators.maxItems.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.uniqueItems) {
+      const unique = arrayValue.some((elem, index, arr) => {
+        const indexOf = arr.indexOf(elem);
+        return indexOf > -1 && indexOf !== index;
+      });
+      if (unique) {
+        fieldErrors[parent + name] = {
+          message: validators.uniqueItems.errorMsg || `required unique array`,
+          value,
+        };
+        return;
+      }
+    }
     return arrayValue;
   }
-  if (validators.minItems && validators.minItems.value) {
-    if (validators.minItems.value > arrayValue.length) {
-      fieldErrors[parent + name] = {
-        message: validators.minItems.errorMsg || `minItems ${validators.minItems.value}`,
-        value,
-      };
-      return;
-    }
+
+  public validateBuffer(name: string, value: string) {
+    return new Buffer(value);
   }
-  if (validators.maxItems && validators.maxItems.value) {
-    if (validators.maxItems.value < arrayValue.length) {
-      fieldErrors[parent + name] = {
-        message: validators.maxItems.errorMsg || `maxItems ${validators.maxItems.value}`,
-        value,
-      };
-      return;
-    }
-  }
-  if (validators.uniqueItems) {
-    const unique = arrayValue.some((elem, index, arr) => {
-      const indexOf = arr.indexOf(elem);
-      return indexOf > -1 && indexOf !== index;
-    });
-    if (unique) {
-      fieldErrors[parent + name] = {
-        message: validators.uniqueItems.errorMsg || `required unique array`,
-        value,
-      };
-      return;
-    }
-  }
-  return arrayValue;
-}
 
-function validateBuffer(name: string, value: string) {
-  return new Buffer(value);
-}
+  public validateModel(name: string, value: any, refName: string, fieldErrors: FieldErrors, parent = ''): any {
+    const modelDefinition = this.models[refName];
 
-export function validateModel(name: string, value: any, refName: string, fieldErrors: FieldErrors, parent = ''): any {
-  const modelDefinition = models[refName];
-
-  if (modelDefinition) {
-    const properties = modelDefinition.properties || {};
-    Object.keys(properties).forEach((key: string) => {
-      const property = properties[key];
-      value[key] = ValidateParam(property, value[key], models, key, fieldErrors, parent);
-    });
-
-    const additionalProperties = modelDefinition.additionalProperties;
-    if (additionalProperties) {
-      const alreadyValidatedProperties = new Set(Object.keys(properties));
-      Object.keys(value).forEach((key: string) => {
-        if (!alreadyValidatedProperties.has(key)) {
-          const validatedValue = ValidateParam(additionalProperties, value[key], models, key, fieldErrors, parent);
-          if (validatedValue !== undefined) {
-            value[key] = validatedValue;
-          } else {
-            fieldErrors[parent + '.' + key] = {
-              message: `No matching model found in additionalProperties to validate ${key}`,
-              value: key,
-            };
-          }
-        }
+    if (modelDefinition) {
+      const properties = modelDefinition.properties || {};
+      Object.keys(properties).forEach((key: string) => {
+        const property = properties[key];
+        value[key] = this.ValidateParam(property, value[key], key, fieldErrors, parent);
       });
+
+      const additionalProperties = modelDefinition.additionalProperties;
+      if (additionalProperties) {
+        const alreadyValidatedProperties = new Set(Object.keys(properties));
+        Object.keys(value).forEach((key: string) => {
+          if (!alreadyValidatedProperties.has(key)) {
+            const validatedValue = this.ValidateParam(additionalProperties, value[key], key, fieldErrors, parent);
+            if (validatedValue !== undefined) {
+              value[key] = validatedValue;
+            } else {
+              fieldErrors[parent + '.' + key] = {
+                message: `No matching model found in additionalProperties to validate ${key}`,
+                value: key,
+              };
+            }
+          }
+        });
+      }
+
+      const enums = modelDefinition.enums;
+      if (enums) {
+        return this.validateEnum(name, value, fieldErrors, enums, parent);
+      }
     }
 
-    const enums = modelDefinition.enums;
-    if (enums) {
-      return validateEnum(name, value, fieldErrors, enums, parent);
-    }
+    return value;
   }
-
-  return value;
 }
 
 export interface IntegerValidator {

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -359,25 +359,26 @@ export function validateModel(name: string, value: any, refName: string, fieldEr
   const modelDefinition = models[refName];
 
   if (modelDefinition) {
-    const properties = modelDefinition.properties;
-    if (properties) {
-      Object.keys(properties).forEach((key: string) => {
-        const property = properties[key];
-        value[key] = ValidateParam(property, value[key], models, key, fieldErrors, parent);
-      });
-    }
+    const properties = modelDefinition.properties || {};
+    Object.keys(properties).forEach((key: string) => {
+      const property = properties[key];
+      value[key] = ValidateParam(property, value[key], models, key, fieldErrors, parent);
+    });
 
     const additionalProperties = modelDefinition.additionalProperties;
     if (additionalProperties) {
+      const alreadyValidatedProperties = new Set(Object.keys(properties));
       Object.keys(value).forEach((key: string) => {
-        const validatedValue = ValidateParam(additionalProperties, value[key], models, key, fieldErrors, parent);
-        if (validatedValue !== undefined) {
-          value[key] = validatedValue;
-        } else {
-          fieldErrors[parent + '.' + key] = {
-            message: `No matching model found in additionalProperties to validate ${key}`,
-            value: key,
-          };
+        if (!alreadyValidatedProperties.has(key)) {
+          const validatedValue = ValidateParam(additionalProperties, value[key], models, key, fieldErrors, parent);
+          if (validatedValue !== undefined) {
+            value[key] = validatedValue;
+          } else {
+            fieldErrors[parent + '.' + key] = {
+              message: `No matching model found in additionalProperties to validate ${key}`,
+              value: key,
+            };
+          }
         }
       });
     }

--- a/src/routeGeneration/templates/express.ts
+++ b/src/routeGeneration/templates/express.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 {{#if canImportByAlias}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -33,6 +33,7 @@ const models: TsoaRoute.Models = {
     },
     {{/each}}
 };
+const validationService = new ValidationService(models);
 
 export function RegisterRoutes(app: any) {
     {{#each controllers}}
@@ -151,15 +152,15 @@ export function RegisterRoutes(app: any) {
                 case 'request':
                     return request;
                 case 'query':
-                    return ValidateParam(args[key], request.query[name], models, name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors);
                 case 'path':
-                    return ValidateParam(args[key], request.params[name], models, name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors);
                 case 'header':
-                    return ValidateParam(args[key], request.header(name), models, name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors);
                 case 'body':
-                    return ValidateParam(args[key], request.body, models, name, fieldErrors, name + '.');
+                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, name + '.');
                 case 'body-prop':
-                    return ValidateParam(args[key], request.body[name], models, name, fieldErrors, 'body.');
+                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.');
             }
         });
         if (Object.keys(fieldErrors).length > 0) {

--- a/src/routeGeneration/templates/hapi.ts
+++ b/src/routeGeneration/templates/hapi.ts
@@ -1,9 +1,9 @@
 // TODO: Replace this with HAPI middleware stuff
 /* tslint:disable */
 {{#if canImportByAlias}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -34,6 +34,7 @@ const models: TsoaRoute.Models = {
     },
     {{/each}}
 };
+const validationService = new ValidationService(models);
 
 export function RegisterRoutes(server: any) {
     {{#each controllers}}
@@ -162,15 +163,15 @@ export function RegisterRoutes(server: any) {
             case 'request':
                 return request;
             case 'query':
-                return ValidateParam(args[key], request.query[name], models, name, errorFields)
+                return validationService.ValidateParam(args[key], request.query[name], name, errorFields)
             case 'path':
-                return ValidateParam(args[key], request.params[name], models, name, errorFields)
+                return validationService.ValidateParam(args[key], request.params[name], name, errorFields)
             case 'header':
-                return ValidateParam(args[key], request.headers[name], models, name, errorFields);
+                return validationService.ValidateParam(args[key], request.headers[name], name, errorFields);
             case 'body':
-                return ValidateParam(args[key], request.payload, models, name, errorFields, name + '.');
+                return validationService.ValidateParam(args[key], request.payload, name, errorFields, name + '.');
              case 'body-prop':
-                return ValidateParam(args[key], request.payload[name], models, name, errorFields, 'body.');
+                return validationService.ValidateParam(args[key], request.payload[name], name, errorFields, 'body.');
             }
         });
         if (Object.keys(errorFields).length > 0) {

--- a/src/routeGeneration/templates/koa.ts
+++ b/src/routeGeneration/templates/koa.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 {{#if canImportByAlias}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}
-  import { Controller, ValidateParam, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -33,6 +33,7 @@ const models: TsoaRoute.Models = {
     },
     {{/each}}
 };
+const validationService = new ValidationService(models);
 
 export function RegisterRoutes(router: any) {
     {{#each controllers}}
@@ -158,15 +159,15 @@ export function RegisterRoutes(router: any) {
             case 'request':
                 return context.request;
             case 'query':
-                return ValidateParam(args[key], context.request.query[name], models, name, errorFields)
+                return validationService.ValidateParam(args[key], context.request.query[name], name, errorFields)
             case 'path':
-                return ValidateParam(args[key], context.params[name], models, name, errorFields)
+                return validationService.ValidateParam(args[key], context.params[name], name, errorFields)
             case 'header':
-                return ValidateParam(args[key], context.request.headers[name], models, name, errorFields);
+                return validationService.ValidateParam(args[key], context.request.headers[name], name, errorFields);
             case 'body':
-                return ValidateParam(args[key], context.request.body, models, name, errorFields, name + '.');
+                return validationService.ValidateParam(args[key], context.request.body, name, errorFields, name + '.');
             case 'body-prop':
-                return ValidateParam(args[key], context.request.body[name], models, name, errorFields, 'body.');
+                return validationService.ValidateParam(args[key], context.request.body[name], name, errorFields, 'body.');
             }
         });
         if (Object.keys(errorFields).length > 0) {

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -1,69 +1,88 @@
 import { expect } from 'chai';
 import 'mocha';
-import * as templateHelpers from './../../../src/routeGeneration/templateHelpers';
+import { ValidationService } from './../../../src/routeGeneration/templateHelpers';
 
-describe('templateHelpers', () => {
-
-    afterEach(() => {
-        // clean up global models
-        Object.keys(templateHelpers.models).forEach(k => {
-            delete templateHelpers.models[k];
-        });
-    });
+describe('ValidationService', () => {
 
     describe('Model validate', () => {
         it('should validate a model with declared properties', () => {
-            templateHelpers.models.ExampleModel = {
-                properties: {
-                    a: { dataType: 'string', required: true },
-                },
-            };
+            const v = new ValidationService({
+                ExampleModel: {
+                    properties: {
+                        a: { dataType: 'string', required: true },
+                    },
+                }
+            });
             const error = {};
-            const result = templateHelpers.validateModel('', { a: 's' }, 'ExampleModel', error);
+            const result = v.validateModel('', { a: 's' }, 'ExampleModel', error);
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: 's' });
         });
 
         it('should not require optional properties', () => {
-            templateHelpers.models.ExampleModel = {
-                properties: {
-                    a: { dataType: 'string' },
-                },
-            };
+            const v = new ValidationService({
+                ExampleModel: {
+                    properties: {
+                        a: { dataType: 'string' },
+                    },
+                }
+            });
             const error = {};
-            const result = templateHelpers.validateModel('', {}, 'ExampleModel', error);
+            const result = v.validateModel('', {}, 'ExampleModel', error);
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: undefined });
         });
 
         it('should validate a model with additional properties', () => {
-            templateHelpers.models.ExampleModel = {
-                additionalProperties: { dataType: 'any' },
-            };
+            const v = new ValidationService({
+                ExampleModel: {
+                    additionalProperties: { dataType: 'any' },
+                }
+            });
             const error = {};
-            const result = templateHelpers.validateModel('', { a: 's' }, 'ExampleModel', error);
+            const result = v.validateModel('', { a: 's' }, 'ExampleModel', error);
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: 's' });
         });
 
         it('should validate a model with optional and additional properties', () => {
-            templateHelpers.models.ExampleModel = {
-                additionalProperties: { dataType: 'any' },
-                properties: {
-                    a: { dataType: 'string' },
-                },
-            };
+            const v = new ValidationService({
+                ExampleModel: {
+                    additionalProperties: { dataType: 'any' },
+                    properties: {
+                        a: { dataType: 'string' },
+                    },
+                }
+            });
             const error = {};
-            const result = templateHelpers.validateModel('', {}, 'ExampleModel', error);
+            const result = v.validateModel('', {}, 'ExampleModel', error);
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: undefined });
+        });
+
+        it('should validate additional properties only against non-explicitly stated properties', () => {
+            const v = new ValidationService({
+                ExampleModel: {
+                    additionalProperties: {
+                        dataType: 'integer',
+                        validators: { minimum: { value: 10 } }
+                    },
+                    properties: {
+                        a: { dataType: 'integer' },
+                    },
+                }
+            });
+            const error = {};
+            const result = v.validateModel('', { a: 9 }, 'ExampleModel', error);
+            expect(Object.keys(error)).to.be.empty;
+            expect(result).to.eql({ a: 9 });
         });
     });
 
     describe('Integer validate', () => {
         it('should integer value', () => {
             const value = '10';
-            const result = templateHelpers.validateInt('name', value, {});
+            const result = new ValidationService({}).validateInt('name', value, {});
             expect(result).to.equal(Number(value));
         });
 
@@ -71,7 +90,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '10.0';
             const error = {};
-            const result = templateHelpers.validateInt(name, value, error);
+            const result = new ValidationService({}).validateInt(name, value, error);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`invalid integer number`);
         });
@@ -81,7 +100,7 @@ describe('templateHelpers', () => {
             const value = '11';
             const error = {};
             const validator = { minimum: { value: 10 }, maximum: { value: 12 } };
-            const result = templateHelpers.validateInt(name, value, error, validator);
+            const result = new ValidationService({}).validateInt(name, value, error, validator);
             expect(result).to.equal(Number(value));
         });
 
@@ -90,7 +109,7 @@ describe('templateHelpers', () => {
             const value = '11';
             const error = {};
             const validator = { minimum: { value: 12 } };
-            const result = templateHelpers.validateInt(name, value, error, validator);
+            const result = new ValidationService({}).validateInt(name, value, error, validator);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`min 12`);
         });
@@ -100,7 +119,7 @@ describe('templateHelpers', () => {
             const value = '11';
             const error = {};
             const validator = { maximum: { value: 10 } };
-            const result = templateHelpers.validateInt(name, value, error, validator);
+            const result = new ValidationService({}).validateInt(name, value, error, validator);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`max 10`);
         });
@@ -109,7 +128,7 @@ describe('templateHelpers', () => {
     describe('Float validate', () => {
         it('should float value', () => {
             const value = '10';
-            const result = templateHelpers.validateFloat('name', value, {});
+            const result = new ValidationService({}).validateFloat('name', value, {});
             expect(result).to.equal(Number(value));
         });
 
@@ -117,7 +136,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = 'Hello';
             const error = {};
-            const result = templateHelpers.validateFloat(name, value, error);
+            const result = new ValidationService({}).validateFloat(name, value, error);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`invalid float number`);
         });
@@ -127,7 +146,7 @@ describe('templateHelpers', () => {
             const value = '11.5';
             const error = {};
             const validator = { minimum: { value: 10 }, maximum: { value: 12 } };
-            const result = templateHelpers.validateFloat(name, value, error, validator);
+            const result = new ValidationService({}).validateFloat(name, value, error, validator);
             expect(result).to.equal(Number(value));
         });
 
@@ -136,7 +155,7 @@ describe('templateHelpers', () => {
             const value = '12.4';
             const error = {};
             const validator = { minimum: { value: 12.5 } };
-            const result = templateHelpers.validateFloat(name, value, error, validator);
+            const result = new ValidationService({}).validateFloat(name, value, error, validator);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`min 12.5`);
         });
@@ -146,7 +165,7 @@ describe('templateHelpers', () => {
             const value = '10.6';
             const error = {};
             const validator = { maximum: { value: 10.5 } };
-            const result = templateHelpers.validateFloat(name, value, error, validator);
+            const result = new ValidationService({}).validateFloat(name, value, error, validator);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`max 10.5`);
         });
@@ -155,13 +174,13 @@ describe('templateHelpers', () => {
     describe('Enum validate', () => {
         it('should enum number value', () => {
             const value = 1;
-            const result = templateHelpers.validateEnum('name', value, {}, ['0', '1'] as any);
+            const result = new ValidationService({}).validateEnum('name', value, {}, ['0', '1'] as any);
             expect(result).to.equal(value);
         });
 
         it('should enum string value', () => {
             const value = 'HELLO';
-            const result = templateHelpers.validateEnum('name', value, {}, ['HELLO'] as any);
+            const result = new ValidationService({}).validateEnum('name', value, {}, ['HELLO'] as any);
             expect(result).to.equal(value);
         });
 
@@ -169,7 +188,7 @@ describe('templateHelpers', () => {
             const error: any = {};
             const name = 'name';
             const value = 'HI';
-            const result = templateHelpers.validateEnum(name, value, error, [] as any);
+            const result = new ValidationService({}).validateEnum(name, value, error, [] as any);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`no member`);
         });
@@ -178,7 +197,7 @@ describe('templateHelpers', () => {
             const error: any = {};
             const name = 'name';
             const value = 'SAY';
-            const result = templateHelpers.validateEnum(name, value, error, ['HELLO', 'HI'] as any);
+            const result = new ValidationService({}).validateEnum(name, value, error, ['HELLO', 'HI'] as any);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`should be one of the following; ['HELLO', 'HI']`);
         });
@@ -187,7 +206,7 @@ describe('templateHelpers', () => {
     describe('String validate', () => {
         it('should string value', () => {
             const value = 'Hello';
-            const result = templateHelpers.validateString('name', value, {});
+            const result = new ValidationService({}).validateString('name', value, {});
             expect(result).to.equal(value);
         });
 
@@ -195,7 +214,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = 'AB';
             const error = {};
-            const result = templateHelpers.validateString(name, value, error, { minLength: { value: 5 } });
+            const result = new ValidationService({}).validateString(name, value, error, { minLength: { value: 5 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`minLength 5`);
         });
@@ -204,7 +223,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = 'ABCDE';
             const error = {};
-            const result = templateHelpers.validateString(name, value, error, { maxLength: { value: 3 } });
+            const result = new ValidationService({}).validateString(name, value, error, { maxLength: { value: 3 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`maxLength 3`);
         });
@@ -213,7 +232,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = 'ABC';
             const error = {};
-            const result = templateHelpers.validateString(name, value, error, { pattern: { value: 'a-z' } });
+            const result = new ValidationService({}).validateString(name, value, error, { pattern: { value: 'a-z' } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`Not match in 'a-z'`);
         });
@@ -222,7 +241,7 @@ describe('templateHelpers', () => {
     describe('Date validate', () => {
         it('should date value', () => {
             const value = '2017-01-01';
-            const result = templateHelpers.validateDate('name', value, {});
+            const result = new ValidationService({}).validateDate('name', value, {});
             expect(result).to.deep.equal(new Date(value));
         });
 
@@ -230,7 +249,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-33-11';
             const error = {};
-            const result = templateHelpers.validateDate(name, value, error);
+            const result = new ValidationService({}).validateDate(name, value, error);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`invalid ISO 8601 date format, i.e. YYYY-MM-DD`);
         });
@@ -239,7 +258,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-06-01';
             const error = {};
-            const result = templateHelpers.validateDate(name, value, error, { minDate: { value: '2017-07-01' } });
+            const result = new ValidationService({}).validateDate(name, value, error, { minDate: { value: '2017-07-01' } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`minDate '2017-07-01'`);
         });
@@ -248,7 +267,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-06-01';
             const error = {};
-            const result = templateHelpers.validateDate(name, value, error, { maxDate: { value: '2017-05-01' } });
+            const result = new ValidationService({}).validateDate(name, value, error, { maxDate: { value: '2017-05-01' } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`maxDate '2017-05-01'`);
         });
@@ -257,7 +276,7 @@ describe('templateHelpers', () => {
     describe('DateTime validate', () => {
         it('should datetime value', () => {
             const value = '2017-12-30T00:00:00';
-            const result = templateHelpers.validateDateTime('name', value, {});
+            const result = new ValidationService({}).validateDateTime('name', value, {});
             expect(result).to.deep.equal(new Date(value));
         });
 
@@ -265,7 +284,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-12-309i';
             const error = {};
-            const result = templateHelpers.validateDateTime(name, value, error);
+            const result = new ValidationService({}).validateDateTime(name, value, error);
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`invalid ISO 8601 datetime format, i.e. YYYY-MM-DDTHH:mm:ss`);
         });
@@ -274,7 +293,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-12-30T00:00:00';
             const error = {};
-            const result = templateHelpers.validateDateTime(name, value, error, { minDate: { value: '2017-12-31T00:00:00' } });
+            const result = new ValidationService({}).validateDateTime(name, value, error, { minDate: { value: '2017-12-31T00:00:00' } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`minDate '2017-12-31T00:00:00'`);
         });
@@ -283,7 +302,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = '2017-12-30T00:00:00';
             const error = {};
-            const result = templateHelpers.validateDateTime(name, value, error, { maxDate: { value: '2017-12-29T00:00:00' } });
+            const result = new ValidationService({}).validateDateTime(name, value, error, { maxDate: { value: '2017-12-29T00:00:00' } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`maxDate '2017-12-29T00:00:00'`);
         });
@@ -292,7 +311,7 @@ describe('templateHelpers', () => {
     describe('Array validate', () => {
         it('should array value', () => {
             const value = ['A', 'B', 'C'];
-            const result = templateHelpers.validateArray('name', value, {}, { dataType: 'string' });
+            const result = new ValidationService({}).validateArray('name', value, {}, { dataType: 'string' });
             expect(result).to.deep.equal(value);
         });
 
@@ -300,7 +319,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = ['A', 10, true];
             const error = {};
-            const result = templateHelpers.validateArray(name, value, error, { dataType: 'integer' });
+            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' });
             expect(result).to.deep.equal([undefined, 10, undefined]);
             expect(error[`${name}.$0`].message).to.equal('invalid integer number');
             expect(error[`${name}.$0`].value).to.equal('A');
@@ -312,7 +331,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = [80, 10, 199];
             const error = {};
-            const result = templateHelpers.validateArray(name, value, error, { dataType: 'integer' }, { minItems: { value: 4 } });
+            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { minItems: { value: 4 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`minItems 4`);
         });
@@ -321,7 +340,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = [80, 10, 199];
             const error = {};
-            const result = templateHelpers.validateArray(name, value, error, { dataType: 'integer' }, { maxItems: { value: 2 } });
+            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { maxItems: { value: 2 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`maxItems 2`);
         });
@@ -330,7 +349,7 @@ describe('templateHelpers', () => {
             const name = 'name';
             const value = [10, 10, 20];
             const error = {};
-            const result = templateHelpers.validateArray(name, value, error, { dataType: 'integer' }, { uniqueItems: {} });
+            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { uniqueItems: {} });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`required unique array`);
         });

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -4,6 +4,62 @@ import * as templateHelpers from './../../../src/routeGeneration/templateHelpers
 
 describe('templateHelpers', () => {
 
+    afterEach(() => {
+        // clean up global models
+        Object.keys(templateHelpers.models).forEach(k => {
+            delete templateHelpers.models[k];
+        });
+    });
+
+    describe('Model validate', () => {
+        it('should validate a model with declared properties', () => {
+            templateHelpers.models.ExampleModel = {
+                properties: {
+                    a: { dataType: 'string', required: true },
+                },
+            };
+            const error = {};
+            const result = templateHelpers.validateModel('', { a: 's' }, 'ExampleModel', error);
+            expect(Object.keys(error)).to.be.empty;
+            expect(result).to.eql({ a: 's' });
+        });
+
+        it('should not require optional properties', () => {
+            templateHelpers.models.ExampleModel = {
+                properties: {
+                    a: { dataType: 'string' },
+                },
+            };
+            const error = {};
+            const result = templateHelpers.validateModel('', {}, 'ExampleModel', error);
+            expect(Object.keys(error)).to.be.empty;
+            expect(result).to.eql({ a: undefined });
+        });
+
+        it('should validate a model with additional properties', () => {
+            templateHelpers.models.ExampleModel = {
+                additionalProperties: { dataType: 'any' },
+            };
+            const error = {};
+            const result = templateHelpers.validateModel('', { a: 's' }, 'ExampleModel', error);
+            expect(Object.keys(error)).to.be.empty;
+            expect(result).to.eql({ a: 's' });
+        });
+
+        it('should validate a model with optional and additional properties', () => {
+            templateHelpers.models.ExampleModel = {
+                additionalProperties: { dataType: 'any' },
+                properties: {
+                    a: { dataType: 'string' },
+                },
+            };
+            const error = {};
+            const result = templateHelpers.validateModel('', {}, 'ExampleModel', error);
+            expect(Object.keys(error)).to.be.empty;
+            expect(result).to.eql({ a: undefined });
+        });
+    });
+
     describe('Integer validate', () => {
         it('should integer value', () => {
             const value = '10';


### PR DESCRIPTION
This fixes issue #314.

The fix was to not check already validated properties against `additionalProperties` again. This assumes that `additionalProperties` is used exclusively for properties defined as `[key: type]: type`.

If `additionalProperties` was meant to set up additional restrictions on *all* properties please let me know, then the fix would be the allow `undefined` as value for type `any`. For my use case this would work as well, but it would break models like the following (which might be unintuitive to users):
```typescript
interface ExampleModel {
    a?: string;
    [key: string]: number;
}
```