### PR TITLE
Better handling of array query parameters

### DIFF
--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -39,6 +39,11 @@ export namespace Tsoa {
     validators: Validators;
   }
 
+  export interface ArrayParameter extends Parameter {
+    type: ArrayType;
+    collectionFormat?: 'csv' | 'multi'| 'pipes' | 'ssv' | 'tsv' ;
+  }
+
   export interface Validators {
     [key: string]: { value?: any, errorMsg?: string };
   }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -174,7 +174,7 @@ export class SpecGenerator {
     const parameterType = this.getSwaggerType(source.type);
     parameter.format = parameterType.format || undefined;
 
-    if (parameter.in === 'query' && parameter.type === 'array') {
+    if (parameter.in === 'query' && parameterType.type === 'array') {
       (parameter as Swagger.QueryParameter).collectionFormat = 'multi';
     }
 

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -22,6 +22,7 @@ export class ParameterController {
    * @param {number} weight Weight description
    * @param {boolean} human Human description
    * @param {Gender} gender Gender description
+   * @param {string[]} nicknames Nicknames description
    *
    * @isInt age
    * @isFloat weight
@@ -34,6 +35,7 @@ export class ParameterController {
     @Query() weight: number,
     @Query() human: boolean,
     @Query() gender: Gender,
+    @Query() nicknames: string[],
   ): Promise<ParameterTestModel> {
     return Promise.resolve<ParameterTestModel>({
       age,
@@ -41,6 +43,7 @@ export class ParameterController {
       gender,
       human,
       lastname,
+      nicknames,
       weight,
     });
   }

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -167,6 +167,7 @@ export class ParameterTestModel {
   public weight: number;
   public human: boolean;
   public gender: Gender;
+  public nicknames?: string[];
 }
 
 export class ValidateCustomErrorModel {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -590,7 +590,7 @@ describe('Express Server', () => {
 
   describe('Parameter data', () => {
     it('parses query parameters', () => {
-      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE', (err, res) => {
+      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');
@@ -598,6 +598,7 @@ describe('Express Server', () => {
         expect(model.weight).to.equal(82.1);
         expect(model.human).to.equal(true);
         expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
       });
     });
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -531,7 +531,7 @@ describe('Hapi Server', () => {
 
   describe('Parameter data', () => {
     it('parses query parameters', () => {
-      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE', (err, res) => {
+      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');
@@ -539,6 +539,7 @@ describe('Hapi Server', () => {
         expect(model.weight).to.equal(82.1);
         expect(model.human).to.equal(true);
         expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
       });
     });
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -508,7 +508,7 @@ describe('Koa Server', () => {
 
   describe('Parameter data', () => {
     it('parses query parameters', () => {
-      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE', (err, res) => {
+      return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');
@@ -516,6 +516,7 @@ describe('Koa Server', () => {
         expect(model.weight).to.equal(82.1);
         expect(model.human).to.equal(true);
         expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
       });
     });
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
+import { Tsoa } from '../../../../src/metadataGeneration/tsoa';
 
 describe('Metadata generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
@@ -216,13 +217,13 @@ describe('Metadata generation', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/parameterController.ts').Generate();
     const controller = parameterMetadata.controllers[0];
 
-    it('should generate an query parameter', () => {
+    it('should generate a query parameter', () => {
       const method = controller.methods.find(m => m.name === 'getQuery');
       if (!method) {
         throw new Error('Method getQuery not defined!');
       }
 
-      expect(method.parameters.length).to.equal(6);
+      expect(method.parameters.length).to.equal(7);
 
       const firstnameParam = method.parameters[0];
       expect(firstnameParam.in).to.equal('query');
@@ -271,6 +272,16 @@ describe('Metadata generation', () => {
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
       expect(genderParam.type.dataType).to.equal('enum');
+
+      const nicknamesParam = method.parameters[6] as Tsoa.ArrayParameter;
+      expect(nicknamesParam.in).to.equal('query');
+      expect(nicknamesParam.name).to.equal('nicknames');
+      expect(nicknamesParam.parameterName).to.equal('nicknames');
+      expect(nicknamesParam.description).to.equal('Nicknames description');
+      expect(nicknamesParam.required).to.be.true;
+      expect(nicknamesParam.type.dataType).to.equal('array');
+      expect(nicknamesParam.collectionFormat).to.equal('multi');
+      expect(nicknamesParam.type.elementType).to.deep.equal({ dataType: 'string' });
     });
 
     it('should generate an path parameter', () => {


### PR DESCRIPTION
This aims to better handle the array query parameters, with a fix for `collectionFormat` property generation in swagger.
CollectionFormat could then later be specified with a tag, but I kept the default value for this fix.

Close #316 