### PR TITLE
Controller inheritance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsoa",
-  "version": "2.3.7",
+  "version": "2.3.81",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
     },
     "@types/connect": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/body-parser": "^1.17.0",
-    "@types/chai": "^3.5.2",
+    "@types/chai": "^4.1.7",
     "@types/express": "^4.16.0",
     "@types/handlebars": "^4.0.37",
     "@types/hapi": "^17.6.1",
@@ -69,7 +69,7 @@
     "@types/yamljs": "^0.2.30",
     "@types/yargs": "^8.0.3",
     "body-parser": "^1.18.3",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chalk": "^2.4.1",
     "copyfiles": "^1.2.0",
     "cross-env": "^5.1.6",

--- a/src/decorators/customAttribute.ts
+++ b/src/decorators/customAttribute.ts
@@ -1,4 +1,4 @@
 // tslint:disable-next-line:variable-name
-export function CustomAttribute(_name: string, _value: string): Function {
+export function CustomAttribute(_name: string, _value: string | any[] | object): Function {
   return () => { return; };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './decorators/tags';
 export * from './decorators/operationid';
 export * from './decorators/route';
 export * from './decorators/security';
+export * from './decorators/customAttribute';
 export * from './interfaces/controller';
 export * from './decorators/response';
 export * from './routeGeneration/templateHelpers';

--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -35,6 +35,7 @@ export class ControllerGenerator {
     const sourceFile = this.node.parent.getSourceFile();
 
     return {
+      inheritanceList: this.getInheritanceList(),
       location: sourceFile.fileName,
       methods: this.buildMethods(),
       name: this.node.name.text,
@@ -87,5 +88,15 @@ export class ControllerGenerator {
     }
 
     return getSecurities(securityDecorators);
+  }
+
+  private getInheritanceList(): string[] {
+    if (!this.node.heritageClauses || !this.node.heritageClauses.length) {
+      return [];
+    }
+
+    return this.node.heritageClauses
+      .reduce((acc, node) => [...acc, ...node.types], [])
+      .map((nodeType: any) => nodeType.expression.escapedText);
   }
 }

--- a/src/metadataGeneration/customAttribute.ts
+++ b/src/metadataGeneration/customAttribute.ts
@@ -1,0 +1,63 @@
+import * as ts from 'typescript';
+import { getInitializerValue } from './initializer-value';
+import { Tsoa } from './tsoa';
+
+const getArgumentValue = (argument: ts.Expression) => {
+  switch (argument.kind as ts.SyntaxKind) {
+    case ts.SyntaxKind.StringLiteral: {
+      const argumentValue = (argument as any).text;
+
+      return argumentValue;
+    }
+
+    case ts.SyntaxKind.ObjectLiteralExpression: {
+      const argumentValueProperties = (argument as any).properties;
+
+      const argumentValue = {};
+
+      for (const property of argumentValueProperties) {
+        const name = property.name.text;
+        const scopes = getInitializerValue(property.initializer);
+        argumentValue[name] = scopes;
+      }
+
+      return argumentValue;
+    }
+
+    case ts.SyntaxKind.ArrayLiteralExpression: {
+      const elements = (argument as any).elements;
+
+      const argumentValue = elements.map((element) => getArgumentValue(element));
+
+      return argumentValue;
+    }
+
+    default: {
+      throw new Error('Custom Attribute values must be of type: string, object, or array');
+    }
+  }
+};
+
+export function getCustomAttributes(decorators: ts.Identifier[]): Tsoa.CustomAttribute[] {
+  const customAttributes: Tsoa.CustomAttribute[] = decorators.map((customAttributeDecorator: ts.Identifier) => {
+    const expression = customAttributeDecorator.parent as ts.CallExpression;
+
+    const [decoratorKeyArg, decoratorValueArg] = expression.arguments;
+
+    if (decoratorKeyArg.kind !== ts.SyntaxKind.StringLiteral) {
+      throw new Error('First argument of Custom Attribute must be the attribute key as a string');
+    }
+
+    const attributeKey = getArgumentValue(decoratorKeyArg);
+
+    if (!decoratorValueArg) {
+      throw new Error(`Custom Attribute '${attributeKey}' must contain a value`);
+    }
+
+    const attributeValue = getArgumentValue(decoratorValueArg);
+
+    return { key: attributeKey, value: attributeValue };
+  });
+
+  return customAttributes;
+}

--- a/src/metadataGeneration/metadataGenerator.ts
+++ b/src/metadataGeneration/metadataGenerator.ts
@@ -61,16 +61,20 @@ export class MetadataGenerator {
     this.circularDependencyResolvers.push(callback);
   }
 
-  private getInheritedMethods(controller: Tsoa.Controller, controllerList: Tsoa.Controller[]): Tsoa.Method[] {
-    const inheritedClasses = controllerList.filter(({ name }) => controller.inheritanceList.includes(name));
+  private checkForDuplicateMethods(controllers: Tsoa.Controller[]) {
+    const methodSet = new Set<string>();
 
-    // Crawl the inherited classes for decorated methods, filter out any that exist on the current controller
-    const currentMethodPaths = controller.methods.map(method => method.path);
-    const inheritedMethods: Tsoa.Method[] = inheritedClasses
-      .reduce((acc, item) => [...acc, ...item.methods], [])
-      .filter(method => !currentMethodPaths.includes(method.path));
+    controllers.forEach((controller) => {
+      controller.methods.forEach(({method, path}) => {
+        const methodIdentifier = `${method.toUpperCase()} /${controller.path}/${path}`;
 
-    return inheritedClasses.reduce((acc, item) => [...acc, ...this.getInheritedMethods(item, controllerList)], inheritedMethods);
+        if (methodSet.has(methodIdentifier)) {
+          throw new Error(`Duplicate method for path '${methodIdentifier}' was found`);
+        }
+
+        methodSet.add(methodIdentifier);
+      });
+    });
   }
 
   private buildControllers() {
@@ -78,15 +82,11 @@ export class MetadataGenerator {
       .filter((node) => node.kind === ts.SyntaxKind.ClassDeclaration && this.IsExportedNode(node as ts.ClassDeclaration))
       .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this));
 
-    // Need a list of all controllers with decorated methods for determining heritage on valid controllers.
-    const allControllers: Tsoa.Controller[] = controllerGenerators.map((generator) => generator.Generate());
-
     const validControllers: Tsoa.Controller[] = controllerGenerators
       .filter((controllerGenerator: ControllerGenerator) => controllerGenerator.IsValid())
       .map((generator) => generator.Generate());
 
-    // Attach all decorated methods, including those on parent classes, to the controller.
-    validControllers.forEach(controller => controller.methods.push(...this.getInheritedMethods(controller, allControllers)));
+    this.checkForDuplicateMethods(validControllers);
 
     return validControllers;
   }

--- a/src/metadataGeneration/metadataGenerator.ts
+++ b/src/metadataGeneration/metadataGenerator.ts
@@ -61,11 +61,33 @@ export class MetadataGenerator {
     this.circularDependencyResolvers.push(callback);
   }
 
+  private getInheritedMethods(controller: Tsoa.Controller, controllerList: Tsoa.Controller[]): Tsoa.Method[] {
+    const inheritedClasses = controllerList.filter(({ name }) => controller.inheritanceList.includes(name));
+
+    // Crawl the inherited classes for decorated methods, filter out any that exist on the current controller
+    const currentMethodPaths = controller.methods.map(method => method.path);
+    const inheritedMethods: Tsoa.Method[] = inheritedClasses
+      .reduce((acc, item) => [...acc, ...item.methods], [])
+      .filter(method => !currentMethodPaths.includes(method.path));
+
+    return inheritedClasses.reduce((acc, item) => [...acc, ...this.getInheritedMethods(item, controllerList)], inheritedMethods);
+  }
+
   private buildControllers() {
-    return this.nodes
+    const controllerGenerators: ControllerGenerator[] = this.nodes
       .filter((node) => node.kind === ts.SyntaxKind.ClassDeclaration && this.IsExportedNode(node as ts.ClassDeclaration))
-      .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this))
-      .filter((generator) => generator.IsValid())
+      .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this));
+
+    // Need a list of all controllers with decorated methods for determining heritage on valid controllers.
+    const allControllers: Tsoa.Controller[] = controllerGenerators.map((generator) => generator.Generate());
+
+    const validControllers: Tsoa.Controller[] = controllerGenerators
+      .filter((controllerGenerator: ControllerGenerator) => controllerGenerator.IsValid())
       .map((generator) => generator.Generate());
+
+    // Attach all decorated methods, including those on parent classes, to the controller.
+    validControllers.forEach(controller => controller.methods.push(...this.getInheritedMethods(controller, allControllers)));
+
+    return validControllers;
   }
 }

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 import { getDecorators } from './../utils/decoratorUtils';
 import { getJSDocComment, getJSDocDescription, isExistJSDocTag } from './../utils/jsDocUtils';
+import { getCustomAttributes } from './customAttribute';
 import { GenerateMetadataError } from './exceptions';
 import { getInitializerValue } from './initializer-value';
 import { MetadataGenerator } from './metadataGenerator';
@@ -44,6 +45,7 @@ export class MethodGenerator {
     responses.push(this.getMethodSuccessResponse(type));
 
     return {
+      customAttributes: this.getCustomAttributes(),
       deprecated: isExistJSDocTag(this.node, (tag) => tag.tagName.text === 'deprecated'),
       description: getJSDocDescription(this.node),
       isHidden: this.getIsHidden(),
@@ -81,6 +83,15 @@ export class MethodGenerator {
       throw new GenerateMetadataError(`Choose either during @Body or @BodyProp in '${this.getCurrentLocation()}' method.`);
     }
     return parameters;
+  }
+
+  private getCustomAttributes() {
+    const customAttributeDecorators = this.getDecoratorsByIdentifier(this.node, 'CustomAttribute');
+    if (!customAttributeDecorators || !customAttributeDecorators.length) {
+      return [];
+    }
+
+    return getCustomAttributes(customAttributeDecorators);
   }
 
   private getCurrentLocation() {

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -18,6 +18,7 @@ export class MethodGenerator {
     private readonly current: MetadataGenerator,
     private readonly parentTags?: string[],
     private readonly parentSecurity?: Tsoa.Security[],
+    private readonly genericTypeMap?: Tsoa.GenericTypeMap,
     ) {
     this.processMethodDecorators();
   }
@@ -38,7 +39,7 @@ export class MethodGenerator {
       const implicitType = typeChecker.getReturnTypeOfSignature(signature!);
       nodeType = typeChecker.typeToTypeNode(implicitType) as ts.TypeNode;
     }
-    const type = new TypeResolver(nodeType, this.current).resolve();
+    const type = new TypeResolver(nodeType, this.current, undefined, true, this.genericTypeMap).resolve();
     const responses = this.getMethodResponses();
     responses.push(this.getMethodSuccessResponse(type));
 

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -5,6 +5,7 @@ export namespace Tsoa {
   }
 
   export interface Controller {
+    inheritanceList: string[];
     location: string;
     methods: Method[];
     name: string;

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -5,7 +5,6 @@ export namespace Tsoa {
   }
 
   export interface Controller {
-    inheritanceList: string[];
     location: string;
     methods: Method[];
     name: string;
@@ -97,4 +96,6 @@ export namespace Tsoa {
   export interface ReferenceTypeMap {
     [refName: string]: Tsoa.ReferenceType;
   }
+
+  export type GenericTypeMap = Map<string, Map<string, string>>
 }

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -12,6 +12,7 @@ export namespace Tsoa {
   }
 
   export interface Method {
+    customAttributes: CustomAttribute[];
     deprecated?: boolean;
     description?: string;
     method: 'get' | 'post' | 'put' | 'delete' | 'options' | 'head' | 'patch' | 'head';
@@ -25,7 +26,6 @@ export namespace Tsoa {
     summary?: string;
     isHidden: boolean;
     operationId?: string;
-
   }
 
   export interface Parameter {
@@ -50,6 +50,11 @@ export namespace Tsoa {
 
   export interface Security {
     [key: string]: string[];
+  }
+
+  export interface CustomAttribute {
+    key: string;
+    value: string | any[] | object;
   }
 
   export interface Response {

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -27,6 +27,7 @@ export class TypeResolver {
     private readonly current: MetadataGenerator,
     private readonly parentNode?: ts.Node,
     private readonly extractEnum = true,
+    private readonly genericTypeMap?: Tsoa.GenericTypeMap,
   ) { }
 
   public resolve(): Tsoa.Type {
@@ -87,12 +88,12 @@ export class TypeResolver {
       if (typeReference.typeName.text === 'Array' && typeReference.typeArguments && typeReference.typeArguments.length === 1) {
         return {
           dataType: 'array',
-          elementType: new TypeResolver(typeReference.typeArguments[0], this.current).resolve(),
+          elementType: new TypeResolver(typeReference.typeArguments[0], this.current, undefined, true, this.genericTypeMap).resolve(),
         } as Tsoa.ArrayType;
       }
 
       if (typeReference.typeName.text === 'Promise' && typeReference.typeArguments && typeReference.typeArguments.length === 1) {
-        return new TypeResolver(typeReference.typeArguments[0], this.current).resolve();
+        return new TypeResolver(typeReference.typeArguments[0], this.current, undefined, true, this.genericTypeMap).resolve();
       }
 
       if (typeReference.typeName.text === 'String') {
@@ -124,6 +125,10 @@ export class TypeResolver {
     const primitiveType = syntaxKindMap[typeNode.kind];
     if (!primitiveType) { return; }
 
+    return this.getPrimitiveTypeByString(primitiveType, parentNode);
+  }
+
+  private getPrimitiveTypeByString(primitiveType: string, parentNode?: ts.Node): Tsoa.Type | undefined {
     if (primitiveType === 'number') {
       if (!parentNode) {
         return { dataType: 'double' };
@@ -249,6 +254,11 @@ export class TypeResolver {
         return existingType;
       }
 
+      const resolvedGenericType = this.resolveGenericTypeFromMap(refNameWithGenerics);
+      if (resolvedGenericType) {
+        return resolvedGenericType;
+      }
+
       const referenceEnumType = this.getEnumerateType(type, true) as Tsoa.ReferenceType;
       if (referenceEnumType) {
         localReferenceTypeCache[refNameWithGenerics] = referenceEnumType;
@@ -287,6 +297,43 @@ export class TypeResolver {
       console.error(`There was a problem resolving type of '${this.getTypeName(typeName, genericTypes)}'.`);
       throw err;
     }
+  }
+
+  private resolveGenericTypeFromMap(typeName: string, typeNode: ts.Node = this.typeNode) {
+    if (!this.genericTypeMap) return undefined;
+
+    // traverse the syntax tree upwards until we find a class declaration that has an entry in the
+    // passed in genericTypeMap, with a corresponding mapping of a generic template variable to a 
+    // resolved type. if found, return it. if we hit the top of the tree without finding it, return
+    // undefined
+
+    if (typeNode.kind === ts.SyntaxKind.ClassDeclaration) {
+      const baseClass = typeNode as ts.ClassDeclaration;
+
+      if (baseClass && baseClass.name) {
+        const baseClassMap = this.genericTypeMap.get(baseClass.name.text);
+
+        if (baseClassMap) {
+          const resolvedTypeName = baseClassMap.get(typeName);
+
+          if (resolvedTypeName) {
+            const primitiveKind = Object.values(syntaxKindMap).find(v => v.toLowerCase() === resolvedTypeName.toLowerCase());
+
+            if (primitiveKind) {
+              return this.getPrimitiveTypeByString(primitiveKind);
+            }
+
+            return localReferenceTypeCache[resolvedTypeName];
+          }
+        }
+      }
+    }
+    
+    if (typeNode.parent) {
+      return this.resolveGenericTypeFromMap(typeName, typeNode.parent);
+    }
+
+    return undefined;
   }
 
   private resolveFqTypeName(type: ts.EntityName): string {

--- a/src/module/generate-swagger-spec.ts
+++ b/src/module/generate-swagger-spec.ts
@@ -22,6 +22,7 @@ export const generateSwaggerSpec = async (
       ignorePaths,
     ).Generate();
   }
+
   const spec = new SpecGenerator(metadata, config).GetSpec();
 
   const exists = await fsExists(config.outputDirectory);

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -127,6 +127,9 @@ export class SpecGenerator {
     if (pathMethod.parameters.filter((p: Swagger.BaseParameter) => p.in === 'body').length > 1) {
       throw new Error('Only one body parameter allowed per controller method.');
     }
+
+    // Apply custom attributes
+    method.customAttributes.forEach((customAttr) => pathMethod[customAttr.key] = customAttr.value);
   }
 
   private buildBodyPropParameter(controllerName: string, method: Tsoa.Method) {

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -138,6 +138,8 @@ export namespace Swagger {
     schemes?: Protocol[];
     deprecated?: boolean;
     security?: Security[];
+    // Used to apply custom attributes to paths
+    [key: string]: any;
   }
 
   export interface Response {

--- a/tests/fixtures/controllers/baseController.ts
+++ b/tests/fixtures/controllers/baseController.ts
@@ -17,8 +17,8 @@ class SuperBaseController extends Controller {
 
 export class BaseController extends SuperBaseController{
   @Get('Get')
-  public async getMethod(): Promise<IncorrectResponseType> {
-    return { wrong: true}
+  public async getMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
   }
 
   @Post('Post')
@@ -32,11 +32,7 @@ export class BaseController extends SuperBaseController{
   }
 
   @Put('OverwrittenMethod')
-  public async thisMethodShouldBeOverwritten(): Promise<IncorrectResponseType> {
-    return { wrong: true };
+  public async putMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
   }
-}
-interface IncorrectResponseType {
-  wrong?: boolean;
-  [index: string]: any;
 }

--- a/tests/fixtures/controllers/baseController.ts
+++ b/tests/fixtures/controllers/baseController.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Put,
+} from '../../../src';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+class SuperBaseController extends Controller {
+  @Patch('SuperBasePatch')
+  public async superBasePatch(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}
+
+export class BaseController extends SuperBaseController{
+  @Get('Get')
+  public async getMethod(): Promise<IncorrectResponseType> {
+    return { wrong: true}
+  }
+
+  @Post('Post')
+  public async postMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Get('Base')
+  public async baseMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async thisMethodShouldBeOverwritten(): Promise<IncorrectResponseType> {
+    return { wrong: true };
+  }
+}
+interface IncorrectResponseType {
+  wrong?: boolean;
+  [index: string]: any;
+}

--- a/tests/fixtures/controllers/duplicateMethodController.ts
+++ b/tests/fixtures/controllers/duplicateMethodController.ts
@@ -1,14 +1,15 @@
 import {
   Get,
   Patch,
+  Put,
   Route,
 } from '../../../src';
 import { ModelService } from '../services/modelService';
 import { TestModel } from '../testModel';
 import { BaseController } from './baseController';
 
-@Route('InheritedMethodTest')
-export class InheritanceMethodController extends BaseController {
+@Route('DuplicateMethodTest')
+export class DuplicateMethodController extends BaseController {
   @Get('Get')
   public async getMethod(): Promise<TestModel> {
       return new ModelService().getModel();
@@ -16,6 +17,11 @@ export class InheritanceMethodController extends BaseController {
 
   @Patch('Patch')
   public async patchMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async differentMethodName(): Promise<TestModel> {
     return new ModelService().getModel();
   }
 }

--- a/tests/fixtures/controllers/inheritanceMethodController.ts
+++ b/tests/fixtures/controllers/inheritanceMethodController.ts
@@ -1,0 +1,27 @@
+import {
+  Get,
+  Patch,
+  Put,
+  Route,
+} from '../../../src';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+import { BaseController } from './baseController';
+
+@Route('InheritedMethodTest')
+export class InheritanceMethodController extends BaseController {
+  @Get('Get')
+  public async getMethod(): Promise<TestModel> {
+      return new ModelService().getModel();
+  }
+
+  @Patch('Patch')
+  public async patchMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async putMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -1,15 +1,16 @@
 import {
-    Controller,
-    Delete,
-    Get,
-    Patch,
-    Post,
-    Put,
-    Response,
-    Route,
-    Security,
-    SuccessResponse,
-    Tags,
+  Controller,
+  CustomAttribute,
+  Delete,
+  Get,
+  Patch,
+  Post,
+  Put,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
 } from '../../../src';
 import { ModelService } from '../services/modelService';
 import { ErrorResponseModel, TestModel } from '../testModel';
@@ -97,6 +98,15 @@ export class MethodController extends Controller {
     @Get('OauthAndAPIkeySecurity')
     public async oauthAndAPIkeySecurity(): Promise<TestModel> {
         return new ModelService().getModel();
+    }
+
+    @CustomAttribute('attKey', 'attValue')
+    @CustomAttribute('attKey1', { test: 'testVal' })
+    @CustomAttribute('attKey2', ['y0', 'y1'])
+    @CustomAttribute('attKey3', [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }])
+    @Get('CustomAttribute')
+    public async customAttribute(): Promise<TestModel> {
+      return new ModelService().getModel();
     }
 
     /**

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -6,6 +6,7 @@ import '../controllers/rootController';
 import '../controllers/deleteController';
 import '../controllers/getController';
 import '../controllers/headController';
+import '../controllers/inheritanceMethodController';
 import '../controllers/patchController';
 import '../controllers/postController';
 import '../controllers/putController';

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -16,11 +16,8 @@ describe('Metadata generation', () => {
 
   describe('InheritedMethodGenerator', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const duplicateGenerator = new MetadataGenerator('./tests/fixtures/controllers/duplicateMethodController.ts');
     const controller = parameterMetadata.controllers[0];
-
-    it('should inherit from BaseController', () => {
-      expect(controller.inheritanceList[0]).to.equal('BaseController');
-    });
 
     it('should inherit postMethod from BaseController', () => {
       const method = controller.methods.find(m => m.name === 'postMethod');
@@ -44,6 +41,10 @@ describe('Metadata generation', () => {
       expect(method.method).to.equal('patch');
       expect(method.path).to.equal('SuperBasePatch');
       expect(method.name).to.equal('superBasePatch');
+    });
+
+    it('should error if a duplicate method is found', () => {
+      expect(() => duplicateGenerator.Generate()).to.throw(/Duplicate method for path '.*' was found/);
     });
   });
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -14,6 +14,39 @@ describe('Metadata generation', () => {
     });
   });
 
+  describe('InheritedMethodGenerator', () => {
+    const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const controller = parameterMetadata.controllers[0];
+
+    it('should inherit from BaseController', () => {
+      expect(controller.inheritanceList[0]).to.equal('BaseController');
+    });
+
+    it('should inherit postMethod from BaseController', () => {
+      const method = controller.methods.find(m => m.name === 'postMethod');
+
+      if (!method) {
+        throw new Error('Method postMethod not defined!');
+      }
+
+      expect(method.method).to.equal('post');
+      expect(method.path).to.equal('Post');
+      expect(method.name).to.equal('postMethod');
+    });
+
+    it('should inherit superBasePatch from SuperBaseController', () => {
+      const method = controller.methods.find(m => m.name === 'superBasePatch');
+
+      if (!method) {
+        throw new Error('Method superBasePatch not defined!');
+      }
+
+      expect(method.method).to.equal('patch');
+      expect(method.path).to.equal('SuperBasePatch');
+      expect(method.name).to.equal('superBasePatch');
+    });
+  });
+
   describe('MethodGenerator', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/methodController.ts').Generate();
     const controller = parameterMetadata.controllers[0];

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -54,7 +54,7 @@ describe('Metadata generation', () => {
     const definedMethods = [
       'getMethod', 'postMethod', 'patchMethod', 'putMethod', 'deleteMethod',
       'description', 'tags', 'multiResponse', 'successResponse', 'oauthOrAPIkeySecurity',
-      'apiSecurity', 'oauthSecurity', 'deprecatedMethod', 'summaryMethod',
+      'apiSecurity', 'oauthSecurity', 'customAttribute', 'deprecatedMethod', 'summaryMethod',
       'oauthAndAPIkeySecurity', 'returnAnyType'];
 
     it('should only generate the defined methods', () => {
@@ -217,6 +217,25 @@ describe('Metadata generation', () => {
       }
       expect(method.security[0].tsoa_auth).to.deep.equal(['write:pets', 'read:pets']);
       expect(method.security[0].api_key).to.deep.equal([]);
+    });
+
+    it('should generate all custom attributes', () => {
+      const method = controller.methods.find(m => m.name === 'customAttribute');
+      if (!method) {
+        throw new Error('Method customAttribute not defined!');
+      }
+      if (!method.customAttributes || method.customAttributes.length <= 0) {
+        throw new Error('No custom attribute decorators defined!');
+      }
+
+      const expectedCustomAttributes = [
+        { key: 'attKey', value: 'attValue' },
+        { key: 'attKey1', value: { test: 'testVal' } },
+        { key: 'attKey2', value: [ 'y0', 'y1' ] },
+        { key: 'attKey3', value: [ { y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' } ] },
+      ];
+
+      expect(method.customAttributes).to.deep.equal(expectedCustomAttributes)
     });
 
     it('should generate deprecated method true', () => {

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -8,7 +8,6 @@ describe('Schema details generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
   const spec = new SpecGenerator(metadata, getDefaultOptions()).GetSpec();
 
-
   if (!spec.info) { throw new Error('No spec info.'); }
   if (!spec.info.title) { throw new Error('No spec info title.'); }
   if (!spec.info.description) { throw new Error('No spec info description.'); }
@@ -51,28 +50,4 @@ describe('Inherited method schema generation', () => {
     expect(spec.paths).to.have.property('/InheritedMethodTest/Post');
     expect(spec.paths).to.have.property('/InheritedMethodTest/SuperBasePatch');
   });
-
-  const overwrittenPutPath = spec.paths['/InheritedMethodTest/OverwrittenMethod'];
-  const overwrittenGetPath = spec.paths['/InheritedMethodTest/Get'];
-
-  it('child should overwrite inherited put method', () => {
-    expect(overwrittenPutPath).to.have.nested.property('put.operationId');
-    expect(overwrittenPutPath).to.have.nested.property(
-      'put.operationId',
-      'PutMethod',
-    );
-  });
-
-  it('child should overwrite inherited get method', () => {
-    expect(spec.paths).to.have.property('/InheritedMethodTest/Get');
-    expect(overwrittenGetPath).to.have.nested.property(
-      'get.operationId',
-      'GetMethod',
-    );
-  })
-
-  it('children should overwrite their inherited method response types', () => {
-    expect(overwrittenPutPath).to.have.nested.property('put.responses.200.schema.$ref', "#/definitions/TestModel")
-    expect(overwrittenGetPath).to.have.nested.property('get.responses.200.schema.$ref', "#/definitions/TestModel")
-  })
 });

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -51,3 +51,30 @@ describe('Inherited method schema generation', () => {
     expect(spec.paths).to.have.property('/InheritedMethodTest/SuperBasePatch');
   });
 });
+
+describe('Custom Attribute schema generation', () => {
+  const metadata = new MetadataGenerator('./tests/fixtures/controllers/methodController').Generate();
+  const spec = new SpecGenerator(metadata, getDefaultOptions()).GetSpec();
+
+  if (!spec.paths) { throw new Error('No spec info.'); }
+
+  const customAttributePath = spec.paths['/MethodTest/CustomAttribute'].get;
+
+  if (!customAttributePath) { throw new Error('customAttribute method was not rendered'); }
+
+  // Verify that custom properties are appened to the path
+  expect(customAttributePath).to.have.property('attKey');
+  expect(customAttributePath).to.have.property('attKey1');
+  expect(customAttributePath).to.have.property('attKey2');
+  expect(customAttributePath).to.have.property('attKey3');
+
+  // Verify that custom attributes have correct values
+  expect(customAttributePath.attKey).to.deep.equal('attValue');
+  expect(customAttributePath.attKey1).to.deep.equal({ test: 'testVal' });
+  expect(customAttributePath.attKey2).to.deep.equal(['y0', 'y1']);
+  expect(customAttributePath.attKey3).to.deep.equal([
+    { y0: 'yt0',  y1: 'yt1' },
+    { y2: 'yt2' },
+  ]);
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "target": "es5",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "es2017"
         ],
         "typeRoots": [
             "node_modules/@types",


### PR DESCRIPTION
Allow for controllers to extend each other via TypeScript `extends`, inheriting all decorated methods from ancestors in the inheritance chain.

**controllers/baseController.ts**
```
export class BaseController extends SuperBaseController{
  @Get('Get')
  public async getMethod(): Promise<Model> {
    return
  }
}
```

**controllers/userController.ts**
```
export class UserController extends BaseController {}
```

UserController will have the `Get` method