### PR TITLE
Controller Inheritance and Generic Resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsoa",
-  "version": "2.3.7",
+  "version": "2.3.81",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
     },
     "@types/connect": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/body-parser": "^1.17.0",
-    "@types/chai": "^3.5.2",
+    "@types/chai": "^4.1.7",
     "@types/express": "^4.16.0",
     "@types/handlebars": "^4.0.37",
     "@types/hapi": "^17.6.1",
@@ -69,7 +69,7 @@
     "@types/yamljs": "^0.2.30",
     "@types/yargs": "^8.0.3",
     "body-parser": "^1.18.3",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chalk": "^2.4.1",
     "copyfiles": "^1.2.0",
     "cross-env": "^5.1.6",

--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -35,6 +35,7 @@ export class ControllerGenerator {
     const sourceFile = this.node.parent.getSourceFile();
 
     return {
+      inheritanceList: this.getInheritanceList(),
       location: sourceFile.fileName,
       methods: this.buildMethods(),
       name: this.node.name.text,
@@ -87,5 +88,15 @@ export class ControllerGenerator {
     }
 
     return getSecurities(securityDecorators);
+  }
+
+  private getInheritanceList(): string[] {
+    if (!this.node.heritageClauses || !this.node.heritageClauses.length) {
+      return [];
+    }
+
+    return this.node.heritageClauses
+      .reduce((acc, node) => [...acc, ...node.types], [])
+      .map((nodeType: any) => nodeType.expression.escapedText);
   }
 }

--- a/src/metadataGeneration/metadataGenerator.ts
+++ b/src/metadataGeneration/metadataGenerator.ts
@@ -61,11 +61,33 @@ export class MetadataGenerator {
     this.circularDependencyResolvers.push(callback);
   }
 
+  private getInheritedMethods(controller: Tsoa.Controller, controllerList: Tsoa.Controller[]): Tsoa.Method[] {
+    const inheritedClasses = controllerList.filter(({ name }) => controller.inheritanceList.includes(name));
+
+    // Crawl the inherited classes for decorated methods, filter out any that exist on the current controller
+    const currentMethodPaths = controller.methods.map(method => method.path);
+    const inheritedMethods: Tsoa.Method[] = inheritedClasses
+      .reduce((acc, item) => [...acc, ...item.methods], [])
+      .filter(method => !currentMethodPaths.includes(method.path));
+
+    return inheritedClasses.reduce((acc, item) => [...acc, ...this.getInheritedMethods(item, controllerList)], inheritedMethods);
+  }
+
   private buildControllers() {
-    return this.nodes
+    const controllerGenerators: ControllerGenerator[] = this.nodes
       .filter((node) => node.kind === ts.SyntaxKind.ClassDeclaration && this.IsExportedNode(node as ts.ClassDeclaration))
-      .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this))
-      .filter((generator) => generator.IsValid())
+      .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this));
+
+    // Need a list of all controllers with decorated methods for determining heritage on valid controllers.
+    const allControllers: Tsoa.Controller[] = controllerGenerators.map((generator) => generator.Generate());
+
+    const validControllers: Tsoa.Controller[] = controllerGenerators
+      .filter((controllerGenerator: ControllerGenerator) => controllerGenerator.IsValid())
       .map((generator) => generator.Generate());
+
+    // Attach all decorated methods, including those on parent classes, to the controller.
+    validControllers.forEach(controller => controller.methods.push(...this.getInheritedMethods(controller, allControllers)));
+
+    return validControllers;
   }
 }

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -18,6 +18,7 @@ export class MethodGenerator {
     private readonly current: MetadataGenerator,
     private readonly parentTags?: string[],
     private readonly parentSecurity?: Tsoa.Security[],
+    private readonly genericTypeMap?: Tsoa.GenericTypeMap,
     ) {
     this.processMethodDecorators();
   }
@@ -38,7 +39,7 @@ export class MethodGenerator {
       const implicitType = typeChecker.getReturnTypeOfSignature(signature!);
       nodeType = typeChecker.typeToTypeNode(implicitType) as ts.TypeNode;
     }
-    const type = new TypeResolver(nodeType, this.current).resolve();
+    const type = new TypeResolver(nodeType, this.current, undefined, true, this.genericTypeMap).resolve();
     const responses = this.getMethodResponses();
     responses.push(this.getMethodSuccessResponse(type));
 

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -5,6 +5,7 @@ export namespace Tsoa {
   }
 
   export interface Controller {
+    inheritanceList: string[];
     location: string;
     methods: Method[];
     name: string;

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -5,7 +5,6 @@ export namespace Tsoa {
   }
 
   export interface Controller {
-    inheritanceList: string[];
     location: string;
     methods: Method[];
     name: string;
@@ -97,4 +96,6 @@ export namespace Tsoa {
   export interface ReferenceTypeMap {
     [refName: string]: Tsoa.ReferenceType;
   }
+
+  export type GenericTypeMap = Map<string, Map<string, string>>
 }

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -125,7 +125,7 @@ export class TypeResolver {
     const primitiveType = syntaxKindMap[typeNode.kind];
     if (!primitiveType) { return; }
 
-    return this.getPrimitiveTypeByString(primitiveType, parentNode)
+    return this.getPrimitiveTypeByString(primitiveType, parentNode);
   }
 
   private getPrimitiveTypeByString(primitiveType: string, parentNode?: ts.Node): Tsoa.Type | undefined {
@@ -254,9 +254,9 @@ export class TypeResolver {
         return existingType;
       }
 
-      const resolvedGenericType = this.resolveGenericTypeFromMap(refNameWithGenerics)
+      const resolvedGenericType = this.resolveGenericTypeFromMap(refNameWithGenerics);
       if (resolvedGenericType) {
-        return resolvedGenericType
+        return resolvedGenericType;
       }
 
       const referenceEnumType = this.getEnumerateType(type, true) as Tsoa.ReferenceType;
@@ -300,7 +300,7 @@ export class TypeResolver {
   }
 
   private resolveGenericTypeFromMap(typeName: string, typeNode: ts.Node = this.typeNode) {
-    if (!this.genericTypeMap) return undefined
+    if (!this.genericTypeMap) return undefined;
 
     // traverse the syntax tree upwards until we find a class declaration that has an entry in the
     // passed in genericTypeMap, with a corresponding mapping of a generic template variable to a 
@@ -308,27 +308,32 @@ export class TypeResolver {
     // undefined
 
     if (typeNode.kind === ts.SyntaxKind.ClassDeclaration) {
-      const baseClass = typeNode as ts.ClassDeclaration
+      const baseClass = typeNode as ts.ClassDeclaration;
+
       if (baseClass && baseClass.name) {
-        const baseClassMap = this.genericTypeMap.get(baseClass.name.text)
+        const baseClassMap = this.genericTypeMap.get(baseClass.name.text);
+
         if (baseClassMap) {
-          const resolvedTypeName = baseClassMap.get(typeName)
+          const resolvedTypeName = baseClassMap.get(typeName);
+
           if (resolvedTypeName) {
-            const primitiveKind = Object.values(syntaxKindMap).find(v => v.toLowerCase() === resolvedTypeName.toLowerCase())
+            const primitiveKind = Object.values(syntaxKindMap).find(v => v.toLowerCase() === resolvedTypeName.toLowerCase());
+
             if (primitiveKind) {
-              return this.getPrimitiveTypeByString(primitiveKind)
+              return this.getPrimitiveTypeByString(primitiveKind);
             }
-            return localReferenceTypeCache[resolvedTypeName]
+
+            return localReferenceTypeCache[resolvedTypeName];
           }
         }
       }
     }
     
     if (typeNode.parent) {
-      return this.resolveGenericTypeFromMap(typeName, typeNode.parent)
+      return this.resolveGenericTypeFromMap(typeName, typeNode.parent);
     }
 
-    return undefined
+    return undefined;
   }
 
   private resolveFqTypeName(type: ts.EntityName): string {

--- a/src/module/generate-swagger-spec.ts
+++ b/src/module/generate-swagger-spec.ts
@@ -22,6 +22,7 @@ export const generateSwaggerSpec = async (
       ignorePaths,
     ).Generate();
   }
+
   const spec = new SpecGenerator(metadata, config).GetSpec();
 
   const exists = await fsExists(config.outputDirectory);

--- a/tests/fixtures/controllers/baseController.ts
+++ b/tests/fixtures/controllers/baseController.ts
@@ -17,8 +17,8 @@ class SuperBaseController extends Controller {
 
 export class BaseController extends SuperBaseController{
   @Get('Get')
-  public async getMethod(): Promise<IncorrectResponseType> {
-    return { wrong: true}
+  public async getMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
   }
 
   @Post('Post')
@@ -32,11 +32,7 @@ export class BaseController extends SuperBaseController{
   }
 
   @Put('OverwrittenMethod')
-  public async thisMethodShouldBeOverwritten(): Promise<IncorrectResponseType> {
-    return { wrong: true };
+  public async putMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
   }
-}
-interface IncorrectResponseType {
-  wrong?: boolean;
-  [index: string]: any;
 }

--- a/tests/fixtures/controllers/baseController.ts
+++ b/tests/fixtures/controllers/baseController.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Put,
+} from '../../../src';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+class SuperBaseController extends Controller {
+  @Patch('SuperBasePatch')
+  public async superBasePatch(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}
+
+export class BaseController extends SuperBaseController{
+  @Get('Get')
+  public async getMethod(): Promise<IncorrectResponseType> {
+    return { wrong: true}
+  }
+
+  @Post('Post')
+  public async postMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Get('Base')
+  public async baseMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async thisMethodShouldBeOverwritten(): Promise<IncorrectResponseType> {
+    return { wrong: true };
+  }
+}
+interface IncorrectResponseType {
+  wrong?: boolean;
+  [index: string]: any;
+}

--- a/tests/fixtures/controllers/duplicateMethodController.ts
+++ b/tests/fixtures/controllers/duplicateMethodController.ts
@@ -1,14 +1,15 @@
 import {
   Get,
   Patch,
+  Put,
   Route,
 } from '../../../src';
 import { ModelService } from '../services/modelService';
 import { TestModel } from '../testModel';
 import { BaseController } from './baseController';
 
-@Route('InheritedMethodTest')
-export class InheritanceMethodController extends BaseController {
+@Route('DuplicateMethodTest')
+export class DuplicateMethodController extends BaseController {
   @Get('Get')
   public async getMethod(): Promise<TestModel> {
       return new ModelService().getModel();
@@ -16,6 +17,11 @@ export class InheritanceMethodController extends BaseController {
 
   @Patch('Patch')
   public async patchMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async differentMethodName(): Promise<TestModel> {
     return new ModelService().getModel();
   }
 }

--- a/tests/fixtures/controllers/inheritanceMethodController.ts
+++ b/tests/fixtures/controllers/inheritanceMethodController.ts
@@ -1,0 +1,27 @@
+import {
+  Get,
+  Patch,
+  Put,
+  Route,
+} from '../../../src';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+import { BaseController } from './baseController';
+
+@Route('InheritedMethodTest')
+export class InheritanceMethodController extends BaseController {
+  @Get('Get')
+  public async getMethod(): Promise<TestModel> {
+      return new ModelService().getModel();
+  }
+
+  @Patch('Patch')
+  public async patchMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Put('OverwrittenMethod')
+  public async putMethod(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -6,6 +6,7 @@ import '../controllers/rootController';
 import '../controllers/deleteController';
 import '../controllers/getController';
 import '../controllers/headController';
+import '../controllers/inheritanceMethodController';
 import '../controllers/patchController';
 import '../controllers/postController';
 import '../controllers/putController';

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -16,11 +16,8 @@ describe('Metadata generation', () => {
 
   describe('InheritedMethodGenerator', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const duplicateGenerator = new MetadataGenerator('./tests/fixtures/controllers/duplicateMethodController.ts');
     const controller = parameterMetadata.controllers[0];
-
-    it('should inherit from BaseController', () => {
-      expect(controller.inheritanceList[0]).to.equal('BaseController');
-    });
 
     it('should inherit postMethod from BaseController', () => {
       const method = controller.methods.find(m => m.name === 'postMethod');
@@ -44,6 +41,10 @@ describe('Metadata generation', () => {
       expect(method.method).to.equal('patch');
       expect(method.path).to.equal('SuperBasePatch');
       expect(method.name).to.equal('superBasePatch');
+    });
+
+    it('should error if a duplicate method is found', () => {
+      expect(() => duplicateGenerator.Generate()).to.throw(/Duplicate method for path '.*' was found/);
     });
   });
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -14,6 +14,39 @@ describe('Metadata generation', () => {
     });
   });
 
+  describe('InheritedMethodGenerator', () => {
+    const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const controller = parameterMetadata.controllers[0];
+
+    it('should inherit from BaseController', () => {
+      expect(controller.inheritanceList[0]).to.equal('BaseController');
+    });
+
+    it('should inherit postMethod from BaseController', () => {
+      const method = controller.methods.find(m => m.name === 'postMethod');
+
+      if (!method) {
+        throw new Error('Method postMethod not defined!');
+      }
+
+      expect(method.method).to.equal('post');
+      expect(method.path).to.equal('Post');
+      expect(method.name).to.equal('postMethod');
+    });
+
+    it('should inherit superBasePatch from SuperBaseController', () => {
+      const method = controller.methods.find(m => m.name === 'superBasePatch');
+
+      if (!method) {
+        throw new Error('Method superBasePatch not defined!');
+      }
+
+      expect(method.method).to.equal('patch');
+      expect(method.path).to.equal('SuperBasePatch');
+      expect(method.name).to.equal('superBasePatch');
+    });
+  });
+
   describe('MethodGenerator', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/methodController.ts').Generate();
     const controller = parameterMetadata.controllers[0];

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -8,7 +8,6 @@ describe('Schema details generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
   const spec = new SpecGenerator(metadata, getDefaultOptions()).GetSpec();
 
-
   if (!spec.info) { throw new Error('No spec info.'); }
   if (!spec.info.title) { throw new Error('No spec info title.'); }
   if (!spec.info.description) { throw new Error('No spec info description.'); }
@@ -51,28 +50,4 @@ describe('Inherited method schema generation', () => {
     expect(spec.paths).to.have.property('/InheritedMethodTest/Post');
     expect(spec.paths).to.have.property('/InheritedMethodTest/SuperBasePatch');
   });
-
-  const overwrittenPutPath = spec.paths['/InheritedMethodTest/OverwrittenMethod'];
-  const overwrittenGetPath = spec.paths['/InheritedMethodTest/Get'];
-
-  it('child should overwrite inherited put method', () => {
-    expect(overwrittenPutPath).to.have.nested.property('put.operationId');
-    expect(overwrittenPutPath).to.have.nested.property(
-      'put.operationId',
-      'PutMethod',
-    );
-  });
-
-  it('child should overwrite inherited get method', () => {
-    expect(spec.paths).to.have.property('/InheritedMethodTest/Get');
-    expect(overwrittenGetPath).to.have.nested.property(
-      'get.operationId',
-      'GetMethod',
-    );
-  })
-
-  it('children should overwrite their inherited method response types', () => {
-    expect(overwrittenPutPath).to.have.nested.property('put.responses.200.schema.$ref', "#/definitions/TestModel")
-    expect(overwrittenGetPath).to.have.nested.property('get.responses.200.schema.$ref', "#/definitions/TestModel")
-  })
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "target": "es5",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "es2017"
         ],
         "typeRoots": [
             "node_modules/@types",


### PR DESCRIPTION
Allow for controllers to extend each other via TypeScript `extends`, inheriting all decorated methods from ancestors in the inheritance chain.

**controllers/superBaseController.ts**
```typescript
export class SuperBaseController<T>{
  @Post()
  public async postMethod(): Promise<T> { return }
}
```

**controllers/baseController.ts**
```typescript
export class BaseController<T> extends SuperBaseController<T>{
  @Get()
  public async getMethod(): Promise<T> { return }
}
```

**controllers/userController.ts**
```typescript
export class UserController extends BaseController<Model> {}
```

UserController will have the both the 'Post' and 'Get' method