### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsoa",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -89,12 +89,6 @@
         "@types/node": "*",
         "@types/range-parser": "*"
       }
-    },
-    "@types/handlebars": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
-      "dev": true
     },
     "@types/hapi": {
       "version": "17.6.2",


### PR DESCRIPTION
The generated `package-lock.json` file has changed due to 7c9dbd0798340c04721dfdca3f2fd31d8be3aca8 and 
ce6245770c9c9e25b78bdf54f6f635b7f5f7f027 but it hasn't been updated in the repository. This changes that.