### PR TITLE
fix: disable eslint along with tslint in templates

### DIFF
--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 {{#if canImportByAlias}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -1,5 +1,6 @@
 // TODO: Replace this with HAPI middleware stuff
 /* tslint:disable */
+/* eslint-disable */
 {{#if canImportByAlias}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}

--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 {{#if canImportByAlias}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}


### PR DESCRIPTION
some are using eslint instead of tslint, there shouldn't be any negative side effects of disabling both in the default templates