### PR TITLE
Allow explicitly typing the SuccessResponse

### DIFF
--- a/src/decorators/response.ts
+++ b/src/decorators/response.ts
@@ -1,4 +1,4 @@
-export function SuccessResponse(name: string | number, description?: string): Function {
+export function SuccessResponse<T>(name: string | number, description?: string): Function {
   return () => { return; };
 }
 

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -173,7 +173,9 @@ export class MethodGenerator {
       description,
       examples,
       name,
-      schema: type,
+      schema: (expression.typeArguments && expression.typeArguments.length > 0)
+      ? new TypeResolver(expression.typeArguments[0], this.current).resolve()
+      : type,
     };
   }
 

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -71,6 +71,13 @@ export class MethodController extends Controller {
         return Promise.resolve();
     }
 
+    @SuccessResponse<TestModel>('201', 'Created')
+    @Get('typedSuccessResponse')
+    public async typedSuccessResponse(): Promise<void> {
+        this.setStatus(201);
+        return Promise.resolve();
+    }
+
     @Security('api_key')
     @Get('ApiSecurity')
     public async apiSecurity(): Promise<TestModel> {

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -19,7 +19,7 @@ describe('Metadata generation', () => {
     const controller = parameterMetadata.controllers[0];
     const definedMethods = [
       'getMethod', 'postMethod', 'patchMethod', 'putMethod', 'deleteMethod',
-      'description', 'tags', 'multiResponse', 'successResponse', 'oauthOrAPIkeySecurity',
+      'description', 'tags', 'multiResponse', 'successResponse', 'typedSuccessResponse', 'oauthOrAPIkeySecurity',
       'apiSecurity', 'oauthSecurity', 'deprecatedMethod', 'summaryMethod',
       'oauthAndAPIkeySecurity', 'returnAnyType'];
 
@@ -137,6 +137,20 @@ describe('Metadata generation', () => {
       const mainResponse = method.responses[0];
       expect(mainResponse.name).to.equal('201');
       expect(mainResponse.description).to.equal('Created');
+    });
+
+    it('should generate typed success response', () => {
+      const method = controller.methods.find(m => m.name === 'typedSuccessResponse');
+      if (!method) {
+        throw new Error('Method typedSuccessResponse not defined!');
+      }
+
+      expect(method.responses.length).to.equal(1);
+
+      const mainResponse = method.responses[0];
+      expect(mainResponse.name).to.equal('201');
+      expect(mainResponse.description).to.equal('Created');
+      expect((mainResponse.schema as any).refName).to.equal("TestModel");
     });
 
     it('should generate api security', () => {


### PR DESCRIPTION
This PR addresses a use case where one would want to return a type union `A | B` documented as `SuccessResponse<A>()` and `Response<B> `from a controller.
In these cases, the function body returns a type union of `A | B` to get full TS support.
In order to document this behavior using TSOA, it should be possible to override the default return type using the SuccessResponse decorator (i.e. `@SuccessResponse<A>(...)`).

Alternatives considered:
- You can't use `@Response<A>(200, ...)` since the default behavior of TSOA is to overwrite that with the default SuccessResponse [here](https://github.com/lukeautry/tsoa/blob/master/src/metadataGeneration/methodGenerator.ts#L43).
- Returning type `A` from the controller function and returning `B as any` feels bad

Syntax: `@SuccessResponse<OverrideType>(...)`

Please note that the test right now abuses a typecast as any. If there are suggestions on how to test the behavior more efficiently I'd gladly apply that suggestion.
Also, this does not address returning a type union within one response documented as oneOf by default.