### PR TITLE
Add support for object keyword

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -70,6 +70,10 @@ export class TypeResolver {
       return { dataType: 'any' } as Tsoa.Type;
     }
 
+    if(this.typeNode.kind === ts.SyntaxKind.ObjectKeyword) {
+      return { dataType: 'object' } as Tsoa.Type;
+    }
+
     if (this.typeNode.kind !== ts.SyntaxKind.TypeReference) {
       throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[this.typeNode.kind]}`);
     }

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -37,6 +37,8 @@ export interface TestModel extends Model {
    */
   boolValue: boolean;
   boolArray: boolean[];
+  object: object;
+  objectArray: object[];
   enumValue?: EnumIndexValue;
   enumArray?: EnumIndexValue[];
   enumNumberValue?: EnumNumberValue;

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -781,6 +781,8 @@ describe('Express Server', () => {
           testSubModel2: false,
         },
       },
+      object: { foo: 'bar' },
+      objectArray: [{ foo1: 'bar1'}, { foo2: 'bar2'}],
       numberArray: [1, 2],
       numberValue: 5,
       optionalString: 'test1234',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -723,6 +723,8 @@ describe('Hapi Server', () => {
           testSubModel2: false,
         },
       },
+      object: { foo: 'bar' },
+      objectArray: [{ foo1: 'bar1' }, { foo2: 'bar2' }],
       numberArray: [1, 2],
       numberValue: 5,
       optionalString: 'test1234',

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -702,6 +702,8 @@ describe('Koa Server', () => {
       id: 1,
       modelValue: { email: 'test@test.com', id: 2 },
       modelsArray: [{ email: 'test@test.com', id: 1 }],
+      object: { foo: 'bar' },
+      objectArray: [{ foo1: 'bar1' }, { foo2: 'bar2' }],
       numberArray: [1, 2],
       numberValue: 5,
       optionalString: 'test1234',

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -39,6 +39,24 @@ describe('Definition generation', () => {
       expect(definition.properties.value.enum).to.deep.equal(['success', 'failure']);
     });
 
+    it('should generate a member of type object for object type', () => {
+      const definition = getValidatedDefinition('TestModel');
+      if (!definition.properties) { throw new Error('Definition has no properties.'); }
+      if (!definition.properties.object) { throw new Error('There was no \'object\' property.'); }
+
+      expect(definition.properties.object.type).to.equal('object');
+    });
+
+    it('should generate a member of type array with items of type object for object array type', () => {
+      const definition = getValidatedDefinition('TestModel');
+      if (!definition.properties) { throw new Error('Definition has no properties.'); }
+      if (!definition.properties.objectArray) { throw new Error('There was no \'objectArray\' property.'); }
+      if (!definition.properties.objectArray.items) { throw new Error('There was no \'items\' property.'); }
+
+      expect(definition.properties.objectArray.type).to.equal('array');
+      expect(definition.properties.objectArray.items.type).to.equal('object');
+    });
+
     it('should generate a definition description from a model jsdoc comment', () => {
       const definition = getValidatedDefinition('TestModel');
       expect(definition.description).to.equal('This is a description of a model');


### PR DESCRIPTION
This PR adds support for interfaces that look like the following
```
export interface IApiResponse {
  statusCode: number;
  body?: string;
  headers?: object;
}
```

The current functionality results in an error being thrown:
`Error: Unknown type: ObjectKeyword`

While, the expected behavior is to generate a swagger definition with the `headers` value set to the following
```
headers:
   type: object
   x-nullable: true
```