### PR TITLE
Rate limit decorator for tsoa

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "author": "Luke Autry <lukeautry@gmail.com> (http://www.lukeautry.com)",
   "license": "MIT",
   "dependencies": {
+    "express-rate-limit": "^5.0.0",
     "fs-extra": "^7.0.1",
     "handlebars": "^4.1.2",
     "lodash.indexof": "^4.0.5",

--- a/src/decorators/rateLimit.ts
+++ b/src/decorators/rateLimit.ts
@@ -1,0 +1,7 @@
+/**
+ * @param {requestCount} number Allowed request in time frame
+ * @param {searchWindow} number Time frame
+ */
+export function RateLimit(requestCount: number, searchWindow: number): Function {
+  return () => { return; };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export * from './decorators/response';
 export * from './routeGeneration/templateHelpers';
 export * from './module/generate-swagger-spec';
 export * from './module/generate-routes';
+export * from './decorators/rateLimit';

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -51,6 +51,7 @@ export class MethodGenerator {
       operationId: this.getOperationId(),
       parameters: this.buildParameters(),
       path: this.path,
+      rateLimit: this.getRateLimit(),
       responses,
       security: this.getSecurity(),
       summary: getJSDocComment(this.node, 'summary'),
@@ -218,6 +219,21 @@ export class MethodGenerator {
     const expression = decorator.parent as ts.CallExpression;
     const ops = expression.arguments.map((a: any) => a.text as string);
     return ops[0];
+  }
+
+  private getRateLimit(): number[] | undefined {
+    const rateLimitDecorators = this.getDecoratorsByIdentifier(this.node, 'RateLimit');
+    if (!rateLimitDecorators || !rateLimitDecorators.length) {
+      return undefined;
+    }
+    if (rateLimitDecorators.length < 1) {
+      throw new GenerateMetadataError(`Only one RateLimit decorator allowed in '${this.getCurrentLocation}' method.`);
+    }
+
+    const decorator = rateLimitDecorators[0];
+    const expression = decorator.parent as ts.CallExpression;
+
+    return expression.arguments.map<number>((e: any) => e.text as number);
   }
 
   private getTags() {

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -233,7 +233,7 @@ export class MethodGenerator {
     const decorator = rateLimitDecorators[0];
     const expression = decorator.parent as ts.CallExpression;
 
-    return expression.arguments.map<number>((e: any) => e.text as number);
+    return expression.arguments.map<number>((e: any) => parseInt(e.text, 10));
   }
 
   private getTags() {

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -25,6 +25,7 @@ export namespace Tsoa {
     summary?: string;
     isHidden: boolean;
     operationId?: string;
+    rateLimit?: number[];
   }
 
   export interface Parameter {

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -53,6 +53,8 @@ export class RouteGenerator {
       canImportByAlias = false;
     }
 
+    let usesRateLimiter = false;
+
     const normalisedBasePath = normalisePath(this.options.basePath as string, '/');
 
     return routesTemplate({
@@ -74,12 +76,17 @@ export class RouteGenerator {
               `${normalisedBasePath}${normalisedControllerPath}${normalisedMethodPath}`, '/', '', false,
             );
 
+            if (method.rateLimit) {
+              usesRateLimiter = true;
+            }
+
             return {
               fullPath: normalisedFullPath,
               method: method.method.toLowerCase(),
               name: method.name,
               parameters: parameterObjs,
               path: normalisedMethodPath,
+              rateLimit: method.rateLimit,
               security: method.security,
             };
           }),
@@ -91,6 +98,7 @@ export class RouteGenerator {
       environment: process.env,
       iocModule,
       models: this.buildModels(),
+      useRateLimiter: usesRateLimiter,
       useSecurity: this.metadata.controllers.some(
         controller => controller.methods.some(method => !!method.security.length),
       ),

--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -15,6 +15,10 @@ import { expressAuthentication } from '{{authenticationModule}}';
 {{/if}}
 import * as express from 'express';
 
+{{#if useRateLimiter}}
+const limiter = require('express-rate-limit');
+{{/if}}
+
 const models: TsoaRoute.Models = {
     {{#each models}}
     "{{@key}}": {
@@ -40,6 +44,12 @@ export function RegisterRoutes(app: express.Express) {
     {{#each controllers}}
     {{#each actions}}
         app.{{method}}('{{fullPath}}',
+            {{#if rateLimit}}
+            limiter({
+                windowMs: 1 * {{rateLimit.[1]}} * 1000,
+                max: {{rateLimit.[0]}}
+            }),
+            {{/if}}
             {{#if security.length}}
             authenticateMiddleware({{json security}}),
             {{/if}}

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -40,6 +40,8 @@ export class GetTestController extends Controller {
     modelsArray: new Array<TestSubModel>(),
     numberArray: [1, 2, 3],
     numberValue: 1,
+    object: new Object(),
+    objectArray: [new Object()],
     optionalString: 'optional string',
     strLiteralArr: ['Foo', 'Bar'],
     strLiteralVal: 'Foo',

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -10,6 +10,7 @@ import {
     Security,
     SuccessResponse,
     Tags,
+    RateLimit,
 } from '../../../src';
 import { ModelService } from '../services/modelService';
 import { ErrorResponseModel, TestModel } from '../testModel';
@@ -40,6 +41,12 @@ export class MethodController extends Controller {
     @Delete('Delete')
     public async deleteMethod(): Promise<TestModel> {
         return new ModelService().getModel();
+    }
+
+    @Get('RateLimit')
+    @RateLimit(5, 60)
+    public async getRateLimit(): Promise<void> {
+      return;
     }
 
     /**

--- a/tests/fixtures/inversify/managedService.ts
+++ b/tests/fixtures/inversify/managedService.ts
@@ -15,6 +15,8 @@ export class ManagedService {
       modelsArray: new Array<TestSubModel>(),
       numberArray: [1, 2, 3],
       numberValue: 1,
+      object: new Object(),
+      objectArray: [new Object()],
       optionalString: 'optional string',
       strLiteralArr: ['Foo', 'Bar'],
       strLiteralVal: 'Foo',

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -13,6 +13,8 @@ export class ModelService {
       modelsArray: new Array<TestSubModel>(),
       numberArray: [1, 2, 3],
       numberValue: 1,
+      object: new Object(),
+      objectArray: [new Object()],
       optionalString: 'optional string',
       strLiteralArr: ['Foo', 'Bar'],
       strLiteralVal: 'Foo',

--- a/tests/integration/inversify-server.spec.ts
+++ b/tests/integration/inversify-server.spec.ts
@@ -40,6 +40,8 @@ describe('Inversify Express Server', () => {
         },
         numberArray: [1, 2, 3],
         numberValue: 1,
+        object: new Object(),
+        objectArray: [new Object()],
         optionalString: 'optional string',
         strLiteralArr: ['Foo', 'Bar'],
         strLiteralVal: 'Foo',

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -21,10 +21,17 @@ describe('Metadata generation', () => {
       'getMethod', 'postMethod', 'patchMethod', 'putMethod', 'deleteMethod',
       'description', 'tags', 'multiResponse', 'successResponse', 'oauthOrAPIkeySecurity',
       'apiSecurity', 'oauthSecurity', 'deprecatedMethod', 'summaryMethod',
-      'oauthAndAPIkeySecurity', 'returnAnyType'];
+      'oauthAndAPIkeySecurity', 'returnAnyType', 'getRateLimit'];
 
     it('should only generate the defined methods', () => {
       expect(controller.methods.filter(m => definedMethods.indexOf(m.name) === -1).length).to.equal(0);
+    });
+
+    it('should generate a RateLimiter', () => {
+      const method = controller.methods.find(m => m.name === 'getRateLimit');
+
+      expect(method!.rateLimit![0]).to.be.equal(5);
+      expect(method!.rateLimit![1]).to.be.equal(60);
     });
 
     it('should generate the defined methods', () => {


### PR DESCRIPTION
# Why?
It would be nice to add rate limiting to certain endpoints in an API with a decorator so that the middleware for rate limiting is attached to the routes by the tsoa generator.

# What was done?
To support this idea I added a new @RateLimit() decorator which can be used to decorate routes that should be protected by a rate limiting strategy.

As a starting point this is currently implemented for express.js only (mainly because all my backends run on express.js) but the goal is to support this for hapi and koa as well.

# What still needs to be done?
* hapi support (help wanted)
* koa support (help wanted)
* support more options besides number of requests and search window

# How to use?
```javascript
@Get()
@SuccessResponse(200, "List of all ogs")
@Security("Bearer", ["user", "admin"])
@RateLimit(1, 60)
public async GetAllDogs(): Promise<DogDto[]> {
  return await this._getAnimals();
}
```

Best regards,
caringdeveloper