### PR TITLE
Ignore unspecified constructor args in type resolution (#394)

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -575,7 +575,7 @@ export class TypeResolver {
 
     if (classConstructor && classConstructor.parameters) {
       const constructorProperties = classConstructor.parameters
-        .filter((parameter) => this.hasPublicModifier(parameter));
+        .filter((parameter) => this.isPublicParameter(parameter));
 
       properties.push(...constructorProperties);
     }
@@ -659,6 +659,10 @@ export class TypeResolver {
     return !node.modifiers || node.modifiers.every((modifier) => {
       return modifier.kind !== ts.SyntaxKind.ProtectedKeyword && modifier.kind !== ts.SyntaxKind.PrivateKeyword;
     });
+  }
+
+  private isPublicParameter(node: ts.Node) {
+    return node.modifiers && node.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.PublicKeyword);
   }
 
   private getNodeDescription(node: UsableDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration | ts.EnumDeclaration) {

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -38,7 +38,7 @@ export class PostTestController {
 
   @Post('WithClassModel')
   public async postClassModel( @Body() model: TestClassModel): Promise<TestClassModel> {
-    const augmentedModel = new TestClassModel('test', 'test2', 'test3');
+    const augmentedModel = new TestClassModel('test', 'test2', 'test3', 'test4');
     augmentedModel.id = 700;
 
     return augmentedModel;

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -32,7 +32,7 @@ export class ModelService {
   }
 
   public getClassModel(): TestClassModel {
-    const testClassModel = new TestClassModel('constructor var', 'private constructor var');
+    const testClassModel = new TestClassModel('constructor var', 'private constructor var', '_default constructor var', 'optional constructor var');
     testClassModel.id = 1;
     testClassModel.publicStringProperty = 'public string property';
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -328,6 +328,7 @@ export class TestClassModel extends TestClassBaseModel {
   constructor(
     public publicConstructorVar: string,
     protected protectedConstructorVar: string,
+    defaultConstructorArgument: string,
     public optionalPublicConstructorVar?: string,
   ) {
     super();

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -794,7 +794,7 @@ describe('Express Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -736,7 +736,7 @@ describe('Hapi Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -715,7 +715,7 @@ describe('Koa Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -192,6 +192,13 @@ describe('Definition generation', () => {
       }
     });
 
+    it('should not generate a property for a non-public constructor var', () => {
+      const propertyName = 'defaultConstructorArgument';
+      if (properties[propertyName]) {
+        throw new Error(`Property '${propertyName}' was not expected to exist.`);
+      }
+    });
+
     it('should generate properties from a base class', () => {
       const property = properties.id;
       expect(property).to.exist;


### PR DESCRIPTION
#394 

Other types of constructor vars are already tested [here](https://github.com/lukeautry/tsoa/blob/master/tests/unit/swagger/definitionsGeneration/definitions.spec.ts#L163).

Class properties are already tested [here](https://github.com/lukeautry/tsoa/blob/master/tests/unit/swagger/definitionsGeneration/definitions.spec.ts#L154).

@dgreene1 I'd appreciate if you could take a look, I think I covered everything we discussed.
