### PR TITLE
OpenAPI 3: Generate valid operations/parameters

### DIFF
--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -10,28 +10,6 @@ export class SpecGenerator {
     return this.getSwaggerType(type);
   }
 
-  protected buildOperation(controllerName: string, method: Tsoa.Method): Swagger.Operation {
-    const swaggerResponses: any = {};
-
-    method.responses.forEach((res: Tsoa.Response) => {
-      swaggerResponses[res.name] = {
-        description: res.description,
-      };
-      if (res.schema && res.schema.dataType !== 'void') {
-        swaggerResponses[res.name].schema = this.getSwaggerType(res.schema);
-      }
-      if (res.examples) {
-        swaggerResponses[res.name].examples = { 'application/json': res.examples };
-      }
-    });
-
-    return {
-      operationId: this.getOperationId(method.name),
-      produces: ['application/json'],
-      responses: swaggerResponses,
-    };
-  }
-
   protected getOperationId(methodName: string) {
     return methodName.charAt(0).toUpperCase() + methodName.substr(1);
   }

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -142,6 +142,28 @@ export class SpecGenerator2 extends SpecGenerator {
     }
   }
 
+  protected buildOperation(controllerName: string, method: Tsoa.Method): Swagger.Operation {
+    const swaggerResponses: any = {};
+
+    method.responses.forEach((res: Tsoa.Response) => {
+      swaggerResponses[res.name] = {
+        description: res.description,
+      };
+      if (res.schema && res.schema.dataType !== 'void') {
+        swaggerResponses[res.name].schema = this.getSwaggerType(res.schema);
+      }
+      if (res.examples) {
+        swaggerResponses[res.name].examples = { 'application/json': res.examples };
+      }
+    });
+
+    return {
+      operationId: this.getOperationId(method.name),
+      produces: ['application/json'],
+      responses: swaggerResponses,
+    };
+  }
+
   private buildBodyPropParameter(controllerName: string, method: Tsoa.Method) {
     const properties = {} as { [name: string]: Swagger.Schema | Swagger.BaseSchema };
     const required: string[] = [];

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -191,6 +191,32 @@ export class SpecGenerator3 extends SpecGenerator {
     }
   }
 
+  protected buildOperation(controllerName: string, method: Tsoa.Method): Swagger.Operation3 {
+    const swaggerResponses: { [name: string]: Swagger.Response3 } = {};
+
+    method.responses.forEach((res: Tsoa.Response) => {
+      swaggerResponses[res.name] = {
+        content: {
+          'application/json': {} as Swagger.Schema3,
+        },
+        description: res.description,
+      };
+      if (res.schema && res.schema.dataType !== 'void') {
+        /* tslint:disable:no-string-literal */
+        (swaggerResponses[res.name].content || {})['application/json']['schema'] = this.getSwaggerType(res.schema);
+      }
+      if (res.examples) {
+        /* tslint:disable:no-string-literal */
+        (swaggerResponses[res.name].content || {})['application/json']['examples'] = { example: { value: res.examples}};
+      }
+    });
+
+    return {
+      operationId: this.getOperationId(method.name),
+      responses: swaggerResponses,
+    };
+  }
+
   private buildRequestBody(controllerName: string, method: Tsoa.Method, parameter: Tsoa.Parameter): Swagger.RequestBody {
     const parameterType = this.getSwaggerType(parameter.type);
 
@@ -214,17 +240,20 @@ export class SpecGenerator3 extends SpecGenerator {
   }
 
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter {
-    let parameter = {
-      default: source.default,
+    const parameter = {
       description: source.description,
       in: source.in,
       name: source.name,
       required: source.required,
+      schema: {
+        default: source.default,
+        format: undefined,
+      },
     } as Swagger.Parameter;
 
     const parameterType = this.getSwaggerType(source.type);
     if (parameterType.format) {
-        parameter.format = this.throwIfNotDataFormat(parameterType.format);
+        parameter.schema.format = this.throwIfNotDataFormat(parameterType.format);
     }
 
     if (parameter.in === 'query' && parameterType.type === 'array') {
@@ -246,20 +275,16 @@ export class SpecGenerator3 extends SpecGenerator {
       });
 
     if (source.type.dataType === 'any') {
-      parameter.type = 'string';
+      parameter.schema.type = 'string';
     } else {
       if (parameterType.type) {
-        parameter.type = this.throwIfNotDataType(parameterType.type);
+        parameter.schema.type = this.throwIfNotDataType(parameterType.type);
       }
-      parameter.items = parameterType.items;
-      parameter.enum = parameterType.enum;
+      parameter.schema.items = parameterType.items;
+      parameter.schema.enum = parameterType.enum;
     }
 
-    if (parameter.schema) {
-      parameter.schema = Object.assign({}, parameter.schema, validatorObjs);
-    } else {
-      parameter = Object.assign({}, parameter, validatorObjs);
-    }
+    parameter.schema = Object.assign({}, parameter.schema, validatorObjs);
 
     return parameter;
   }

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -188,9 +188,8 @@ export namespace Swagger {
     externalDocs?: ExternalDocs;
     operationId: string;
     consumes?: string[];
-    produces?: string[];
     parameters?: Parameter[];
-    responses: { [name: string]: Response };
+    responses: { [name: string]: Response3 };
     schemes?: Protocol[];
     deprecated?: boolean;
     security?: Security[];
@@ -215,6 +214,12 @@ export namespace Swagger {
     schema?: Schema;
     headers?: { [name: string]: Header };
     examples?: { [name: string]: Example };
+  }
+
+  export interface Response3 {
+    description: string;
+    content?: { [name: string]: Schema | Example };
+    headers?: { [name: string]: Header };
   }
 
   export interface BaseSchema {


### PR DESCRIPTION
This PR should ensure we generate a valid spec for the GetController in the tests.

I moved the schema and example to the correct position to ensure we mostly* comply with the specification.

*There are still $refs that should be allowed in 3.1, so I don't see a reason to fix these.