### PR TITLE
Generate a property for readonly constructor args

### DIFF
--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -38,7 +38,7 @@ export class PostTestController {
 
   @Post('WithClassModel')
   public async postClassModel( @Body() model: TestClassModel): Promise<TestClassModel> {
-    const augmentedModel = new TestClassModel('test', 'test2', 'test3', 'test4');
+    const augmentedModel = new TestClassModel('test', 'test2', 'test3', 'test4', 'test5');
     augmentedModel.id = 700;
 
     return augmentedModel;

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -32,7 +32,13 @@ export class ModelService {
   }
 
   public getClassModel(): TestClassModel {
-    const testClassModel = new TestClassModel('constructor var', 'private constructor var', '_default constructor var', 'optional constructor var');
+    const testClassModel = new TestClassModel(
+      'constructor var',
+      'private constructor var',
+      '_default constructor var',
+      'readonlyConstructorvar',
+      'optional constructor var'
+    );
     testClassModel.id = 1;
     testClassModel.publicStringProperty = 'public string property';
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -329,6 +329,7 @@ export class TestClassModel extends TestClassBaseModel {
     public publicConstructorVar: string,
     protected protectedConstructorVar: string,
     defaultConstructorArgument: string,
+    readonly readonlyConstructorArgument: string,
     public optionalPublicConstructorVar?: string,
   ) {
     super();

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -794,7 +794,7 @@ describe('Express Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -794,7 +794,7 @@ describe('Express Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -736,7 +736,7 @@ describe('Hapi Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -716,7 +716,7 @@ describe('Koa Server', () => {
   }
 
   function getFakeClassModel() {
-    const model = new TestClassModel('test', 'test', 'test', 'test');
+    const model = new TestClassModel('test', 'test', 'test', 'test', 'test');
     model.id = 100;
     model.publicStringProperty = 'test';
     model.stringProperty = 'test';

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -428,6 +428,15 @@ describe('Definition generation', () => {
           }
         });
 
+        it('should generate a property from a readonly constructor argument', () => {
+          const propertyName = 'readonlyConstructorArgument';
+          if (!properties[propertyName]) {
+            throw new Error(`Property '${propertyName}' was expected to exist.`);
+          }
+
+          expect(definition.required).to.contain(propertyName);
+        });
+
         it('should generate properties from a base class', () => {
           const property = properties.id;
           expect(property).to.exist;


### PR DESCRIPTION
Follow up on #397:

Before #397:
```
export class TestClassModel {
  constructor(
    public publicConstructorVar: string,
    protected protectedConstructorVar: string,
    defaultConstructorArgument: string,
    readonly readonlyConstructorArgument: string,
    public optionalPublicConstructorVar?: string,
  ) {
  }
}
```

would generate properties for: `publicConstructorVar, defaultConstructorArgument, readonlyConstructorArgument, optionalPublicConstructorVar`.

After #397:
`publicConstructorVar, optionalPublicConstructorVar`

This is according to my understanding of the [TypeScript Specification for constructor parameters](https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#831-constructor-parameters).

However, as it turns out, this is valid TS and `readonlyConstructorArgument` is accessible:

```
class ReadonlyClass {
  constructor(
    readonly readonlyConstructorArgument: string,
  ) {
  }
}

new ReadonlyClass("oh hi").readonlyConstructorArgument // => "oh hi"
```

Therefore, I think these parameters should generate properties:
`publicConstructorVar, readonlyConstructorArgument, optionalPublicConstructorVar`
