### PR TITLE
Improve "noImplicitAdditionalProperties" to allow for flexibility

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -192,13 +192,15 @@ Yes, set `swagger.specVersion` to `3` in your `tsoa.json` file. See more config 
 
 ### How to ensure no additional properties come in at runtime
 
-By default, Swagger allows for models to have [`additionalProperties`](https://swagger.io/docs/specification/data-models/dictionaries/). If you would like to ensure at runtime that the data has only the properties defined in your models, set the `noImplicitAdditionalProperties` [config](https://github.com/lukeautry/tsoa/blob/master/src/config.ts) option to `true`.
+By default, Swagger allows for models to have [`additionalProperties`](https://swagger.io/docs/specification/data-models/dictionaries/). If you would like to ensure at runtime that the data has only the properties defined in your models, set the `noImplicitAdditionalProperties` [config](https://github.com/lukeautry/tsoa/blob/master/src/config.ts) option to either `"silently-remove-extras"` or `"throw-on-extras"`.
 
 Caveats:
   * The following types will always allow additional properties due to the nature of the way they work:
     * The `any` type
     * An indexed type (which explicitly allows additional properties) like `export interface IStringToStringDictionary { [key: string] : string }`
-  * If you are using tsoa for an existing service that has consumers, you will need to inform your consumers before turning on `noImplicitAdditionalProperties` since it would be a breaking change (due to the fact that request bodies that previously worked would now get an error). However, this option is a great choice for new APIs.
+  * If you are using tsoa for an existing service that has consumers...
+    * you will need to inform your consumers before setting `noImplicitAdditionalProperties` to `"throw-on-extras"` since it would be a breaking change (due to the fact that request bodies that previously worked would now get an error).
+  * Regardless, `"noImplicitAdditionalProperties" : "silently-remove-extras"` is a great choice for both legacy AND new APIs (since this mirrors the behavior of C# serializers and other popular JSON serializers).
 
 ### Dealing with duplicate model names
 If you have multiple models with the same name, you may get errors indicating that there are multiple matching models. If you'd like to designate a class/interface as the 'canonical' version of a model, add a jsdoc element marking it as such:

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,11 @@ export interface Config {
   compilerOptions?: ts.CompilerOptions;
 }
 
+/**
+ * these options will be removed in a future version since we would prefer consumers to explicitly state their preference that the tsoa validation throws or removes additional properties
+ */
+export type DeprecatedOptionForAdditionalPropertiesHandling = true | false;
+
 export interface SwaggerConfig {
   /**
    * Generated SwaggerConfig.json will output here
@@ -40,7 +45,7 @@ export interface SwaggerConfig {
   /**
    * Modes that allow you to prevent input data from entering into your API. This will document your decision in the swagger.yaml and it will turn on excess-property validation (at runtime) in your routes.
    */
-  noImplicitAdditionalProperties?: 'throw-on-extras' | 'silently-remove-extras';
+  noImplicitAdditionalProperties?: 'throw-on-extras' | 'silently-remove-extras' | DeprecatedOptionForAdditionalPropertiesHandling;
 
   /**
    * API host, expressTemplate.g. localhost:3000 or myapi.com

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,9 +38,9 @@ export interface SwaggerConfig {
   entryFile: string;
 
   /**
-   * Set this to true if you want to prevent requests from coming in with more properties than are known/allowed
+   * Modes that allow you to prevent input data from entering into your API. This will document your decision in the swagger.yaml and it will turn on excess-property validation (at runtime) in your routes.
    */
-  noImplicitAdditionalProperties?: boolean;
+  noImplicitAdditionalProperties?: 'throw-on-extras' | 'silently-remove-extras';
 
   /**
    * API host, expressTemplate.g. localhost:3000 or myapi.com

--- a/src/module/generate-routes.ts
+++ b/src/module/generate-routes.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import * as ts from 'typescript';
-import { RoutesConfig, SwaggerConfig } from '../config';
+import { RoutesConfig } from '../config';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '../metadataGeneration/tsoa';
-import { RouteGenerator } from '../routeGeneration/routeGenerator';
+import { RouteGenerator, SwaggerConfigRelatedToRoutes } from '../routeGeneration/routeGenerator';
 
 export const generateRoutes = async (
   routesConfig: RoutesConfig,
-  swaggerConfig: SwaggerConfig,
+  minimalSwaggerConfig: SwaggerConfigRelatedToRoutes,
   compilerOptions?: ts.CompilerOptions,
   ignorePaths?: string[],
   /**
@@ -24,7 +24,7 @@ export const generateRoutes = async (
     ).Generate();
   }
 
-  const routeGenerator = new RouteGenerator(metadata, routesConfig, swaggerConfig);
+  const routeGenerator = new RouteGenerator(metadata, routesConfig, exactly(minimalSwaggerConfig));
 
   let pathTransformer;
   let template;
@@ -52,4 +52,29 @@ export const generateRoutes = async (
   await routeGenerator.GenerateCustomRoutes(template, pathTransformer);
 
   return metadata;
+};
+
+const exactly = (input: SwaggerConfigRelatedToRoutes): SwaggerConfigRelatedToRoutes => {
+  // Validate the config values first
+  if (
+    input.noImplicitAdditionalProperties === undefined ||
+    input.noImplicitAdditionalProperties === 'throw-on-extras' ||
+    input.noImplicitAdditionalProperties === 'silently-remove-extras'
+  ) {
+    // then it's good to go
+  } else {
+    throw new Error(`noImplicitAdditionalProperties is set to an invalid value. See https://github.com/lukeautry/tsoa/blob/master/src/config.ts for available options.`);
+  }
+
+  // Make an exact copy that doesn't have other properties
+  const recordOfProps: Record<keyof SwaggerConfigRelatedToRoutes, 'right side does not matter'> = {
+    noImplicitAdditionalProperties: 'right side does not matter',
+  };
+
+  const exactObj: SwaggerConfigRelatedToRoutes = {};
+  Object.keys(recordOfProps).forEach((key) => {
+    const strictKey = key as keyof SwaggerConfigRelatedToRoutes;
+    exactObj[strictKey] = input[strictKey];
+  });
+  return exactObj;
 };

--- a/src/module/generate-routes.ts
+++ b/src/module/generate-routes.ts
@@ -4,6 +4,7 @@ import { RoutesConfig } from '../config';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '../metadataGeneration/tsoa';
 import { RouteGenerator, SwaggerConfigRelatedToRoutes } from '../routeGeneration/routeGenerator';
+import { warnAdditionalPropertiesDeprecation } from '../utils/deprecations';
 
 export const generateRoutes = async (
   routesConfig: RoutesConfig,
@@ -56,7 +57,11 @@ export const generateRoutes = async (
 
 const exactly = (input: SwaggerConfigRelatedToRoutes): SwaggerConfigRelatedToRoutes => {
   // Validate the config values first
-  if (
+  if (input.noImplicitAdditionalProperties === true) {
+    warnAdditionalPropertiesDeprecation(input.noImplicitAdditionalProperties);
+  } else if (input.noImplicitAdditionalProperties === false) {
+    warnAdditionalPropertiesDeprecation(input.noImplicitAdditionalProperties);
+  } else if (
     input.noImplicitAdditionalProperties === undefined ||
     input.noImplicitAdditionalProperties === 'throw-on-extras' ||
     input.noImplicitAdditionalProperties === 'silently-remove-extras'

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as tsfmt from 'typescript-formatter';
 import { Tsoa } from '../metadataGeneration/tsoa';
 import { assertNever } from '../utils/assertNever';
+import { warnAdditionalPropertiesDeprecation } from '../utils/deprecations';
 import { fsReadFile, fsWriteFile } from '../utils/fs';
 import { RoutesConfig, SwaggerConfig } from './../config';
 import { normalisePath } from './../utils/pathUtils';
@@ -55,6 +56,12 @@ export class RouteGenerator {
         return JSON.stringify(false);
       } else if (this.minimalSwaggerConfig.noImplicitAdditionalProperties === undefined) {
         // Since Swagger defaults to allowing additional properties, then that will be our default
+        return JSON.stringify(true);
+      } else if (this.minimalSwaggerConfig.noImplicitAdditionalProperties === true) {
+        warnAdditionalPropertiesDeprecation(this.minimalSwaggerConfig.noImplicitAdditionalProperties);
+        return JSON.stringify(false);
+      } else if (this.minimalSwaggerConfig.noImplicitAdditionalProperties === false) {
+        warnAdditionalPropertiesDeprecation(this.minimalSwaggerConfig.noImplicitAdditionalProperties);
         return JSON.stringify(true);
       } else {
         return assertNever(this.minimalSwaggerConfig.noImplicitAdditionalProperties);

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -1,6 +1,7 @@
 import * as moment from 'moment';
 import * as validator from 'validator';
 import { assertNever } from '../utils/assertNever';
+import { warnAdditionalPropertiesDeprecation } from '../utils/deprecations';
 import { SwaggerConfigRelatedToRoutes } from './routeGenerator';
 import { isDefaultForAdditionalPropertiesAllowed, TsoaRoute } from './tsoa-route';
 
@@ -399,12 +400,20 @@ export class ValidationService {
                 message: `"${key}" is an excess property and therefore is not allowed`,
                 value: key,
               };
+            } else if (swaggerConfig.noImplicitAdditionalProperties === true) {
+              warnAdditionalPropertiesDeprecation(swaggerConfig.noImplicitAdditionalProperties);
+              fieldErrors[parent + '.' + key] = {
+                message: `"${key}" is an excess property and therefore is not allowed`,
+                value: key,
+              };
             } else if (
-              swaggerConfig.noImplicitAdditionalProperties === 'silently-remove-extras' ||
-              swaggerConfig.noImplicitAdditionalProperties === true
+              swaggerConfig.noImplicitAdditionalProperties === 'silently-remove-extras'
             ) {
               delete value[key];
-            } else if (swaggerConfig.noImplicitAdditionalProperties === false || swaggerConfig.noImplicitAdditionalProperties === undefined) {
+            } else if (swaggerConfig.noImplicitAdditionalProperties === false) {
+              warnAdditionalPropertiesDeprecation(swaggerConfig.noImplicitAdditionalProperties);
+              // then it's okay to have additionalProperties
+            } else if (swaggerConfig.noImplicitAdditionalProperties === undefined) {
               // then it's okay to have additionalProperties
             } else {
               assertNever(swaggerConfig.noImplicitAdditionalProperties);

--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -177,15 +177,15 @@ export function RegisterRoutes(app: express.Express) {
                 case 'request':
                     return request;
                 case 'query':
-                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'path':
-                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'header':
-                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors);
+                    return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'body':
-                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, name + '.');
+                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, name + '.', {{{json minimalSwaggerConfig}}});
                 case 'body-prop':
-                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.');
+                    return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {{{json minimalSwaggerConfig}}});
             }
         });
 

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -183,15 +183,15 @@ export function RegisterRoutes(server: any) {
             case 'request':
                 return request;
             case 'query':
-                return validationService.ValidateParam(args[key], request.query[name], name, errorFields)
+                return validationService.ValidateParam(args[key], request.query[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}})
             case 'path':
-                return validationService.ValidateParam(args[key], request.params[name], name, errorFields)
+                return validationService.ValidateParam(args[key], request.params[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}})
             case 'header':
-                return validationService.ValidateParam(args[key], request.headers[name], name, errorFields);
+                return validationService.ValidateParam(args[key], request.headers[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body':
-                return validationService.ValidateParam(args[key], request.payload, name, errorFields, name + '.');
+                return validationService.ValidateParam(args[key], request.payload, name, errorFields, name + '.', {{{json minimalSwaggerConfig}}});
              case 'body-prop':
-                return validationService.ValidateParam(args[key], request.payload[name], name, errorFields, 'body.');
+                return validationService.ValidateParam(args[key], request.payload[name], name, errorFields, 'body.', {{{json minimalSwaggerConfig}}});
             }
         });
         if (Object.keys(errorFields).length > 0) {

--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -184,15 +184,15 @@ export function RegisterRoutes(router: KoaRouter) {
             case 'request':
                 return context.request;
             case 'query':
-                return validationService.ValidateParam(args[key], context.request.query[name], name, errorFields);
+                return validationService.ValidateParam(args[key], context.request.query[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'path':
-                return validationService.ValidateParam(args[key], context.params[name], name, errorFields);
+                return validationService.ValidateParam(args[key], context.params[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'header':
-                return validationService.ValidateParam(args[key], context.request.headers[name], name, errorFields);
+                return validationService.ValidateParam(args[key], context.request.headers[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body':
-                return validationService.ValidateParam(args[key], context.request.body, name, errorFields, name + '.');
+                return validationService.ValidateParam(args[key], context.request.body, name, errorFields, name + '.', {{{json minimalSwaggerConfig}}});
             case 'body-prop':
-                return validationService.ValidateParam(args[key], context.request.body[name], name, errorFields, 'body.');
+                return validationService.ValidateParam(args[key], context.request.body[name], name, errorFields, 'body.', {{{json minimalSwaggerConfig}}});
             }
         });
         if (Object.keys(errorFields).length > 0) {

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -116,9 +116,20 @@ export class SpecGenerator {
     return voidSchema;
   }
 
-  protected getSwaggerTypeForPrimitiveType(dataType: Tsoa.PrimitiveTypeLiteral): Swagger.Schema {
+  protected determineImplicitAdditionalPropertiesValue = (): boolean => {
+    if (this.config.noImplicitAdditionalProperties === 'silently-remove-extras') {
+      return false;
+    } else if (this.config.noImplicitAdditionalProperties === 'throw-on-extras') {
+      return false;
+    } else if (this.config.noImplicitAdditionalProperties === undefined) {
+      // Since Swagger defaults to allowing additional properties, then that will be our default
+      return true;
+    } else {
+      return assertNever(this.config.noImplicitAdditionalProperties);
+    }
+  }
 
-    const defaultAdditionalPropertiesSetting = true;
+  protected getSwaggerTypeForPrimitiveType(dataType: Tsoa.PrimitiveTypeLiteral): Swagger.Schema {
 
     if (dataType === 'object') {
       if (process.env.NODE_ENV !== 'tsoa_test') {
@@ -152,7 +163,7 @@ export class SpecGenerator {
       integer: { type: 'integer', format: 'int32' },
       long: { type: 'integer', format: 'int64' },
       object: {
-        additionalProperties: this.config.noImplicitAdditionalProperties ? false : defaultAdditionalPropertiesSetting,
+        additionalProperties: this.determineImplicitAdditionalPropertiesValue(),
         type: 'object',
       },
       string: { type: 'string' },

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -1,4 +1,5 @@
 import { Tsoa } from '../metadataGeneration/tsoa';
+import { warnAdditionalPropertiesDeprecation } from '../utils/deprecations';
 import { SwaggerConfig } from './../config';
 import { assertNever } from './../utils/assertNever';
 import { Swagger } from './swagger';
@@ -101,6 +102,12 @@ export class SpecGenerator {
       return false;
     } else if (this.config.noImplicitAdditionalProperties === undefined) {
       // Since Swagger defaults to allowing additional properties, then that will be our default
+      return true;
+    } else if (this.config.noImplicitAdditionalProperties === true) {
+      warnAdditionalPropertiesDeprecation(this.config.noImplicitAdditionalProperties);
+      return false;
+    } else if (this.config.noImplicitAdditionalProperties === false) {
+      warnAdditionalPropertiesDeprecation(this.config.noImplicitAdditionalProperties);
       return true;
     } else {
       return assertNever(this.config.noImplicitAdditionalProperties);

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -48,7 +48,6 @@ export class SpecGenerator2 extends SpecGenerator {
 
   private buildDefinitions() {
     const definitions: { [definitionsName: string]: Swagger.Schema } = {};
-    const config = this.config;
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
 
@@ -67,12 +66,7 @@ export class SpecGenerator2 extends SpecGenerator {
         } else {
             // Since additionalProperties was not explicitly set in the TypeScript interface for this model
             //      ...we need to make a decision
-            if (config.noImplicitAdditionalProperties) {
-                definitions[referenceType.refName].additionalProperties = false;
-            } else {
-                // we'll explicitly set the default, which for swagger
-                definitions[referenceType.refName].additionalProperties = true;
-            }
+            definitions[referenceType.refName].additionalProperties = this.determineImplicitAdditionalPropertiesValue();
         }
 
         if (referenceType.example) {

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -95,7 +95,6 @@ export class SpecGenerator3 extends SpecGenerator {
 
   private buildSchema() {
     const schema: { [name: string]: Swagger.Schema } = {};
-    const config = this.config;
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
 
@@ -114,12 +113,7 @@ export class SpecGenerator3 extends SpecGenerator {
         } else {
             // Since additionalProperties was not explicitly set in the TypeScript interface for this model
             //      ...we need to make a decision
-            if (config.noImplicitAdditionalProperties) {
-                schema[referenceType.refName].additionalProperties = false;
-            } else {
-                // we'll explicitly set the default, which for swagger
-                schema[referenceType.refName].additionalProperties = true;
-            }
+            schema[referenceType.refName].additionalProperties = this.determineImplicitAdditionalPropertiesValue();
         }
 
         if (referenceType.example) {

--- a/src/utils/assertNever.ts
+++ b/src/utils/assertNever.ts
@@ -1,3 +1,6 @@
+/**
+ * This function does exhaustiveness checking to ensure that you have discriminated a union so that no type remains. Use this to get the typescript compiler to help discover cases that were not considered.
+ */
 export function assertNever(value: never): never {
     throw new Error(
       `Unhandled discriminated union member: ${JSON.stringify(value)}`,

--- a/src/utils/deprecations.ts
+++ b/src/utils/deprecations.ts
@@ -1,0 +1,10 @@
+import { DeprecatedOptionForAdditionalPropertiesHandling } from '../config';
+
+export const warnAdditionalPropertiesDeprecation = (noAdditionalPropertiesValue: DeprecatedOptionForAdditionalPropertiesHandling): void => {
+    // tslint:disable-next-line: no-console
+    console.warn(
+        '###########################################\n' +
+        `  WARNING: ${noAdditionalPropertiesValue} is a deprecated selection for noImplicitAdditionalProperties and will be removed in a future version. \n` +
+        '           Please review the config documentation for more explicit options: https://github.com/lukeautry/tsoa/blob/master/src/config.ts\n' +
+        '###########################################');
+};

--- a/tests/fixtures/custom/custom-tsoa-template.ts.hbs
+++ b/tests/fixtures/custom/custom-tsoa-template.ts.hbs
@@ -127,15 +127,15 @@ export function RegisterRoutes(app: any) {
             case 'request':
                 return request;
             case 'query':
-                return ValidateParam(args[key], request.query[name], models, name, errorFields);
+                return ValidateParam(args[key], request.query[name], models, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'path':
-                return ValidateParam(args[key], request.params[name], models, name, errorFields);
+                return ValidateParam(args[key], request.params[name], models, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'header':
-                return ValidateParam(args[key], request.header(name), models, name, errorFields);
+                return ValidateParam(args[key], request.header(name), models, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body':
-                return ValidateParam(args[key], request.body, models, name, errorFields);
+                return ValidateParam(args[key], request.body, models, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body-prop':
-                return ValidateParam(args[key], request.body[name], models, name, errorFields);
+                return ValidateParam(args[key], request.body[name], models, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             }
         });
 

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -23,7 +23,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
 
     return verifyPostRequest(basePath + '/PostTest', data, (err: any, res: any) => {
       const body = JSON.parse(err.text);
-      expect(body.fields['model..someExtraProperty'].message).to.eql('someExtraProperty is an excess property and therefore is not allowed');
+      expect(body.fields['model..someExtraProperty'].message).to.eql('"someExtraProperty" is an excess property and therefore is not allowed');
     }, 400);
   });
 
@@ -155,7 +155,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
         const body = JSON.parse(err.text);
 
         // Although dictionaries/records allow additionalProperties they are still subject to their own validation
-        const excessPropertyErrMessage = `key1 is an excess property and therefore is not allowed`;
+        const excessPropertyErrMessage = `"key1" is an excess property and therefore is not allowed`;
         const expectedErrorMessage = 'No matching model found in additionalProperties to validate key1';
         expect(body.fields['map..key1'].message).not.to.eql(excessPropertyErrMessage);
         expect(body.fields['map..key1'].message).to.eql(expectedErrorMessage);

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -9,6 +9,7 @@ const defaultOptions: SwaggerConfig = {
     basePath: '/v1',
     entryFile: './tests/fixtures/express/server.ts',
     host: 'localhost:3000',
+    noImplicitAdditionalProperties: 'silently-remove-extras',
     outputDirectory: './dist',
     securityDefinitions: {
       api_key: {
@@ -29,7 +30,7 @@ const defaultOptions: SwaggerConfig = {
     yaml: true,
 };
 const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
-  noImplicitAdditionalProperties: true,
+  noImplicitAdditionalProperties: 'throw-on-extras',
   outputDirectory: './distForNoAdditional',
 });
 
@@ -72,7 +73,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
       middleware: 'koa',
       routesDir: './tests/fixtures/koa',
     }, defaultOptions, undefined, undefined, metadata)),
-    log('Koa Route Generation (but noImplicitAdditionalProperties is true)', () => generateRoutes({
+    log('Koa Route Generation (but noImplicitAdditionalProperties is set to "throw-on-extras")', () => generateRoutes({
         authenticationModule: './tests/fixtures/koaNoAdditional/authentication.ts',
         basePath: '/v1',
         entryFile: './tests/fixtures/server.ts',

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -11,7 +11,7 @@ describe('Definition generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
   const defaultOptions = getDefaultOptions();
   const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
-    noImplicitAdditionalProperties: true,
+    noImplicitAdditionalProperties: 'silently-remove-extras',
   });
 
   interface ISpecAndName {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -12,7 +12,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
   const defaultOptions = getDefaultOptions();
   const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
-    noImplicitAdditionalProperties: true,
+    noImplicitAdditionalProperties: 'silently-remove-extras',
   });
 
   interface ISpecAndName {
@@ -129,10 +129,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
   allSpecs.forEach(currentSpec => {
     describe(`for ${currentSpec.specName}`, () => {
-        describe('should set additionalProperties to false if noImplicitAdditionalProperties is true (when there are no dictionary or any types)', () => {
+        describe('should set additionalProperties to false if noImplicitAdditionalProperties is set to "throw-on-extras" (when there are no dictionary or any types)', () => {
             // Arrange
-            const options = getDefaultOptions();
-            options.noImplicitAdditionalProperties = true;
 
             // Assert
             if (!currentSpec.spec.components.schemas) {

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import 'mocha';
+import { SwaggerConfigRelatedToRoutes } from '../../../src/routeGeneration/routeGenerator';
 import { FieldErrors, ValidationService } from './../../../src/routeGeneration/templateHelpers';
 
 describe('ValidationService', () => {
@@ -13,13 +14,23 @@ describe('ValidationService', () => {
                     },
                 },
             });
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                noImplicitAdditionalProperties: undefined,
+            };
             const error = {};
-            const result = v.validateModel('', { a: 's' }, 'ExampleModel', error);
+            const result = v.validateModel({
+                fieldErrors: error,
+                minimalSwaggerConfig,
+                name: '',
+                refName: 'ExampleModel',
+                value: { a: 's' },
+            });
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: 's' });
         });
 
-        it('should not allow additionalProperties if noImplicitAdditionalProperties is true', () => {
+        it('should not allow additionalProperties if noImplicitAdditionalProperties is set to throw-on-extras', () => {
+            // Arrange
             const refName = 'ExampleModel';
             const v = new ValidationService({
                 [refName]: {
@@ -29,17 +40,72 @@ describe('ValidationService', () => {
                     },
                 },
             });
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                noImplicitAdditionalProperties: 'throw-on-extras',
+            };
             const errorDictionary: FieldErrors = {};
-            v.validateModel(
-                '',
-                { a: 's', uhOh: 'something extra' },
+            const nameOfAdditionalProperty = 'I am the bad key name';
+            const dataToValidate = {
+                a: 's',
+                [nameOfAdditionalProperty]: 'something extra',
+            };
+
+            // Act
+            v.validateModel({
+                fieldErrors: errorDictionary,
+                minimalSwaggerConfig,
+                name: '',
                 refName,
-                errorDictionary,
-            );
+                value: dataToValidate,
+            });
+
+            // Assert
             const errorKeys = Object.keys(errorDictionary);
             expect(errorKeys).to.have.lengthOf(1);
             const firstAndOnlyErrorKey = errorKeys[0];
-            expect(errorDictionary[firstAndOnlyErrorKey].message).to.eq('uhOh is an excess property and therefore is not allowed');
+            expect(errorDictionary[firstAndOnlyErrorKey].message).to.eq(`"${nameOfAdditionalProperty}" is an excess property and therefore is not allowed`);
+            if (!dataToValidate[nameOfAdditionalProperty]) {
+                throw new Error(`dataToValidate.${nameOfAdditionalProperty} should have been there because .validateModel should NOT have removed it since it took the more severe option of producing an error instead.`);
+            }
+        });
+
+        it('should allow (but remove) additionalProperties if noImplicitAdditionalProperties is set to throw-on-extras', () => {
+            // Arrange
+            const refName = 'ExampleModel';
+            const v = new ValidationService({
+                [refName]: {
+                    additionalProperties: false,
+                    properties: {
+                        a: { dataType: 'string', required: true },
+                    },
+                },
+            });
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                noImplicitAdditionalProperties: 'silently-remove-extras',
+            };
+            const errorDictionary: FieldErrors = {};
+            const nameOfAdditionalProperty = 'I am the bad key name';
+            const dataToValidate = {
+                a: 's',
+                [nameOfAdditionalProperty]: 'something extra',
+            };
+
+            // Act
+            v.validateModel({
+                fieldErrors: errorDictionary,
+                minimalSwaggerConfig,
+                name: '',
+                refName,
+                value: dataToValidate,
+            });
+
+            // Assert
+            if (dataToValidate[nameOfAdditionalProperty]) {
+                throw new Error(`dataToValidate.${nameOfAdditionalProperty} should NOT have been present because .validateModel should have removed it due to it being an excess property.`);
+            }
+            expect(dataToValidate).not.to.have.ownProperty(nameOfAdditionalProperty, '');
+            const errorKeys = Object.keys(errorDictionary);
+            expect(errorKeys).to.have.lengthOf(0);
         });
 
         it('should not require optional properties', () => {
@@ -51,7 +117,10 @@ describe('ValidationService', () => {
                 },
             });
             const error = {};
-            const result = v.validateModel('', {}, 'ExampleModel', error);
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                noImplicitAdditionalProperties: undefined,
+            };
+            const result = v.validateModel({ name: '', value: {}, refName: 'ExampleModel', fieldErrors: error, minimalSwaggerConfig });
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: undefined });
         });
@@ -63,7 +132,10 @@ describe('ValidationService', () => {
                 },
             });
             const error = {};
-            const result = v.validateModel('', { a: 's' }, 'ExampleModel', error);
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                noImplicitAdditionalProperties: undefined,
+            };
+            const result = v.validateModel({ name: '', value: { a: 's' }, refName: 'ExampleModel', fieldErrors: error, minimalSwaggerConfig });
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: 's' });
         });
@@ -78,7 +150,12 @@ describe('ValidationService', () => {
                 },
             });
             const error = {};
-            const result = v.validateModel('', {}, 'ExampleModel', error);
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                // This test should ignore this, otherwise there's a problem the code
+                //      when the model has additionalProperties, that should take precedence since it's explicit
+                noImplicitAdditionalProperties: 'throw-on-extras',
+            };
+            const result = v.validateModel({ name: '', value: {}, refName: 'ExampleModel', fieldErrors: error, minimalSwaggerConfig });
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: undefined });
         });
@@ -96,7 +173,12 @@ describe('ValidationService', () => {
                 },
             });
             const error = {};
-            const result = v.validateModel('', { a: 9 }, 'ExampleModel', error);
+            const minimalSwaggerConfig: SwaggerConfigRelatedToRoutes = {
+                // This test should ignore this, otherwise there's a problem the code
+                //      when the model has additionalProperties, that should take precedence since it's explicit
+                noImplicitAdditionalProperties: 'throw-on-extras',
+            };
+            const result = v.validateModel({ name: '', value: { a: 9 }, refName: 'ExampleModel', fieldErrors: error, minimalSwaggerConfig });
             expect(Object.keys(error)).to.be.empty;
             expect(result).to.eql({ a: 9 });
         });
@@ -334,7 +416,7 @@ describe('ValidationService', () => {
     describe('Array validate', () => {
         it('should array value', () => {
             const value = ['A', 'B', 'C'];
-            const result = new ValidationService({}).validateArray('name', value, {}, { dataType: 'string' });
+            const result = new ValidationService({}).validateArray('name', value, {}, {}, { dataType: 'string' });
             expect(result).to.deep.equal(value);
         });
 
@@ -342,7 +424,7 @@ describe('ValidationService', () => {
             const name = 'name';
             const value = ['A', 10, true];
             const error = {};
-            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' });
+            const result = new ValidationService({}).validateArray(name, value, error, {}, { dataType: 'integer' });
             expect(result).to.deep.equal([undefined, 10, undefined]);
             expect(error[`${name}.$0`].message).to.equal('invalid integer number');
             expect(error[`${name}.$0`].value).to.equal('A');
@@ -354,7 +436,7 @@ describe('ValidationService', () => {
             const name = 'name';
             const value = [80, 10, 199];
             const error = {};
-            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { minItems: { value: 4 } });
+            const result = new ValidationService({}).validateArray(name, value, error, {}, { dataType: 'integer' }, { minItems: { value: 4 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`minItems 4`);
         });
@@ -363,7 +445,7 @@ describe('ValidationService', () => {
             const name = 'name';
             const value = [80, 10, 199];
             const error = {};
-            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { maxItems: { value: 2 } });
+            const result = new ValidationService({}).validateArray(name, value, error, {}, { dataType: 'integer' }, { maxItems: { value: 2 } });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`maxItems 2`);
         });
@@ -372,7 +454,7 @@ describe('ValidationService', () => {
             const name = 'name';
             const value = [10, 10, 20];
             const error = {};
-            const result = new ValidationService({}).validateArray(name, value, error, { dataType: 'integer' }, { uniqueItems: {} });
+            const result = new ValidationService({}).validateArray(name, value, error, {}, { dataType: 'integer' }, { uniqueItems: {} });
             expect(result).to.equal(undefined);
             expect(error[name].message).to.equal(`required unique array`);
         });

--- a/tests/unit/templating/routeGenerator.spec.ts
+++ b/tests/unit/templating/routeGenerator.spec.ts
@@ -6,7 +6,7 @@ import { RouteGenerator } from '../../../src/routeGeneration/routeGenerator';
 describe('RouteGenerator', () => {
   describe('.buildModels', () => {
 
-    it('should produce models where no additionalProperties are allowed unless explicitly stated', () => {
+    it('should produce models where additionalProperties are not allowed unless explicitly stated', () => {
       // Arrange
       const stringType: Tsoa.Type = {
         dataType: 'string',
@@ -37,7 +37,7 @@ describe('RouteGenerator', () => {
         entryFile: 'mockEntryFile',
         routesDir: 'mockRoutesDir',
       }, {
-        noImplicitAdditionalProperties: true,
+        noImplicitAdditionalProperties: 'silently-remove-extras',
       });
 
       // Act

--- a/tsoa.json
+++ b/tsoa.json
@@ -4,7 +4,7 @@
         "entryFile": "./tests/fixtures/express/server.ts",
         "host": "localhost:3000",
         "basePath": "/v1",
-        "noImplicitAdditionalProperties": true,
+        "noImplicitAdditionalProperties": "silently-remove-extras",
         "securityDefinitions": {
             "api_key": {
                 "type": "apiKey",


### PR DESCRIPTION
I showed v2.4.5 to friends at work and the asked if there was an option to accept the request but to safely discard the additional properties. In fact, they told me that it was their belief that it was generally more preferable to strip the additional properties. They said that it would be burdensome to consumers if the consumer had to always watch what they were sending. They cited the "Robustness Principle":

> Be conservative in what you do, be liberal in what you accept from others.

Personally, I can't decide if it's better to throw or to fix the object, so I'm providing both options.