### PR TITLE
explicitly setting to any since otherwise users will get a no implicit any compiler error

### DIFF
--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -54,7 +54,7 @@ export function RegisterRoutes(router: KoaRouter) {
             {{#if security.length}}
             authenticateMiddleware({{json security}}),
             {{/if}}
-            async (context, next) => {
+            async (context: any, next: any) => {
             const args = {
                 {{#each parameters}}
                     {{@key}}: {{{json this}}},


### PR DESCRIPTION
explicitly setting to any since otherwise users will get a no implicit any compiler error