### PR TITLE
provided documentation for the feature where we accept controllerPath…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -146,7 +146,7 @@ See [CLI documentation](#command-line-interface)
 #### Programmatic
 
 ```typescript
-import { generateRoutes, generateSwaggerSpec, SwaggerConfig } from 'tsoa';
+import { generateRoutes, generateSwaggerSpec, SwaggerConfig, RoutesConfig } from 'tsoa';
 
 (async () => {
     const swaggerOptions: SwaggerConfig = {
@@ -154,17 +154,24 @@ import { generateRoutes, generateSwaggerSpec, SwaggerConfig } from 'tsoa';
         entryFile: "./api/server.ts",
         specVersion: 3,
         outputDirectory: "./api/dist",
+        controllerPathGlobs: [
+            "./routeControllers/**/*Controller.ts"
+        ]
     }
 
-    await generateSwaggerSpec(swaggerOptions);
-
-    await generateRoutes({
+    const routeOptions: RoutesConfig = {
         basePath: "/api",
         entryFile: "./api/server.ts",
         routesDir: "./api",
-    }, swaggerOptions);
+    }
+
+    await generateSwaggerSpec(swaggerOptions, routeOptions);
+
+    await generateRoutes(routeOptions, swaggerOptions);
 })();
 ```
+
+**Note:** If you use tsoa programmatically, please be aware that tsoa's methods can change in minor and patch releases. But if you are using tsoa in a .ts file, then TypeScript will help you migrate to any changes. We reserve this right to change what are essentially our internal methods so that we can continue to provide incremental value to the majority user (our CLI users). The CLI however will only recieve breaking changes during a major release.
 
 #### Automating Regeneration
 
@@ -237,7 +244,7 @@ by defining it in your tsoa.json configuration. Route paths are generated based 
 You have two options for how to tell tsoa where it can find the controllers that it will use to create the auto-generated `routes.ts` file.
 
 #### (1) Using automatic controllers discovery
-You can tell `tsoa` to use your automatic controllers discovery by providing a [minimatch glob](http://www.globtester.com/) in the [config](https://github.com/lukeautry/tsoa/blob/master/src/config.ts) file (e.g. `tsoa.json`):
+You can tell `tsoa` to use your automatic controllers discovery by providing a [minimatch glob](http://www.globtester.com/) in the [config](https://github.com/lukeautry/tsoa/blob/master/src/config.ts) file (e.g. `tsoa.json`). It can be provided on `config.swagger` or `config.routes`.
 
 Pros:
   * New developers can add a controller without having to know how tsoa "crawls" for the controllers. As long as their controller is caught by the glob that you provide, the controller will be added to the swagger documentation and to the auto-generated `routes.ts` file.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,8 +167,9 @@ async function swaggerSpecGenerator(args) {
 
     const compilerOptions = validateCompilerOptions(config.compilerOptions);
     const swaggerConfig = await validateSwaggerConfig(config.swagger);
+    const routesConfig = await validateRoutesConfig(config.routes);
 
-    await generateSwaggerSpec(swaggerConfig, compilerOptions, config.ignore);
+    await generateSwaggerSpec(swaggerConfig, routesConfig, compilerOptions, config.ignore);
   } catch (err) {
     // tslint:disable-next-line:no-console
     console.error('Generate swagger error.\n', err);

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,11 @@ export interface SwaggerConfig {
   yaml?: boolean;
 
   schemes?: Swagger.Protocol[];
+
+  /**
+   * An array of path globs that point to your route controllers that you would like to have tsoa include. You can provide this config on either the SwaggerConfig or the RoutesConfig
+   */
+  controllerPathGlobs?: string[];
 }
 
 export interface RoutesConfig {
@@ -158,7 +163,7 @@ export interface RoutesConfig {
   authenticationModule?: string;
 
   /**
-   * Controllers glob path, contains directories with wild card to file names.
+   * An array of path globs that point to your route controllers that you would like to have tsoa include. You can provide this config on either the SwaggerConfig or the RoutesConfig
    */
   controllerPathGlobs?: string[];
 }

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -29,7 +29,7 @@ export class TypeResolver {
     private readonly extractEnum = true,
   ) { }
 
-  public static clearCache(){
+  public static clearCache() {
     Object.keys(localReferenceTypeCache).forEach(key => {
       delete localReferenceTypeCache[key];
     });

--- a/src/module/generate-swagger-spec.ts
+++ b/src/module/generate-swagger-spec.ts
@@ -1,16 +1,22 @@
 import * as ts from 'typescript';
 import * as YAML from 'yamljs';
-import { SwaggerConfig } from '../config';
-export { SwaggerConfig } from '../config';
+import { RoutesConfig, SwaggerConfig } from '../config';
+export { SwaggerConfig, Config, RoutesConfig } from '../config';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '../metadataGeneration/tsoa';
 import { SpecGenerator2 } from '../swagger/specGenerator2';
 import { SpecGenerator3 } from '../swagger/specGenerator3';
 import { Swagger } from '../swagger/swagger';
 import { fsExists, fsMkDir, fsWriteFile } from '../utils/fs';
+import { validateMutualConfigs } from '../utils/mutualConfigValidation';
+
+export interface RoutesConfigRelatedToSwagger {
+  controllerPathGlobs?: RoutesConfig['controllerPathGlobs'];
+}
 
 export const generateSwaggerSpec = async (
-  config: SwaggerConfig,
+  swaggerConfig: SwaggerConfig,
+  routesConfigRelatedToSwagger: RoutesConfigRelatedToSwagger,
   compilerOptions?: ts.CompilerOptions,
   ignorePaths?: string[],
   /**
@@ -18,35 +24,44 @@ export const generateSwaggerSpec = async (
    */
   metadata?: Tsoa.Metadata,
 ) => {
+
+  // NOTE: I did not realize that the controllerPathGlobs was related to both swagger
+  //   and route generation when I merged https://github.com/lukeautry/tsoa/pull/396
+  //   So this allows tsoa consumers to submit it on either config and tsoa will respect the selection
+  if (routesConfigRelatedToSwagger.controllerPathGlobs && !swaggerConfig.controllerPathGlobs) {
+    swaggerConfig.controllerPathGlobs = routesConfigRelatedToSwagger.controllerPathGlobs;
+  }
+  validateMutualConfigs(routesConfigRelatedToSwagger, swaggerConfig);
+
   if (!metadata) {
     metadata = new MetadataGenerator(
-      config.entryFile,
+      swaggerConfig.entryFile,
       compilerOptions,
       ignorePaths,
-      config.controllerPathGlobs
+      swaggerConfig.controllerPathGlobs,
     ).Generate();
   }
 
   let spec: Swagger.Spec;
-  if (config.specVersion && config.specVersion === 3) {
-    spec = new SpecGenerator3(metadata, config).GetSpec();
+  if (swaggerConfig.specVersion && swaggerConfig.specVersion === 3) {
+    spec = new SpecGenerator3(metadata, swaggerConfig).GetSpec();
   } else {
-    spec = new SpecGenerator2(metadata, config).GetSpec();
+    spec = new SpecGenerator2(metadata, swaggerConfig).GetSpec();
   }
 
-  const exists = await fsExists(config.outputDirectory);
+  const exists = await fsExists(swaggerConfig.outputDirectory);
   if (!exists) {
-    await fsMkDir(config.outputDirectory);
+    await fsMkDir(swaggerConfig.outputDirectory);
   }
 
   let data = JSON.stringify(spec, null, '\t');
-  if (config.yaml) {
+  if (swaggerConfig.yaml) {
     data = YAML.stringify(JSON.parse(data), 10);
   }
-  const ext = config.yaml ? 'yaml' : 'json';
+  const ext = swaggerConfig.yaml ? 'yaml' : 'json';
 
   await fsWriteFile(
-    `${config.outputDirectory}/swagger.${ext}`,
+    `${swaggerConfig.outputDirectory}/swagger.${ext}`,
     data,
     { encoding: 'utf8' },
   );

--- a/src/routeGeneration/routeGenerator.ts
+++ b/src/routeGeneration/routeGenerator.ts
@@ -11,6 +11,7 @@ import { TsoaRoute } from './tsoa-route';
 
 export interface SwaggerConfigRelatedToRoutes {
   noImplicitAdditionalProperties?: SwaggerConfig['noImplicitAdditionalProperties'];
+  controllerPathGlobs?: SwaggerConfig['controllerPathGlobs'];
 }
 
 export class RouteGenerator {

--- a/src/utils/mutualConfigValidation.ts
+++ b/src/utils/mutualConfigValidation.ts
@@ -1,0 +1,36 @@
+import { RoutesConfigRelatedToSwagger } from '..';
+import { SwaggerConfigRelatedToRoutes } from '../routeGeneration/routeGenerator';
+
+export const validateMutualConfigs = (routesConfig: RoutesConfigRelatedToSwagger, swaggerConfig: SwaggerConfigRelatedToRoutes): void => {
+  const validateControllerPathGlobs = (test: string[]): void => {
+
+      if (!Array.isArray(test)) {
+          throw new Error(`controllerPathGlobs must be an array`);
+      }
+      if (!test.length) {
+          throw new Error(`controllerPathGlobs must include at least one glob string`);
+      }
+      test.forEach(item => {
+          if (typeof item !== 'string' || item === '') {
+              throw new Error(`Found a value (${item}) that is not a valid glob for controllerPathGlobs`);
+          }
+      });
+  };
+
+  const haveSameValues = (array1: string[], array2: string[]): boolean => {
+      return array1.every(item => array2.includes(item));
+  };
+
+  if (routesConfig.controllerPathGlobs) {
+      validateControllerPathGlobs(routesConfig.controllerPathGlobs);
+  }
+  if (swaggerConfig.controllerPathGlobs) {
+      validateControllerPathGlobs(swaggerConfig.controllerPathGlobs);
+  }
+  if (swaggerConfig.controllerPathGlobs && routesConfig.controllerPathGlobs) {
+      if (!haveSameValues(swaggerConfig.controllerPathGlobs, routesConfig.controllerPathGlobs)) {
+          throw new Error(`You do not have to pass controllerPathGlobs for both SwaggerConfig and RoutesConfig; ` +
+          `but if you do, then they must have the same values. Current they differ.`);
+      }
+  }
+};

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 import { SwaggerConfig } from '../src/config';
 import { generateRoutes } from '../src/module/generate-routes';
-import { generateSwaggerSpec } from '../src/module/generate-swagger-spec';
+import { generateSwaggerSpec, RoutesConfigRelatedToSwagger } from '../src/module/generate-swagger-spec';
 import { Timer } from './utils/timer';
 
 const defaultOptions: SwaggerConfig = {
@@ -34,8 +34,12 @@ const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<Swagger
   outputDirectory: './distForNoAdditional',
 });
 
+const routesConfigRelatedToSwagger: RoutesConfigRelatedToSwagger = {
+    controllerPathGlobs: defaultOptions.controllerPathGlobs,
+};
+
 const spec = () => {
-  return generateSwaggerSpec(defaultOptions);
+  return generateSwaggerSpec(defaultOptions, routesConfigRelatedToSwagger);
 };
 
 const log = async <T>(label: string, fn: () => Promise<T>) => {

--- a/tests/unit/swagger/config.spec.ts
+++ b/tests/unit/swagger/config.spec.ts
@@ -1,76 +1,202 @@
 import { expect } from 'chai';
 import 'mocha';
 import { validateSwaggerConfig } from '../../../src/cli';
-import { SwaggerConfig } from '../../../src/config';
+import { Config, SwaggerConfig } from '../../../src/config';
+import { validateMutualConfigs } from '../../../src/utils/mutualConfigValidation';
 import { getDefaultOptions } from '../../fixtures/defaultOptions';
 
 describe('Configuration', () => {
 
-  it('should reject when outputDirectory is not set', (done) => {
+  describe('.validateSwaggerConfig', () => {
 
-    const config: SwaggerConfig = getDefaultOptions();
-    validateSwaggerConfig(config).then((result) => {
-      throw new Error('Should not get here, expecting error regarding outputDirectory');
-    }, (err) => {
-      expect(err.message).to.equal('Missing outputDirectory: configuration must contain output directory.');
-      done();
+    it('should reject when outputDirectory is not set', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions();
+      validateSwaggerConfig(config).then((result) => {
+        throw new Error('Should not get here, expecting error regarding outputDirectory');
+      }, (err) => {
+        expect(err.message).to.equal('Missing outputDirectory: configuration must contain output directory.');
+        done();
+      });
+
+    });
+
+    it('should reject when entryFile is not set', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory');
+      validateSwaggerConfig(config).then((result) => {
+        throw new Error('Should not get here, expecting error regarding entryFile');
+      }, (err) => {
+        expect(err.message).to.equal('Missing entryFile: Configuration must contain an entry point file.');
+        done();
+      });
+
+    });
+
+    it('should set the default API version', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
+        expect(configResult.version).to.equal('1.0.0');
+        done();
+      });
+
+    });
+
+    it('should set the default Spec version 2 when not specified', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
+        expect(configResult.specVersion).to.equal(2);
+        done();
+      });
+
+    });
+
+    it('should reject an unsupported Spec version', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
+      config.specVersion = -2 as any;
+      validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
+        throw new Error('Should not get here, expecting error regarding unsupported Spec version');
+      }, (err) => {
+        expect(err.message).to.equal('Unsupported Spec version.');
+        done();
+      });
+
+    });
+
+    it('should accept Spec version 3 when specified', (done) => {
+
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      config.specVersion = 3;
+      validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
+        expect(configResult.specVersion).to.equal(3);
+        done();
+      });
+
     });
 
   });
 
-  it('should reject when entryFile is not set', (done) => {
+  describe('.validateMutualConfigs', () => {
 
-    const config: SwaggerConfig = getDefaultOptions('some/output/directory');
-    validateSwaggerConfig(config).then((result) => {
-      throw new Error('Should not get here, expecting error regarding entryFile');
-    }, (err) => {
-      expect(err.message).to.equal('Missing entryFile: Configuration must contain an entry point file.');
-      done();
+    it('should throw if config.routes.controllerPathGlobs in an empty array', () => {
+      // Arrange
+      const config: Config = {
+        routes: {
+          controllerPathGlobs: [],
+        },
+        swagger: {},
+      } as any;
+      const expectedError = 'controllerPathGlobs must include at least one glob string';
+
+      // tslint:disable-next-line: no-unnecessary-initializer
+      let errToValidate: Error | undefined = undefined;
+      try {
+        validateMutualConfigs(config.routes, config.swagger);
+      } catch (err) {
+        errToValidate = err;
+      }
+      if (!errToValidate) {
+        throw new Error(`We expected to get a failure but we did not. Expected error was ${expectedError}`);
+      }
+      expect(errToValidate.message).to.equal(expectedError);
     });
 
-  });
+    it('should throw if config.swagger.controllerPathGlobs in an empty array', () => {
+      // Arrange
+      const config: Config = {
+        routes: {},
+        swagger: {
+          controllerPathGlobs: [],
+        },
+      } as any;
+      const expectedError = 'controllerPathGlobs must include at least one glob string';
 
-  it('should set the default API version', (done) => {
-
-    const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
-    validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
-      expect(configResult.version).to.equal('1.0.0');
-      done();
+      // tslint:disable-next-line: no-unnecessary-initializer
+      let errToValidate: Error | undefined = undefined;
+      try {
+        validateMutualConfigs(config.routes, config.swagger);
+      } catch (err) {
+        errToValidate = err;
+      }
+      if (!errToValidate) {
+        throw new Error(`We expected to get a failure but we did not. Expected error was ${expectedError}`);
+      }
+      expect(errToValidate.message).to.equal(expectedError);
     });
 
-  });
+    it('should throw if config.routes.controllerPathGlobs has empty strings', () => {
+      // Arrange
+      const config: Config = {
+        routes: {
+          controllerPathGlobs: [],
+        },
+        swagger: {},
+      } as any;
+      const expectedError = `controllerPathGlobs must include at least one glob string`;
 
-  it('should set the default Spec version 2 when not specified', (done) => {
-
-    const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
-    validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
-      expect(configResult.specVersion).to.equal(2);
-      done();
+      // tslint:disable-next-line: no-unnecessary-initializer
+      let errToValidate: Error | undefined = undefined;
+      try {
+        validateMutualConfigs(config.routes, config.swagger);
+      } catch (err) {
+        errToValidate = err;
+      }
+      if (!errToValidate) {
+        throw new Error(`We expected to get a failure but we did not. Expected error was ${expectedError}`);
+      }
+      expect(errToValidate.message).to.equal(expectedError);
     });
 
-  });
+    it('should throw if config.swagger.controllerPathGlobs has empty strings', () => {
+      // Arrange
+      const config: Config = {
+        routes: {},
+        swagger: {
+          controllerPathGlobs: [''],
+        },
+      } as any;
+      const expectedError = `Found a value () that is not a valid glob for controllerPathGlobs`;
 
-  it('should reject an unsupported Spec version', (done) => {
-
-    const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
-    // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
-    config.specVersion = -2 as any;
-    validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
-      throw new Error('Should not get here, expecting error regarding unsupported Spec version');
-    }, (err) => {
-      expect(err.message).to.equal('Unsupported Spec version.');
-      done();
+      // tslint:disable-next-line: no-unnecessary-initializer
+      let errToValidate: Error | undefined = undefined;
+      try {
+        validateMutualConfigs(config.routes, config.swagger);
+      } catch (err) {
+        errToValidate = err;
+      }
+      if (!errToValidate) {
+        throw new Error(`We expected to get a failure but we did not. Expected error was ${expectedError}`);
+      }
+      expect(errToValidate.message).to.equal(expectedError);
     });
 
-  });
+    it('should throw if both controllerPathGlobs values do not match', () => {
+      // Arrange
+      const config: Config = {
+        routes: {
+          controllerPathGlobs: ['directory1/**/*'],
+        },
+        swagger: {
+          controllerPathGlobs: ['directory2/**'],
+        },
+      } as any;
+      const expectedError = `You do not have to pass controllerPathGlobs for both SwaggerConfig and RoutesConfig; but if you do, then they must have the same values. Current they differ.`;
 
-  it('should accept Spec version 3 when specified', (done) => {
-
-    const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
-    config.specVersion = 3;
-    validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
-      expect(configResult.specVersion).to.equal(3);
-      done();
+      // tslint:disable-next-line: no-unnecessary-initializer
+      let errToValidate: Error | undefined = undefined;
+      try {
+        validateMutualConfigs(config.routes, config.swagger);
+      } catch (err) {
+        errToValidate = err;
+      }
+      if (!errToValidate) {
+        throw new Error(`We expected to get a failure but we did not. Expected error was ${expectedError}`);
+      }
+      expect(errToValidate.message).to.equal(expectedError);
     });
 
   });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -9,7 +9,7 @@ import { TestModel } from '../../../fixtures/testModel';
 
 describe('Definition generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
-  const dynamicMetadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts', undefined, undefined, ['./tests/fixtures/controllers/getController.ts'],).Generate();
+  const dynamicMetadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts', undefined, undefined, ['./tests/fixtures/controllers/getController.ts']).Generate();
   const defaultOptions = getDefaultOptions();
   const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
     noImplicitAdditionalProperties: 'silently-remove-extras',
@@ -103,7 +103,7 @@ describe('Definition generation', () => {
             it('should produce schemas for the properties and should make a choice about additionalProperties', () => {
                 if (!definition.properties) { throw new Error('Definition has no properties.'); }
 
-              if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
+                if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
                     expect(definition.additionalProperties).to.eq(false, forSpec(currentSpec));
                 } else {
                     expect(definition.additionalProperties).to.eq(true, forSpec(currentSpec));
@@ -164,7 +164,7 @@ describe('Definition generation', () => {
                 },
                 object: (propertyName, propertySchema) => {
                     expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-                  if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
+                    if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
                         expect(propertySchema.additionalProperties).to.eq(false, forSpec(currentSpec));
                     } else {
                         expect(propertySchema.additionalProperties).to.eq(true, forSpec(currentSpec));
@@ -178,7 +178,7 @@ describe('Definition generation', () => {
                     // The "PetShop" Swagger editor considers it valid to have additionalProperties on an array of objects
                     //      So, let's convince TypeScript
                     const itemsAsSchema = propertySchema.items as Swagger.Schema;
-                  if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
+                    if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
                         expect(itemsAsSchema.additionalProperties).to.eq(false, forSpec(currentSpec));
                     } else {
                         expect(itemsAsSchema.additionalProperties).to.eq(true, forSpec(currentSpec));


### PR DESCRIPTION
…Globs from either config.

Fixed #420 

Note: the only way that I felt that this could be introduced without causing undue burden on the user was to look for the new property (`controllerPathGlob`) on either swaggerConfig or routeConfig. This is a breaking change to only users who use tsoa programmatically. I provide justification for that in the readme: https://github.com/lukeautry/tsoa/pull/430/files#diff-26205fa396afae7e698346556c23f256R174

> **Note:** If you use tsoa programmatically, please be aware that tsoa's methods can change in minor and patch releases. But if you are using tsoa in a .ts file, then TypeScript will help you migrate to any changes. We reserve this right to change what are essentially our internal methods so that we can continue to provide incremental value to the majority user (our CLI users). The CLI however will only recieve breaking changes during a major release.