### PR TITLE
Fix Model validation if value is not an Object

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -381,6 +381,14 @@ export class ValidationService {
         return this.validateEnum(name, value, fieldErrors, enums, parent);
       }
 
+      if (!(value instanceof Object)) {
+        fieldErrors[parent + name] = {
+          message: `invalid object`,
+          value,
+        };
+        return;
+      }
+
       const properties = modelDefinition.properties || {};
       const keysOnPropertiesModelDefinition = new Set(Object.keys(properties));
       const allPropertiesOnData = new Set(Object.keys(value));

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -258,6 +258,8 @@ export class ValidateModel {
    * @ignore
    */
   public ignoredProperty: string;
+
+  public model: TypeAliasModel1;
 }
 
 export interface ValidateMapStringToNumber {

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -376,6 +376,7 @@ describe('Express Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
       bodyModel.arrayUniqueItem = [0, 1, 2, 3];
+      bodyModel.model = { value1: 'abcdef'};
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const { body } = res;
@@ -399,6 +400,7 @@ describe('Express Server', () => {
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.arrayUniqueItem).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.model).to.deep.equal(bodyModel.model);
       }, 200);
     });
 
@@ -421,6 +423,7 @@ describe('Express Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
       bodyModel.arrayUniqueItem = [0, 0, 1, 1];
+      bodyModel.model = 1 as any;
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const body = JSON.parse(err.text);
@@ -458,6 +461,8 @@ describe('Express Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.fields['body.model'].message).to.equal('invalid object');
+        expect(body.fields['body.model'].value).to.deep.equal(bodyModel.model);
       }, 400);
     });
 

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -376,6 +376,7 @@ describe('Express Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
       bodyModel.arrayUniqueItem = [0, 1, 2, 3];
+      bodyModel.model = { value1: 'abcdef'};
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const { body } = res;
@@ -399,6 +400,7 @@ describe('Express Server', () => {
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.arrayUniqueItem).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.model).to.deep.equal(bodyModel.model);
       }, 200);
     });
 
@@ -421,6 +423,7 @@ describe('Express Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
       bodyModel.arrayUniqueItem = [0, 0, 1, 1];
+      bodyModel.model = 1 as any;
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const body = JSON.parse(err.text);
@@ -458,6 +461,8 @@ describe('Express Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.fields['body.model'].message).to.equal('invalid object');
+        expect(body.fields['body.model'].value).to.deep.equal(bodyModel.model);
       }, 400);
     });
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -362,6 +362,7 @@ describe('Hapi Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
       bodyModel.arrayUniqueItem = [0, 1, 2, 3];
+      bodyModel.model = { value1: 'abcdef'};
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const { body } = res;
@@ -385,6 +386,7 @@ describe('Hapi Server', () => {
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.arrayUniqueItem).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.model).to.deep.equal(bodyModel.model);
       }, 200);
     });
 
@@ -407,6 +409,7 @@ describe('Hapi Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
       bodyModel.arrayUniqueItem = [0, 0, 1, 1];
+      bodyModel.model = 1 as any;
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const body = JSON.parse(err.text);
@@ -444,9 +447,10 @@ describe('Hapi Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.fields['body.model'].message).to.equal('invalid object');
+        expect(body.fields['body.model'].value).to.deep.equal(bodyModel.model);
       }, 400);
     });
-
     it('should custom required error message', () => {
       return verifyGetRequest(basePath + `/Validate/parameter/customRequiredErrorMsg`, (err, res) => {
         const body = JSON.parse(err.text);

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -109,6 +109,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
       bodyModel.arrayUniqueItem = [0, 1, 2, 3];
+      bodyModel.model = { value1: 'abcdef'};
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const { body } = res;
@@ -132,6 +133,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.arrayUniqueItem).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.model).to.deep.equal(bodyModel.model);
       }, 200);
     });
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -340,6 +340,7 @@ describe('Koa Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
       bodyModel.arrayUniqueItem = [0, 1, 2, 3];
+      bodyModel.model = { value1: 'abcdef'};
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const { body } = res;
@@ -363,6 +364,7 @@ describe('Koa Server', () => {
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.arrayUniqueItem).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.model).to.deep.equal(bodyModel.model);
       }, 200);
     });
 
@@ -385,6 +387,7 @@ describe('Koa Server', () => {
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
       bodyModel.arrayUniqueItem = [0, 0, 1, 1];
+      bodyModel.model = 1 as any;
 
       return verifyPostRequest(basePath + `/Validate/body`, bodyModel, (err, res) => {
         const body = JSON.parse(err.text);
@@ -422,6 +425,8 @@ describe('Koa Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
+        expect(body.fields['body.model'].message).to.equal('invalid object');
+        expect(body.fields['body.model'].value).to.deep.equal(bodyModel.model);
       }, 400);
     });
 


### PR DESCRIPTION
#426 

@dgreene1 I believe recent commits to master broke typescript compilation because Array.includes() which requires es7 as lib in the tsconfig.json is used. I can add it to this PR if you want me to.

```
TSError: ⨯ Unable to compile TypeScript
src/utils/mutualConfigValidation.ts (21,42): Property 'includes' does not exist on type 'string[]'. (2339)
```
