### PR TITLE
reverting the yarn engine requirement to CodeShip's default

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "tsoa": "dist/cli.js"
   },
   "engines": {
-    "yarn": ">=1.17.3",
+    "yarn": ">=1.9.4",
     "node": ">=6.0.0"
   },
   "engineStrict": true


### PR DESCRIPTION
I don't think we actually use the `circle.yml` file in here. So I think we need to eventually get a `codeship-steps.yml` file in here. But until then I want to play nicely with the defaults that Luke has set up in CodeShip.