### PR TITLE
Refactor type aliases

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -139,9 +139,14 @@ export class TypeResolver {
       return literalType;
     }
 
-    const possibleTypeAlias = this.getModelTypeDeclaration(typeReference.typeName);
-    if (ts.isTypeAliasDeclaration(possibleTypeAlias)) {
-      return new TypeResolver(possibleTypeAlias.type, this.current, this.typeNode, this.extractEnum).resolve();
+    const typeAlias = this.getModelTypeDeclaration(typeReference.typeName);
+    if (ts.isTypeAliasDeclaration(typeAlias)) {
+      if (typeAlias.typeParameters && ts.isTypeReferenceNode(typeAlias.type)) {
+        // A typeAlias is the type of the reference. The reference holds the arguments.
+        // We need to capture this and pass it on.
+        typeAlias.type.typeArguments = typeReference.typeArguments;
+      }
+      return new TypeResolver(typeAlias.type, this.current, this.typeNode, this.extractEnum).resolve();
     }
 
     let referenceType: Tsoa.ReferenceType;

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -306,12 +306,31 @@ export class SpecGenerator2 extends SpecGenerator {
     }
     return { type: 'object' };
   }
+
   protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType) {
-    if (process.env.NODE_ENV !== 'tsoa_test') {
-      // tslint:disable-next-line: no-console
-      console.warn('Swagger 2.0 does not support this kind of intersection types.\n' + 'If you would like to take advantage of this, please change tsoa.json\'s "specVersion" to 3.');
-    }
-    return { type: 'object' };
+    const properties = type.types.reduce((acc, type) => {
+      if (type.dataType === 'refObject') {
+        let refType = type as Tsoa.ReferenceType;
+        refType = this.metadata.referenceTypeMap[refType.refName];
+
+        const props =
+          refType &&
+          refType.properties &&
+          refType.properties.reduce((acc, prop) => {
+            return {
+              ...acc,
+              [prop.name]: this.getSwaggerType(prop.type),
+            };
+          }, {});
+        return { ...acc, ...props };
+      } else {
+        // tslint:disable-next-line: no-console
+        process.env.NODE_ENV !== 'tsoa_test' &&
+          console.warn('Swagger 2.0 does not fully support this kind of intersection types.\n' + 'If you would like to take advantage of this, please change tsoa.json\'s "specVersion" to 3.');
+        return { ...acc };
+      }
+    }, {});
+    return { type: 'object', properties };
   }
 
   protected getSwaggerTypeForReferenceType(referenceType: Tsoa.ReferenceType): Swagger.BaseSchema {

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -1,6 +1,6 @@
 import { Controller, Example, Get, OperationId, Query, Request, Route, SuccessResponse, Tags } from '../../../src';
 import '../duplicateTestModel';
-import { GenericModel, TestClassModel, TestModel, TestSubModel } from '../testModel';
+import { GenericTypeModel, TestClassModel, TestModel, TestSubModel } from '../testModel';
 import { ModelService } from './../services/modelService';
 
 @Route('GetTest')
@@ -146,28 +146,28 @@ export class GetTestController extends Controller {
   }
 
   @Get('GenericModel')
-  public async getGenericModel(): Promise<GenericModel<TestModel>> {
+  public async getGenericModel(): Promise<GenericTypeModel<TestModel>> {
     return {
       result: new ModelService().getModel(),
     };
   }
 
   @Get('GenericModelArray')
-  public async getGenericModelArray(): Promise<GenericModel<TestModel[]>> {
+  public async getGenericModelArray(): Promise<GenericTypeModel<TestModel[]>> {
     return {
       result: [new ModelService().getModel()],
     };
   }
 
   @Get('GenericPrimitive')
-  public async getGenericPrimitive(): Promise<GenericModel<string>> {
+  public async getGenericPrimitive(): Promise<GenericTypeModel<string>> {
     return {
       result: new ModelService().getModel().stringValue,
     };
   }
 
   @Get('GenericPrimitiveArray')
-  public async getGenericPrimitiveArray(): Promise<GenericModel<string[]>> {
+  public async getGenericPrimitiveArray(): Promise<GenericTypeModel<string[]>> {
     return {
       result: new ModelService().getModel().stringArray,
     };

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -353,6 +353,8 @@ export class TestClassModel extends TestClassBaseModel {
   }
 }
 
+export type GenericTypeModel<T> = GenericModel<T>;
+
 export interface GenericModel<T> {
   result: T;
 }

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -5,8 +5,8 @@ import { base64image } from '../fixtures/base64image';
 import { app } from '../fixtures/express-dynamic-controllers/server';
 import {
   Gender,
-  GenericModel,
   GenericRequest,
+  GenericTypeModel,
   ParameterTestModel,
   TestClassModel,
   TestModel,
@@ -848,28 +848,28 @@ describe('Express Server', () => {
 
     it('can get request with generic type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
-        const model = res.body as GenericModel<TestModel>;
+        const model = res.body as GenericTypeModel<TestModel>;
         expect(model.result.id).to.equal(1);
       });
     });
 
     it('can get request with generic array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
-        const model = res.body as GenericModel<TestModel[]>;
+        const model = res.body as GenericTypeModel<TestModel[]>;
         expect(model.result[0].id).to.equal(1);
       });
     });
 
     it('can get request with generic primative type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
-        const model = res.body as GenericModel<string>;
+        const model = res.body as GenericTypeModel<string>;
         expect(model.result).to.equal('a string');
       });
     });
 
     it('can get request with generic primative array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
-        const model = res.body as GenericModel<string[]>;
+        const model = res.body as GenericTypeModel<string[]>;
         expect(model.result[0]).to.equal('string one');
       });
     });

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -5,8 +5,8 @@ import { base64image } from '../fixtures/base64image';
 import { app } from '../fixtures/express/server';
 import {
   Gender,
-  GenericModel,
   GenericRequest,
+  GenericTypeModel,
   ParameterTestModel,
   TestClassModel,
   TestModel,
@@ -848,28 +848,28 @@ describe('Express Server', () => {
 
     it('can get request with generic type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
-        const model = res.body as GenericModel<TestModel>;
+        const model = res.body as GenericTypeModel<TestModel>;
         expect(model.result.id).to.equal(1);
       });
     });
 
     it('can get request with generic array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
-        const model = res.body as GenericModel<TestModel[]>;
+        const model = res.body as GenericTypeModel<TestModel[]>;
         expect(model.result[0].id).to.equal(1);
       });
     });
 
     it('can get request with generic primative type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
-        const model = res.body as GenericModel<string>;
+        const model = res.body as GenericTypeModel<string>;
         expect(model.result).to.equal('a string');
       });
     });
 
     it('can get request with generic primative array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
-        const model = res.body as GenericModel<string[]>;
+        const model = res.body as GenericTypeModel<string[]>;
         expect(model.result[0]).to.equal('string one');
       });
     });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -2,7 +2,18 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/hapi/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
+import {
+  Gender,
+  GenericRequest,
+  GenericTypeModel,
+  Model,
+  ParameterTestModel,
+  TestClassModel,
+  TestModel,
+  ValidateMapStringToAny,
+  ValidateMapStringToNumber,
+  ValidateModel,
+} from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -777,28 +788,28 @@ describe('Hapi Server', () => {
 
     it('can get request with generic type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
-        const model = res.body as GenericModel<TestModel>;
+        const model = res.body as GenericTypeModel<TestModel>;
         expect(model.result.id).to.equal(1);
       });
     });
 
     it('can get request with generic array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
-        const model = res.body as GenericModel<TestModel[]>;
+        const model = res.body as GenericTypeModel<TestModel[]>;
         expect(model.result[0].id).to.equal(1);
       });
     });
 
     it('can get request with generic primative type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
-        const model = res.body as GenericModel<string>;
+        const model = res.body as GenericTypeModel<string>;
         expect(model.result).to.equal('a string');
       });
     });
 
     it('can get request with generic primative array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
-        const model = res.body as GenericModel<string[]>;
+        const model = res.body as GenericTypeModel<string[]>;
         expect(model.result[0]).to.equal('string one');
       });
     });

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -2,7 +2,18 @@ import { expect } from 'chai';
 import 'mocha';
 import * as request from 'supertest';
 import { server } from '../fixtures/koa/server';
-import { Gender, GenericModel, GenericRequest, Model, ParameterTestModel, TestClassModel, TestModel, ValidateMapStringToAny, ValidateMapStringToNumber, ValidateModel } from '../fixtures/testModel';
+import {
+  Gender,
+  GenericRequest,
+  GenericTypeModel,
+  Model,
+  ParameterTestModel,
+  TestClassModel,
+  TestModel,
+  ValidateMapStringToAny,
+  ValidateMapStringToNumber,
+  ValidateModel,
+} from '../fixtures/testModel';
 
 const basePath = '/v1';
 
@@ -766,28 +777,28 @@ describe('Koa Server', () => {
 
     it('can get request with generic type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModel', (err, res) => {
-        const model = res.body as GenericModel<TestModel>;
+        const model = res.body as GenericTypeModel<TestModel>;
         expect(model.result.id).to.equal(1);
       });
     });
 
     it('can get request with generic array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericModelArray', (err, res) => {
-        const model = res.body as GenericModel<TestModel[]>;
+        const model = res.body as GenericTypeModel<TestModel[]>;
         expect(model.result[0].id).to.equal(1);
       });
     });
 
     it('can get request with generic primative type', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitive', (err, res) => {
-        const model = res.body as GenericModel<string>;
+        const model = res.body as GenericTypeModel<string>;
         expect(model.result).to.equal('a string');
       });
     });
 
     it('can get request with generic primative array', () => {
       return verifyGetRequest(basePath + '/GetTest/GenericPrimitiveArray', (err, res) => {
-        const model = res.body as GenericModel<string[]>;
+        const model = res.body as GenericTypeModel<string[]>;
         expect(model.result[0]).to.equal('string one');
       });
     });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -127,6 +127,7 @@ describe('Definition generation', () => {
         }
 
         expect(definition.properties.and.type).to.equal('object');
+        expect(definition.properties.and.properties).to.deep.equal({ value1: { type: 'string' }, value2: { type: 'string' } });
       });
     });
 
@@ -362,12 +363,12 @@ describe('Definition generation', () => {
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS_Alias: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace_TestSubModelContainer', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace.TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS2_Alias: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace_InnerNamespace_TestSubModelContainer2', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace.InnerNamespace.TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
@@ -382,13 +383,13 @@ describe('Definition generation', () => {
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           typeAliasCase1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/TypeAliasModelCase1', `for property ${propertyName}.$ref`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.type).to.eq('object');
+            expect(propertySchema.properties).to.deep.equal({ value1: { type: 'string' }, value2: { type: 'string' } });
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           TypeAliasCase2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/TypeAliasModelCase2', `for property ${propertyName}.$ref`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.type).to.eq('object');
+            expect(propertySchema.properties).to.deep.equal({ value3: { type: 'string' } });
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           genericMultiNested: (propertyName, propertySchema) => {
@@ -407,12 +408,12 @@ describe('Definition generation', () => {
             expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestTypeAliasModel2Array', `for property ${propertyName}.$ref`);
           },
           and: (propertyName, propertySchema) => {
-            expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.type).to.eq('object', `for property ${propertyName}.type`);
+            expect(propertySchema.properties).to.deep.equal({ value1: { type: 'string' }, value2: { type: 'string' } }, `for property ${propertyName}.properties`);
           },
           referenceAnd: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/TypeAliasModelCase1', `for property ${propertyName}.$ref`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.type).to.eq('object', `for property ${propertyName}.type`);
+            expect(propertySchema.properties).to.deep.equal({ value1: { type: 'string' }, value2: { type: 'string' } }, `for property ${propertyName}.properties`);
           },
           or: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -371,12 +371,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS_Alias: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace_TestSubModelContainer', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace.TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS2_Alias: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace_InnerNamespace_TestSubModelContainer2', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace.InnerNamespace.TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
           },
@@ -391,14 +391,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
           },
           typeAliasCase1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/TypeAliasModelCase1', `for property ${propertyName}.$ref`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.allOf).to.deep.eq([{ $ref: '#/components/schemas/TypeAliasModel1' }, { $ref: '#/components/schemas/TypeAliasModel2' }], `for property ${propertyName}.$ref`);
           },
           TypeAliasCase2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/TypeAliasModelCase2', `for property ${propertyName}.$ref`);
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.allOf).to.deep.eq(
+              [{ allOf: [{ $ref: '#/components/schemas/TypeAliasModel1' }, { $ref: '#/components/schemas/TypeAliasModel2' }] }, { $ref: '#/components/schemas/TypeAliasModel3' }],
+              `for property ${propertyName}.$ref`,
+            );
           },
           genericMultiNested: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestGenericRequestTypeAliasModel1', `for property ${propertyName}.$ref`);
@@ -425,13 +424,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           referenceAnd: (propertyName, propertySchema) => {
-            expect(propertySchema).to.deep.include(
-              {
-                $ref: '#/components/schemas/TypeAliasModelCase1',
-              },
-              `for property ${propertyName}.$ref`,
-            );
-            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.allOf).to.deep.eq([{ $ref: '#/components/schemas/TypeAliasModel1' }, { $ref: '#/components/schemas/TypeAliasModel2' }], `for property ${propertyName}.$refs`);
           },
           or: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.include(


### PR DESCRIPTION
**Historic context:**
As far as I can tell, resolving type aliases was introduced to support a narrow set of intersection types. 2 interfaces were scanned for properties and merged together.

**Why may this not make sense anymore?**
Now that we can properly represent the metadata of an intersection, we can use that to support the (narrowly defined) Swagger 2 representation of 2 interfaces.
However, we should eliminate that code path from type resolving and handle type aliases "properly": #429

**What's the cost?**
This would break some swagger component/definition names (In my mind, the new representation is better and consistent with nested interfaces, that's why I would prefer the new way):

`#/components/schemas/Namespace_InnerNamespace_TestModel`
would become
`#/components/schemas/Namespace.InnerNamespace.TestModel`

(OpenAPI3, Swagger is similar)

Furthermore, there would no longer be a definition/component for the alias, the content would be inlined.

**What's the benefit?**
We remove a legacy code path from the typeResolver that does not make sense anymore.
We get more consistent naming with fewer code.
We avoid issues with type aliases themselves (we forward the resolution responsibility to the thing referenced by the type alias)
We are closer to the TypeScript internals (See #429) and it would make it easier to support i.e. TS convenience types.
Why?: Pick, Omit, ..., all the convenience types are type aliases.
If we want to support them at a point in time, the way to do that would be to resolve the mapped type py passing the arguments to the type alias to the mapped type.
```
type Pick<T, K extends keyof T> = {
    [P in K]: T[P];
};
```