### PR TITLE
Generics: Use %-encoded escaped names to prevent clashes

### DIFF
--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -85,7 +85,7 @@ export class GetTestController extends Controller {
     @Query() stringParam: string,
     @Query() numberParam: number,
     @Query() optionalStringParam = '',
-  ) {
+  ): Promise<TestModel> {
     const model = new ModelService().getModel();
     model.optionalString = optionalStringParam;
     model.numberValue = numberPathParam;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -391,19 +391,19 @@ describe('Definition generation', () => {
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
           },
           genericMultiNested: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestGenericRequestTypeAliasModel1', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_GenericRequest_TypeAliasModel1__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayKeyword1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestArrayTypeAliasModel1', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_Array_TypeAliasModel1__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayCharacter1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestTypeAliasModel1Array', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_TypeAliasModel1Array_', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayKeyword2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestArrayTypeAliasModel2', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_Array_TypeAliasModel2__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayCharacter2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequestTypeAliasModel2Array', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_TypeAliasModel2Array_', `for property ${propertyName}.$ref`);
           },
           and: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
@@ -679,7 +679,7 @@ describe('Definition generation', () => {
         });
 
         it('should generate different definitions for a generic model', () => {
-          const genericDefinition = getValidatedDefinition('GenericModelTestModel', currentSpec).properties;
+          const genericDefinition = getValidatedDefinition('GenericModel_TestModel_', currentSpec).properties;
 
           if (!genericDefinition) {
             throw new Error(`There were no properties on model.`);
@@ -693,7 +693,7 @@ describe('Definition generation', () => {
           expect(property.$ref).to.equal('#/definitions/TestModel');
         });
         it('should generate different definitions for a generic model array', () => {
-          const definition = getValidatedDefinition('GenericModelTestModelArray', currentSpec).properties;
+          const definition = getValidatedDefinition('GenericModel_TestModelArray_', currentSpec).properties;
 
           if (!definition) {
             throw new Error(`There were no properties on model.`);
@@ -715,7 +715,7 @@ describe('Definition generation', () => {
           expect((property.items as Swagger.Schema).$ref).to.equal('#/definitions/TestModel');
         });
         it('should generate different definitions for a generic primitive', () => {
-          const definition = getValidatedDefinition('GenericModelstring', currentSpec).properties;
+          const definition = getValidatedDefinition('GenericModel_string_', currentSpec).properties;
 
           if (!definition) {
             throw new Error(`There were no properties on model.`);
@@ -729,7 +729,7 @@ describe('Definition generation', () => {
           expect(property.type).to.equal('string');
         });
         it('should generate different definitions for a generic primitive array', () => {
-          const definition = getValidatedDefinition('GenericModelstringArray', currentSpec).properties;
+          const definition = getValidatedDefinition('GenericModel_stringArray_', currentSpec).properties;
 
           if (!definition) {
             throw new Error(`There were no properties on model.`);
@@ -751,33 +751,33 @@ describe('Definition generation', () => {
           expect((property.items as Swagger.Schema).type).to.equal('string');
         });
         it('should propagate generics', () => {
-          const definition = getValidatedDefinition('GenericModelTestModelArray', currentSpec).properties;
+          const definition = getValidatedDefinition('GenericModel_TestModelArray_', currentSpec).properties;
 
           expect(definition!.result).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined });
           expect(definition!.union).to.deep.equal({ type: 'object', description: undefined, format: undefined, default: undefined, 'x-nullable': true });
-          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequestTestModelArray', description: undefined, format: undefined, 'x-nullable': true });
+          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequest_TestModelArray_', description: undefined, format: undefined, 'x-nullable': true });
 
-          const ref = getValidatedDefinition('GenericRequestTestModelArray', currentSpec).properties;
+          const ref = getValidatedDefinition('GenericRequest_TestModelArray_', currentSpec).properties;
           expect(ref!.name).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
           expect(ref!.value).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined });
         });
         it('should not propagate dangling context', () => {
-          const definition = getValidatedDefinition('DanglingContextnumber', currentSpec).properties;
+          const definition = getValidatedDefinition('DanglingContext_number_', currentSpec).properties;
 
           expect(definition!.number).to.deep.equal({ type: 'number', format: 'double', description: undefined, default: undefined });
           expect(definition!.shouldBeString!.$ref).to.deep.equal('#/definitions/TSameNameDifferentValue');
         });
         it('should check heritage clauses for type args', () => {
-          const definition = getValidatedDefinition('GenericModelTestModelArray', currentSpec).properties;
+          const definition = getValidatedDefinition('GenericModel_TestModelArray_', currentSpec).properties;
 
           expect(definition!.heritageCheck).to.deep.equal({
-            $ref: '#/definitions/ThingContainerWithTitleTestModelArray',
+            $ref: '#/definitions/ThingContainerWithTitle_TestModelArray_',
             description: undefined,
             format: undefined,
             'x-nullable': true,
           });
 
-          const ref = getValidatedDefinition('ThingContainerWithTitleTestModelArray', currentSpec).properties;
+          const ref = getValidatedDefinition('ThingContainerWithTitle_TestModelArray_', currentSpec).properties;
           expect(ref!.title).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
           expect(ref!.t).to.deep.equal({
             default: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -428,19 +428,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
           },
           genericMultiNested: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestGenericRequestTypeAliasModel1', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_GenericRequest_TypeAliasModel1__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayKeyword1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestArrayTypeAliasModel1', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_Array_TypeAliasModel1__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayCharacter1: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestTypeAliasModel1Array', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_TypeAliasModel1Array_', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayKeyword2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestArrayTypeAliasModel2', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_Array_TypeAliasModel2__', `for property ${propertyName}.$ref`);
           },
           genericNestedArrayCharacter2: (propertyName, propertySchema) => {
-            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequestTypeAliasModel2Array', `for property ${propertyName}.$ref`);
+            expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_TypeAliasModel2Array_', `for property ${propertyName}.$ref`);
           },
           and: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.include(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue? #470

**Closing issues**

Closes #470 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This changes the names of the generated schemas and therefore may be a breaking change if you rely on the names of the schemas (if you do, please tell me why)

**Test plan**

I updated existing names. By additionally encoding potentially unescaped by illegal characters, it should be impossible to generate illegal names (although they will be harder to decipher)


I believe we could hold off on this for 3.0 and merge it together with type alias changes I'm currently working on. 