### PR TITLE
feat: generate both swagger and routes with one metadata call

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,17 @@ const jsonArgs: yargs.Options = {
   type: 'boolean',
 };
 
+export interface ConfigArgs {
+  basePath?: string;
+  configuration?: string;
+}
+
+export interface SwaggerArgs extends ConfigArgs {
+  host?: string;
+  json?: boolean;
+  yaml?: boolean;
+}
+
 yargs
   .usage('Usage: $0 <command> [options]')
   .demand(1)
@@ -181,7 +192,7 @@ yargs
   .help('help')
   .alias('help', 'h').argv;
 
-async function swaggerSpecGenerator(args) {
+async function swaggerSpecGenerator(args: SwaggerArgs) {
   try {
     const config = await getConfig(args.configuration);
     if (args.basePath) {
@@ -209,7 +220,7 @@ async function swaggerSpecGenerator(args) {
   }
 }
 
-async function routeGenerator(args) {
+async function routeGenerator(args: ConfigArgs) {
   try {
     const config = await getConfig(args.configuration);
     if (args.basePath) {
@@ -228,7 +239,7 @@ async function routeGenerator(args) {
   }
 }
 
-async function generateSwaggerAndRoutes(args) {
+async function generateSwaggerAndRoutes(args: SwaggerArgs) {
   try {
     const config = await getConfig(args.configuration);
     if (args.basePath) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,44 +153,46 @@ export interface SwaggerArgs extends ConfigArgs {
   yaml?: boolean;
 }
 
-yargs
-  .usage('Usage: $0 <command> [options]')
-  .demand(1)
-  .command(
-    'swagger',
-    'Generate swagger spec',
-    {
-      basePath: basePathArgs,
-      configuration: configurationArgs,
-      host: hostArgs,
-      json: jsonArgs,
-      yaml: yarmlArgs,
-    },
-    swaggerSpecGenerator,
-  )
-  .command(
-    'routes',
-    'Generate routes',
-    {
-      basePath: basePathArgs,
-      configuration: configurationArgs,
-    },
-    routeGenerator,
-  )
-  .command(
-    'swagger-and-routes',
-    'Generate swagger and routes',
-    {
-      basePath: basePathArgs,
-      configuration: configurationArgs,
-      host: hostArgs,
-      json: jsonArgs,
-      yaml: yarmlArgs,
-    },
-    generateSwaggerAndRoutes,
-  )
-  .help('help')
-  .alias('help', 'h').argv;
+if (!module.parent) {
+  yargs
+    .usage('Usage: $0 <command> [options]')
+    .demand(1)
+    .command(
+      'swagger',
+      'Generate swagger spec',
+      {
+        basePath: basePathArgs,
+        configuration: configurationArgs,
+        host: hostArgs,
+        json: jsonArgs,
+        yaml: yarmlArgs,
+      },
+      swaggerSpecGenerator as any,
+    )
+    .command(
+      'routes',
+      'Generate routes',
+      {
+        basePath: basePathArgs,
+        configuration: configurationArgs,
+      },
+      routeGenerator as any,
+    )
+    .command(
+      'swagger-and-routes',
+      'Generate swagger and routes',
+      {
+        basePath: basePathArgs,
+        configuration: configurationArgs,
+        host: hostArgs,
+        json: jsonArgs,
+        yaml: yarmlArgs,
+      },
+      generateSwaggerAndRoutes as any,
+    )
+    .help('help')
+    .alias('help', 'h').argv;
+}
 
 async function swaggerSpecGenerator(args: SwaggerArgs) {
   try {
@@ -239,7 +241,7 @@ async function routeGenerator(args: ConfigArgs) {
   }
 }
 
-async function generateSwaggerAndRoutes(args: SwaggerArgs) {
+export async function generateSwaggerAndRoutes(args: SwaggerArgs) {
   try {
     const config = await getConfig(args.configuration);
     if (args.basePath) {
@@ -261,7 +263,7 @@ async function generateSwaggerAndRoutes(args: SwaggerArgs) {
 
     const metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, config.ignore, routesConfig.controllerPathGlobs).Generate();
 
-    await Promise.all([
+    return await Promise.all([
       generateRoutes(routesConfig, swaggerConfig, compilerOptions, config.ignore, metadata),
       generateSwaggerSpec(swaggerConfig, routesConfig, compilerOptions, config.ignore, metadata),
     ]);
@@ -269,5 +271,6 @@ async function generateSwaggerAndRoutes(args: SwaggerArgs) {
     // tslint:disable-next-line:no-console
     console.error('Generate routes error.\n', err);
     process.exit(1);
+    throw err;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,6 @@ import { MetadataGenerator } from './metadataGeneration/metadataGenerator';
 import { generateRoutes } from './module/generate-routes';
 import { generateSwaggerSpec } from './module/generate-swagger-spec';
 import { fsExists, fsReadFile } from './utils/fs';
-// import { validateMutualConfigs } from './utils/mutualConfigValidation';
 
 const workingDir: string = process.cwd();
 
@@ -248,11 +247,6 @@ async function generateSwaggerAndRoutes(args) {
     const compilerOptions = validateCompilerOptions(config.compilerOptions);
     const routesConfig = await validateRoutesConfig(config.routes);
     const swaggerConfig = await validateSwaggerConfig(config.swagger);
-
-    // if (swaggerConfig.controllerPathGlobs && !routesConfig.controllerPathGlobs) {
-    //   routesConfig.controllerPathGlobs = swaggerConfig.controllerPathGlobs;
-    // }
-    // validateMutualConfigs(routesConfig, swaggerConfig);
 
     const metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, config.ignore, routesConfig.controllerPathGlobs).Generate();
 

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-console
 import chalk from 'chalk';
+import { generateSwaggerAndRoutes } from '../src/cli';
 import { SwaggerConfig } from '../src/config';
 import { generateRoutes } from '../src/module/generate-routes';
-import { generateSwaggerSpec, RoutesConfigRelatedToSwagger } from '../src/module/generate-swagger-spec';
 import { Timer } from './utils/timer';
 
 const defaultOptions: SwaggerConfig = {
@@ -34,12 +34,11 @@ const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<Swagger
   outputDirectory: './distForNoAdditional',
 });
 
-const routesConfigRelatedToSwagger: RoutesConfigRelatedToSwagger = {
-  controllerPathGlobs: defaultOptions.controllerPathGlobs,
-};
-
-const spec = () => {
-  return generateSwaggerSpec(defaultOptions, routesConfigRelatedToSwagger);
+const spec = async () => {
+  const result = await generateSwaggerAndRoutes({
+    configuration: 'tsoa.json',
+  });
+  return result[0];
 };
 
 const log = async <T>(label: string, fn: () => Promise<T>) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [ ] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

closes #480

### If this is a new feature submission:

* [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This was an experiment I tried to improve the regeneration speed of swagger/routes during development. It reduced the time in our app from 7s to 5s. More time could be reduced by only doing `validateMutualConfigs` once. I'm unsure if this would add value to the project.

**Test plan**
