### PR TITLE
Remove Request.user declarations (#486)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 !dist/**
 !distForNoAdditional/**
+tests/
+docs/

--- a/src/express.d.ts
+++ b/src/express.d.ts
@@ -1,6 +1,0 @@
-import 'express';
-declare module 'express' {
-  export interface Request {
-    user?: any;
-  }
-}

--- a/src/hapi.d.ts
+++ b/src/hapi.d.ts
@@ -1,6 +1,0 @@
-import '@hapi/hapi';
-declare module '@hapi/hapi' {
-  interface Request {
-    user?: any;
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-/// <reference path="express.d.ts" />
-/// <reference path="hapi.d.ts" />
-/// <reference path="koa.d.ts" />
-
 export * from './decorators/example';
 export * from './decorators/parameter';
 export * from './decorators/methods';

--- a/src/koa.d.ts
+++ b/src/koa.d.ts
@@ -1,6 +1,0 @@
-import 'koa';
-declare module 'koa' {
-  interface Request {
-    user?: any;
-  }
-}

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -1,25 +1,8 @@
-import * as hapi from '@hapi/hapi';
-import * as express from 'express';
-import * as koa from 'koa';
 import { Get, Request, Response, Route, Security } from '../../../src';
 import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
 
-declare module 'express' {
-  interface Request {
-    user?: any;
-  }
-}
-
-declare module '@hapi/hapi' {
-  interface Request {
-    user?: any;
-  }
-}
-
-declare module 'koa' {
-  interface Request {
-    user?: any;
-  }
+interface RequestWithUser {
+  user?: any;
 }
 
 @Route('SecurityTest')
@@ -27,28 +10,28 @@ export class SecurityTestController {
   @Response<ErrorResponseModel>('default', 'Unexpected error')
   @Security('api_key')
   @Get()
-  public async GetWithApi(@Request() request: express.Request): Promise<UserResponseModel> {
+  public async GetWithApi(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
   @Response<ErrorResponseModel>('default', 'Unexpected error')
   @Security('api_key')
   @Get('Hapi')
-  public async GetWithApiForHapi(@Request() request: hapi.Request): Promise<UserResponseModel> {
+  public async GetWithApiForHapi(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
   @Response<ErrorResponseModel>('default', 'Unexpected error')
   @Security('api_key')
   @Get('Koa')
-  public async GetWithApiForKoa(@Request() request: koa.Request): Promise<UserResponseModel> {
+  public async GetWithApiForKoa(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
   @Response<ErrorResponseModel>('404', 'Not Found')
   @Security('tsoa_auth', ['write:pets', 'read:pets'])
   @Get('Oauth')
-  public async GetWithSecurity(@Request() request: express.Request): Promise<UserResponseModel> {
+  public async GetWithSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
@@ -56,7 +39,7 @@ export class SecurityTestController {
   @Security('tsoa_auth', ['write:pets', 'read:pets'])
   @Security('api_key')
   @Get('OauthOrAPIkey')
-  public async GetWithOrSecurity(@Request() request: express.Request): Promise<UserResponseModel> {
+  public async GetWithOrSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
@@ -66,14 +49,14 @@ export class SecurityTestController {
     tsoa_auth: ['write:pets', 'read:pets'],
   })
   @Get('OauthAndAPIkey')
-  public async GetWithAndSecurity(@Request() request: express.Request): Promise<UserResponseModel> {
+  public async GetWithAndSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
 
   @Response<ErrorResponseModel>('default', 'Unexpected error')
   @Security('api_key')
   @Get('ServerError')
-  public async GetServerError(@Request() request: express.Request): Promise<UserResponseModel> {
+  public async GetServerError(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.reject(new Error('Unexpected'));
   }
 }

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -4,6 +4,24 @@ import * as koa from 'koa';
 import { Get, Request, Response, Route, Security } from '../../../src';
 import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
 
+declare module 'express' {
+  interface Request {
+    user?: any;
+  }
+}
+
+declare module '@hapi/hapi' {
+  interface Request {
+    user?: any;
+  }
+}
+
+declare module 'koa' {
+  interface Request {
+    user?: any;
+  }
+}
+
 @Route('SecurityTest')
 export class SecurityTestController {
   @Response<ErrorResponseModel>('default', 'Unexpected error')


### PR DESCRIPTION
As discussed in #486. I actually moved them to the test file that uses this property to keep the typescript compiler happy.
I added the tests & docs folder to the .npmignore to avoid conflicts (and because they shouldn't be published as far as I know).
No router template modification was needed because `request` already has an `any`-type there.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [ ] ~~Have you written unit tests?~~ *(not applicable)*
* [ ] ~~Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?~~ *(not applicable)*
* [x] This PR is associated with an existing issue?

**Closing issues**
Closes #486

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
Users might be confused about not having a `user` property, I should probably add a note to the readme that mentions this and shows how to do it for those that don't use an external authentication library that already does this for them.
I have no idea how to properly write such a thing though.