### PR TITLE
Add more info to metadata generation errors

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -121,7 +121,7 @@ export class TypeResolver {
         const indexSignatureDeclaration = indexMember as ts.IndexSignatureDeclaration;
         const indexType = new TypeResolver(indexSignatureDeclaration.parameters[0].type as ts.TypeNode, this.current, this.parentNode, this.extractEnum, this.context).resolve();
         if (indexType.dataType !== 'string') {
-          throw new GenerateMetadataError(`Only string indexers are supported.`);
+          throw new GenerateMetadataError(`Only string indexers are supported.`, this.typeNode);
         }
 
         additionalType = new TypeResolver(indexSignatureDeclaration.type as ts.TypeNode, this.current, this.parentNode, this.extractEnum, this.context).resolve();
@@ -140,7 +140,7 @@ export class TypeResolver {
     }
 
     if (this.typeNode.kind !== ts.SyntaxKind.TypeReference) {
-      throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[this.typeNode.kind]}`);
+      throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[this.typeNode.kind]}`, this.typeNode);
     }
 
     const typeReference = this.typeNode as ts.TypeReferenceNode;
@@ -451,7 +451,7 @@ export class TypeResolver {
     }
 
     if (typeNode.kind !== ts.SyntaxKind.TypeReference) {
-      throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[typeNode.kind]}.`);
+      throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[typeNode.kind]}.`, this.typeNode);
     }
 
     const typeReference = typeNode as ts.TypeReferenceNode;
@@ -713,7 +713,7 @@ export class TypeResolver {
       const indexSignatureDeclaration = indexMember as ts.IndexSignatureDeclaration;
       const indexType = new TypeResolver(indexSignatureDeclaration.parameters[0].type as ts.TypeNode, this.current, this.parentNode, this.extractEnum, this.context).resolve();
       if (indexType.dataType !== 'string') {
-        throw new GenerateMetadataError(`Only string indexers are supported.`);
+        throw new GenerateMetadataError(`Only string indexers are supported.`, this.typeNode);
       }
 
       return new TypeResolver(indexSignatureDeclaration.type as ts.TypeNode, this.current, this.parentNode, this.extractEnum, this.context).resolve();

--- a/tests/fixtures/program.ts
+++ b/tests/fixtures/program.ts
@@ -1,0 +1,11 @@
+interface Model {
+  id: number;
+  description: string;
+  fail: unknown;
+}
+
+const model: Model = {
+  id: 1,
+  description: 'Hello, World',
+  fail: null,
+};

--- a/tests/unit/utilities/GenerateMetadataError.spec.ts
+++ b/tests/unit/utilities/GenerateMetadataError.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import 'mocha';
+import { join } from 'path';
+import { createProgram, InterfaceDeclaration, isInterfaceDeclaration, PropertySignature } from 'typescript';
+import { GenerateMetadataError } from '../../../src/metadataGeneration/exceptions';
+
+const path = join(__dirname, '../../fixtures/program.ts');
+const program = createProgram([path], {});
+program.getTypeChecker();
+const sourceFile = program.getSourceFiles().filter(sourceFile => sourceFile.fileName === path)[0];
+
+const iface = sourceFile
+  .getChildren()[0]
+  .getChildren()
+  .find(child => isInterfaceDeclaration(child)) as InterfaceDeclaration;
+
+const propertySignature = iface.members[2] as PropertySignature;
+const type = propertySignature.type!;
+
+describe('GenerateMetadataError', () => {
+  it(`Should have a given text`, () => {
+    expect(new GenerateMetadataError('Text').message).to.eq('Text');
+  });
+
+  it(`Should give context on a failing type if provided`, () => {
+    expect(new GenerateMetadataError('Text', type).message).to.eq(`Text\nAt: ${path}:4:4.\nThis was caused by 'fail: unknown;'`);
+  });
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests? I assume we don't need any here?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? I assume we don't need any here?
* [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?
No, feel free to close if it's not helpful @dgreene1 

I think this would be nice to have, inspired by https://github.com/lukeautry/tsoa/issues/483#issuecomment-537568590

The error message in some places where I thought it'd make sense, tsoa can now print the location and the surrounding code that causes an issue:

```
There was a problem resolving type of 'TestModel'.
(node:826) UnhandledPromiseRejectionWarning: Error: Unknown type: LiteralType.
    at new GenerateMetadataError ([folder]/tsoa/src/metadataGeneration/exceptions.ts:5:5)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:148:13)
    at [folder]/tsoa/src/metadataGeneration/typeResolver.ts:634:141
    at Array.map (<anonymous>)
    at TypeResolver.getModelProperties ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:620:10)
    at TypeResolver.getReferenceType ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:380:31)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:198:26)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:169:128)
    at MethodGenerator.Generate ([folder]/tsoa/src/metadataGeneration/methodGenerator.ts:36:59)
    at [folder]/tsoa/src/metadataGeneration/controllerGenerator.ts:47:35
(node:826) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:826) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

after

```
There was a problem resolving type of 'TestModel'.
(node:5018) UnhandledPromiseRejectionWarning: Error: Unknown type: LiteralType
At: [folder]/tsoa/tests/fixtures/testModel.ts:25:25.
This was caused by 'literal?: '42';'
    at new GenerateMetadataError ([folder]/tsoa/src/metadataGeneration/exceptions.ts:5:5)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:143:13)
    at [folder]/tsoa/src/metadataGeneration/typeResolver.ts:627:141
    at Array.map (<anonymous>)
    at TypeResolver.getModelProperties ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:613:10)
    at TypeResolver.getReferenceType ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:375:31)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:193:26)
    at TypeResolver.resolve ([folder]/tsoa/src/metadataGeneration/typeResolver.ts:164:128)
    at MethodGenerator.Generate ([folder]/tsoa/src/metadataGeneration/methodGenerator.ts:36:59)
    at [folder]/tsoa/src/metadataGeneration/controllerGenerator.ts:47:35
(node:5018) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:5018) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Done in 7.40s.
```

Due to how most integrated terminals work, you should be able to click that location and get right back to the issue.