### PR TITLE
fix(typings): swagger security type def fixes

### DIFF
--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -256,54 +256,53 @@ export namespace Swagger {
     wrapped?: boolean;
   }
 
-  export interface BasicSecurity3 {
+  interface BaseSecurity {
+    description?: string;
+  }
+
+  interface BaseOAuthSecurity extends BaseSecurity {
+    scopes?: OAuthScope;
+  }
+
+  export interface BasicSecurity3 extends BaseSecurity {
     type: 'http';
     scheme: 'basic';
-    description?: string;
   }
 
-  export interface BasicSecurity {
+  export interface BasicSecurity extends BaseSecurity {
     type: 'basic';
-    description?: string;
   }
 
-  export interface ApiKeySecurity {
+  export interface ApiKeySecurity extends BaseSecurity {
     type: 'apiKey';
     name: string;
     in: 'query' | 'header';
-    description?: string;
   }
 
-  export interface OAuth2ImplicitSecurity {
+  export interface OAuth2ImplicitSecurity extends BaseOAuthSecurity {
     type: 'oauth2';
     description?: string;
     flow: 'implicit';
     authorizationUrl: string;
   }
 
-  export interface OAuth2PasswordSecurity {
+  export interface OAuth2PasswordSecurity extends BaseOAuthSecurity {
     type: 'oauth2';
-    description?: string;
     flow: 'password';
     tokenUrl: string;
-    scopes?: OAuthScope;
   }
 
-  export interface OAuth2ApplicationSecurity {
+  export interface OAuth2ApplicationSecurity extends BaseOAuthSecurity {
     type: 'oauth2';
-    description?: string;
     flow: 'application';
     tokenUrl: string;
-    scopes?: OAuthScope;
   }
 
-  export interface OAuth2AccessCodeSecurity {
+  export interface OAuth2AccessCodeSecurity extends BaseOAuthSecurity {
     type: 'oauth2';
-    description?: string;
     flow: 'accessCode';
     tokenUrl: string;
     authorizationUrl: string;
-    scopes?: OAuthScope;
   }
 
   export interface OAuthScope {


### PR DESCRIPTION
the security type defintions were incomplete, the implict type also has scopes, as it turned out all oauth methods have a scope and therefore I introduced two abstract levels for the seucrity interfaces.

see:
 - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/swagger-schema-official/index.d.ts#L216
 - the comment of dgreene1 here https://github.com/lukeautry/tsoa/pull/526#discussion_r344458058

fixes this error message:
```
Error:(23, 7) TS2322: Type '{ api_key: { in: "query"; name: string; type: "apiKey"; }; tsoa_auth: { authorizationUrl: string; flow: "implicit"; scopes: { 'read:pets': string; 'write:pets': string; }; type: "oauth2"; }; }' is not assignable to type '{ [name: string]: Security; }'.

Property 'tsoa_auth' is incompatible with index signature.
Type '{ authorizationUrl: string; flow: "implicit"; scopes: { 'read:pets': string; 'write:pets': string; }; type: "oauth2"; }' is not assignable to type 'Security'.
Object literal may only specify known properties, and 'scopes' does not exist in type 'OAuth2ImplicitSecurity'.
```

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [ ] Have you written unit tests? **not relevant**
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? **not relevant**
* [ ] This PR is associated with an existing issue? 
not directly, it turned out whle working on #526 
