### PR TITLE
Nested Property Descriptions not being added to swagger output

### DIFF
--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -80,6 +80,9 @@ export interface TestModel extends Model {
   mixedUnion?: string | TypeAliasModel1;
 
   objLiteral: {
+    /**
+     * Nested property description
+     */
     name: string;
     nested?: {
       bool: boolean;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -469,7 +469,7 @@ describe('Definition generation', () => {
               description: undefined,
               format: undefined,
               properties: {
-                name: { type: 'string' },
+                name: { type: 'string', description: 'Nested property description' },
                 nested: {
                   properties: {
                     additionals: {


### PR DESCRIPTION
NOTE: I've submitted this issue as a PR as I have added a failing unit test to demonstrate the issue.

## Sorting

* **I'm submitting a ...**
  - [x] bug report
  - [ ] feature request
  - [ ] support request

* I confirm that I
  - [x] used the [search](https://github.com/lukeautry/tsoa/search?type=Issues) to make sure that a similar issue hasn't already been submit

## Expected Behavior

When a nested object literal is used in an interface, tsoa should include any description jsdoc comments to the definition generated. 

eg.

```ts
interface ApiRequest {
  data: {
    /**
     * Description of parameter
     */
     parameter: number
  }
}
```

should result in a definition in the openapi output:

```json
{
  "properties": {
    "description": "Description of parameter",
    "type": "number"
  }
}
```



