### PR TITLE
BigInt type

### DIFF
--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -75,6 +75,7 @@ export namespace Tsoa {
     | 'float'
     | 'integer'
     | 'long'
+    | 'bigint'
     | 'enum'
     | 'array'
     | 'datetime'
@@ -99,7 +100,7 @@ export namespace Tsoa {
     dataType: TypeStringLiteral;
   }
 
-  export type PrimitiveType = StringType | BooleanType | DoubleType | FloatType | IntegerType | LongType | VoidType;
+  export type PrimitiveType = StringType | BooleanType | DoubleType | FloatType | IntegerType | LongType | BigIntType | VoidType;
 
   /**
    * This is one of the possible objects that tsoa creates that helps the code store information about the type it found in the code.
@@ -150,6 +151,10 @@ export namespace Tsoa {
 
   export interface LongType extends TypeBase {
     dataType: 'long';
+  }
+
+  export interface BigIntType extends TypeBase {
+    dataType: 'bigint';
   }
 
   /**

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -285,6 +285,10 @@ export class TypeResolver {
         default:
           return { dataType: 'double' };
       }
+    } else if (resolution.resolvedType === 'bigint') {
+      return {
+        dataType: 'bigint',
+      };
     } else if (resolution.resolvedType === 'string') {
       return {
         dataType: 'string',
@@ -521,6 +525,11 @@ export class TypeResolver {
       return {
         foundMatch: true,
         resolvedType: 'void',
+      };
+    } else if (syntaxKind === ts.SyntaxKind.BigIntKeyword) {
+      return {
+        foundMatch: true,
+        resolvedType: 'bigint',
       };
     } else {
       return {
@@ -958,7 +967,7 @@ export class TypeResolver {
 
 interface ResolvesToPrimitive {
   foundMatch: true;
-  resolvedType: 'number' | 'string' | 'boolean' | 'void';
+  resolvedType: 'number' | 'string' | 'boolean' | 'void' | 'bigint';
 }
 interface DoesNotResolveToPrimitive {
   foundMatch: false;

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -52,6 +52,8 @@ export class ValidationService {
       case 'integer':
       case 'long':
         return this.validateInt(name, value, fieldErrors, property.validators, parent);
+      case 'bigint':
+        return this.validateBigInt(name, value, fieldErrors, property.validators, parent);
       case 'float':
       case 'double':
         return this.validateFloat(name, value, fieldErrors, property.validators, parent);
@@ -159,6 +161,40 @@ export class ValidationService {
     }
 
     const numberValue = validator.toInt(String(value), 10);
+    if (!validators) {
+      return numberValue;
+    }
+    if (validators.minimum && validators.minimum.value !== undefined) {
+      if (validators.minimum.value > numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.minimum.errorMsg || `min ${validators.minimum.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    if (validators.maximum && validators.maximum.value !== undefined) {
+      if (validators.maximum.value < numberValue) {
+        fieldErrors[parent + name] = {
+          message: validators.maximum.errorMsg || `max ${validators.maximum.value}`,
+          value,
+        };
+        return;
+      }
+    }
+    return numberValue;
+  }
+
+  public validateBigInt(name: string, value: any, fieldErrors: FieldErrors, validators?: IntegerValidator, parent = ''): bigint | undefined {
+    if (!validator.isInt(String(value))) {
+      fieldErrors[parent + name] = {
+        message: `invalid bigint number`,
+        value,
+      };
+      return;
+    }
+
+    const numberValue = BigInt(String(value));
     if (!validators) {
       return numberValue;
     }

--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -19,6 +19,7 @@ import { expressAuthentication } from '{{authenticationModule}}';
 import * as express from 'express';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+BigInt.prototype['toJSON'] = function() { return this.toString(); };
 
 const models: TsoaRoute.Models = {
     {{#each models}}

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -18,6 +18,7 @@ import { hapiAuthentication } from '{{authenticationModule}}';
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+BigInt.prototype['toJSON'] = function() { return this.toString(); };
 
 const models: TsoaRoute.Models = {
     {{#each models}}

--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -19,6 +19,7 @@ import { koaAuthentication } from '{{authenticationModule}}';
 import * as KoaRouter from 'koa-router';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+BigInt.prototype['toJSON'] = function() { return this.toString(); };
 
 const models: TsoaRoute.Models = {
     {{#each models}}

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -67,6 +67,7 @@ export abstract class SpecGenerator {
       type.dataType === 'float' ||
       type.dataType === 'integer' ||
       type.dataType === 'long' ||
+      type.dataType === 'bigint' ||
       type.dataType === 'object' ||
       type.dataType === 'string'
     ) {
@@ -177,6 +178,7 @@ export abstract class SpecGenerator {
       float: { type: 'number', format: 'float' },
       integer: { type: 'integer', format: 'int32' },
       long: { type: 'integer', format: 'int64' },
+      bigint: { type: 'integer' },
       object: {
         additionalProperties: this.determineImplicitAdditionalPropertiesValue(),
         type: 'object',

--- a/src/utils/internalTypeGuards.ts
+++ b/src/utils/internalTypeGuards.ts
@@ -35,6 +35,8 @@ export function isRefType(metaType: Tsoa.Type): metaType is Tsoa.ReferenceType {
       return false;
     case 'long':
       return false;
+    case 'bigint':
+      return false;
     case 'nestedObjectLiteral':
       return false;
     case 'object':

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -93,6 +93,8 @@ export interface TestModel extends Model {
       };
     };
   };
+
+  bigInt?: bigint;
 }
 
 export interface TypeAliasModel1 {
@@ -237,6 +239,9 @@ export class ValidateModel {
    * @isLong Custom Required long number.
    */
   public longValue: number;
+
+  public bigIntValue: bigint;
+
   /**
    * @isBoolean
    */

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -483,6 +483,8 @@ describe('Express Server', () => {
       bodyModel.doubleValue = 1.2;
       bodyModel.intValue = 120;
       bodyModel.longValue = 120;
+      // supertest can't serialize BigInts, so we send the string representation
+      bodyModel.bigIntValue = '9007199254740993' as any;
       bodyModel.booleanValue = true;
       bodyModel.arrayValue = [0, 2];
       bodyModel.dateValue = new Date('2017-01-01');
@@ -536,6 +538,7 @@ describe('Express Server', () => {
           expect(body.doubleValue).to.equal(bodyModel.doubleValue);
           expect(body.intValue).to.equal(bodyModel.intValue);
           expect(body.longValue).to.equal(bodyModel.longValue);
+          expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
           expect(body.booleanValue).to.equal(bodyModel.booleanValue);
           expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 
@@ -589,6 +592,7 @@ describe('Express Server', () => {
       bodyModel.doubleValue = '120a' as any;
       bodyModel.intValue = 1.2;
       bodyModel.longValue = 1.2;
+      bodyModel.bigIntValue = 'zasd' as any;
       bodyModel.booleanValue = 'abc' as any;
       bodyModel.dateValue = 'abc' as any;
       bodyModel.datetimeValue = 'abc' as any;
@@ -644,6 +648,8 @@ describe('Express Server', () => {
           expect(body.fields['body.intValue'].value).to.equal(bodyModel.intValue);
           expect(body.fields['body.longValue'].message).to.equal('Custom Required long number.');
           expect(body.fields['body.longValue'].value).to.equal(bodyModel.longValue);
+          expect(body.fields['body.bigIntValue'].message).to.equal('invalid bigint number');
+          expect(body.fields['body.bigIntValue'].value).to.equal(bodyModel.bigIntValue);
           expect(body.fields['body.booleanValue'].message).to.equal('invalid boolean value');
           expect(body.fields['body.booleanValue'].value).to.equal(bodyModel.booleanValue);
 

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -503,6 +503,8 @@ describe('Express Server', () => {
       bodyModel.doubleValue = 1.2;
       bodyModel.intValue = 120;
       bodyModel.longValue = 120;
+      // supertest can't serialize BigInts, so we send the string representation
+      bodyModel.bigIntValue = '9007199254740993' as any;
       bodyModel.booleanValue = true;
       bodyModel.arrayValue = [0, 2];
       bodyModel.dateValue = new Date('2017-01-01');
@@ -556,6 +558,7 @@ describe('Express Server', () => {
           expect(body.doubleValue).to.equal(bodyModel.doubleValue);
           expect(body.intValue).to.equal(bodyModel.intValue);
           expect(body.longValue).to.equal(bodyModel.longValue);
+          expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
           expect(body.booleanValue).to.equal(bodyModel.booleanValue);
           expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 
@@ -609,6 +612,7 @@ describe('Express Server', () => {
       bodyModel.doubleValue = '120a' as any;
       bodyModel.intValue = 1.2;
       bodyModel.longValue = 1.2;
+      bodyModel.bigIntValue = 'zasd' as any;
       bodyModel.booleanValue = 'abc' as any;
       bodyModel.dateValue = 'abc' as any;
       bodyModel.datetimeValue = 'abc' as any;
@@ -664,6 +668,8 @@ describe('Express Server', () => {
           expect(body.fields['body.intValue'].value).to.equal(bodyModel.intValue);
           expect(body.fields['body.longValue'].message).to.equal('Custom Required long number.');
           expect(body.fields['body.longValue'].value).to.equal(bodyModel.longValue);
+          expect(body.fields['body.bigIntValue'].message).to.equal('invalid bigint number');
+          expect(body.fields['body.bigIntValue'].value).to.equal(bodyModel.bigIntValue);
           expect(body.fields['body.booleanValue'].message).to.equal('invalid boolean value');
           expect(body.fields['body.booleanValue'].value).to.equal(bodyModel.booleanValue);
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -456,6 +456,8 @@ describe('Hapi Server', () => {
       bodyModel.doubleValue = 1.2;
       bodyModel.intValue = 120;
       bodyModel.longValue = 120;
+      // supertest can't serialize BigInts, so we send the string representation
+      bodyModel.bigIntValue = '9007199254740993' as any;
       bodyModel.booleanValue = true;
       bodyModel.arrayValue = [0, 2];
       bodyModel.dateValue = new Date('2017-01-01');
@@ -509,6 +511,7 @@ describe('Hapi Server', () => {
           expect(body.doubleValue).to.equal(bodyModel.doubleValue);
           expect(body.intValue).to.equal(bodyModel.intValue);
           expect(body.longValue).to.equal(bodyModel.longValue);
+          expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
           expect(body.booleanValue).to.equal(bodyModel.booleanValue);
           expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 
@@ -562,6 +565,7 @@ describe('Hapi Server', () => {
       bodyModel.doubleValue = '120a' as any;
       bodyModel.intValue = 1.2;
       bodyModel.longValue = 1.2;
+      bodyModel.bigIntValue = 'zasd' as any;
       bodyModel.booleanValue = 'abc' as any;
       bodyModel.dateValue = 'abc' as any;
       bodyModel.datetimeValue = 'abc' as any;
@@ -617,6 +621,8 @@ describe('Hapi Server', () => {
           expect(body.fields['body.intValue'].value).to.equal(bodyModel.intValue);
           expect(body.fields['body.longValue'].message).to.equal('Custom Required long number.');
           expect(body.fields['body.longValue'].value).to.equal(bodyModel.longValue);
+          expect(body.fields['body.bigIntValue'].message).to.equal('invalid bigint number');
+          expect(body.fields['body.bigIntValue'].value).to.equal(bodyModel.bigIntValue);
           expect(body.fields['body.booleanValue'].message).to.equal('invalid boolean value');
           expect(body.fields['body.booleanValue'].value).to.equal(bodyModel.booleanValue);
 

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -178,6 +178,8 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       bodyModel.doubleValue = 1.2;
       bodyModel.intValue = 120;
       bodyModel.longValue = 120;
+      // supertest can't serialize BigInts, so we send the string representation
+      bodyModel.bigIntValue = '9007199254740993' as any;
       bodyModel.booleanValue = true;
       bodyModel.arrayValue = [0, 2];
       bodyModel.dateValue = new Date('2017-01-01');
@@ -231,6 +233,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
           expect(body.doubleValue).to.equal(bodyModel.doubleValue);
           expect(body.intValue).to.equal(bodyModel.intValue);
           expect(body.longValue).to.equal(bodyModel.longValue);
+          expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
           expect(body.booleanValue).to.equal(bodyModel.booleanValue);
           expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -434,6 +434,8 @@ describe('Koa Server', () => {
       bodyModel.doubleValue = 1.2;
       bodyModel.intValue = 120;
       bodyModel.longValue = 120;
+      // supertest can't serialize BigInts, so we send the string representation
+      bodyModel.bigIntValue = '9007199254740993' as any;
       bodyModel.booleanValue = true;
       bodyModel.arrayValue = [0, 2];
       bodyModel.dateValue = new Date('2017-01-01');
@@ -487,6 +489,7 @@ describe('Koa Server', () => {
           expect(body.doubleValue).to.equal(bodyModel.doubleValue);
           expect(body.intValue).to.equal(bodyModel.intValue);
           expect(body.longValue).to.equal(bodyModel.longValue);
+          expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
           expect(body.booleanValue).to.equal(bodyModel.booleanValue);
           expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 
@@ -540,6 +543,7 @@ describe('Koa Server', () => {
       bodyModel.doubleValue = '120a' as any;
       bodyModel.intValue = 1.2;
       bodyModel.longValue = 1.2;
+      bodyModel.bigIntValue = 'zasd' as any;
       bodyModel.booleanValue = 'abc' as any;
       bodyModel.dateValue = 'abc' as any;
       bodyModel.datetimeValue = 'abc' as any;
@@ -595,6 +599,8 @@ describe('Koa Server', () => {
           expect(body.fields['body.intValue'].value).to.equal(bodyModel.intValue);
           expect(body.fields['body.longValue'].message).to.equal('Custom Required long number.');
           expect(body.fields['body.longValue'].value).to.equal(bodyModel.longValue);
+          expect(body.fields['body.bigIntValue'].message).to.equal('invalid bigint number');
+          expect(body.fields['body.bigIntValue'].value).to.equal(bodyModel.bigIntValue);
           expect(body.fields['body.booleanValue'].message).to.equal('invalid boolean value');
           expect(body.fields['body.booleanValue'].value).to.equal(bodyModel.booleanValue);
 

--- a/tests/integration/openapi3-express.spec.ts
+++ b/tests/integration/openapi3-express.spec.ts
@@ -13,6 +13,8 @@ describe('OpenAPI3 Express Server', () => {
     bodyModel.doubleValue = 1.2;
     bodyModel.intValue = 120;
     bodyModel.longValue = 120;
+    // supertest can't serialize BigInts, so we send the string representation
+    bodyModel.bigIntValue = '9007199254740993' as any;
     bodyModel.booleanValue = true;
     bodyModel.arrayValue = [0, 2];
     bodyModel.dateValue = new Date('2017-01-01');
@@ -66,6 +68,7 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.doubleValue).to.equal(bodyModel.doubleValue);
         expect(body.intValue).to.equal(bodyModel.intValue);
         expect(body.longValue).to.equal(bodyModel.longValue);
+        expect(body.bigIntValue).to.equal(bodyModel.bigIntValue);
         expect(body.booleanValue).to.equal(bodyModel.booleanValue);
         expect(body.arrayValue).to.deep.equal(bodyModel.arrayValue);
 
@@ -119,6 +122,7 @@ describe('OpenAPI3 Express Server', () => {
     bodyModel.doubleValue = '120a' as any;
     bodyModel.intValue = 1.2;
     bodyModel.longValue = 1.2;
+    bodyModel.bigIntValue = 'zasd' as any;
     bodyModel.booleanValue = 'abc' as any;
     bodyModel.dateValue = 'abc' as any;
     bodyModel.datetimeValue = 'abc' as any;
@@ -175,6 +179,8 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.intValue'].value).to.equal(bodyModel.intValue);
         expect(body.fields['body.longValue'].message).to.equal('Custom Required long number.');
         expect(body.fields['body.longValue'].value).to.equal(bodyModel.longValue);
+        expect(body.fields['body.bigIntValue'].message).to.equal('invalid bigint number');
+        expect(body.fields['body.bigIntValue'].value).to.equal(bodyModel.bigIntValue);
         expect(body.fields['body.booleanValue'].message).to.equal('invalid boolean value');
         expect(body.fields['body.booleanValue'].value).to.equal(bodyModel.booleanValue);
 

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -494,6 +494,10 @@ describe('Definition generation', () => {
               type: 'object',
             });
           },
+          bigInt: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq('integer', `for property ${propertyName}.type`);
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+          },
         };
 
         Object.keys(assertionsPerProperty).forEach(aPropertyName => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -553,6 +553,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             );
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
+          bigInt: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq('integer', `for property ${propertyName}.type`);
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+          },
         };
 
         const testModel = currentSpec.spec.components.schemas[interfaceModelName];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

* [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

The JSON lib does not handle serialization of BigInts. Since there are [special tools required to parse a json with bigint values](https://github.com/sidorares/json-bigint), I've decided it's more convenient to serialize bigints to strings, which is i.e. what most databases do. When validating input, due to this issue, it makes sense to send them in as a string, since for example the bodyparser in express uses the default JSON.parse() which leads to issues like [this](https://github.com/sidorares/json-bigint):

```
Input: { "value" : 9223372036854775807, "v2": 123 }

node.js bult-in JSON:
JSON.parse(input).value :  9223372036854776000
JSON.stringify(JSON.parse(input)): {"value":9223372036854776000,"v2":123}


big number JSON:
JSONbig.parse(input).value :  9223372036854775807
JSONbig.stringify(JSONbig.parse(input)): {"value":9223372036854775807,"v2":123}
```


**Explainations**

Initially, one might think we could just use swagger/json/schema's integer, without introducing a new datatype in the validation layer, but this causes trouble with existing `@isInt` annotations.

If you specified type `number` in your code, it does not make sense to return a bigint from the validation layer even though the number is basically unusable (if it's below Number.MIN_SAFE_INTEGER or above Number.MAX_SAFE_INTEGER), see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger):

```
Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2
// => true
```

But if you specify `number`, we should give you a number, since you probably wouldn't expect to handle a bigint. However, we should maybe throw a runtime warning if that happens?.

So, in case we actually have TS type `bigint`, we will save that as metadata and only return a bigint in this case. In OpenAPI, we type that as `{ dataType: integer }`, which does not impose any limits on the range.