### PR TITLE
Deprecate extractEnum

### DIFF
--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -85,7 +85,7 @@ export class ParameterGenerator {
 
   private getHeaderParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter {
     const parameterName = (parameter.name as ts.Identifier).text;
-    const type = this.getValidatedType(parameter, false);
+    const type = this.getValidatedType(parameter);
 
     if (!this.supportPathDataType(type)) {
       throw new GenerateMetadataError(`@Header('${parameterName}') Can't support '${type.dataType}' type.`);
@@ -105,7 +105,7 @@ export class ParameterGenerator {
 
   private getQueryParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter {
     const parameterName = (parameter.name as ts.Identifier).text;
-    const type = this.getValidatedType(parameter, false);
+    const type = this.getValidatedType(parameter);
 
     const commonProperties = {
       default: getInitializerValue(parameter.initializer, type),
@@ -141,7 +141,7 @@ export class ParameterGenerator {
 
   private getPathParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter {
     const parameterName = (parameter.name as ts.Identifier).text;
-    const type = this.getValidatedType(parameter, false);
+    const type = this.getValidatedType(parameter);
     const pathName = getDecoratorTextValue(this.parameter, ident => ident.text === 'Path') || parameterName;
 
     if (!this.supportPathDataType(type)) {
@@ -190,12 +190,12 @@ export class ParameterGenerator {
     return supportedPathDataTypes.find(t => t === parameterType.dataType);
   }
 
-  private getValidatedType(parameter: ts.ParameterDeclaration, extractEnum = true) {
+  private getValidatedType(parameter: ts.ParameterDeclaration) {
     let typeNode = parameter.type;
     if (!typeNode) {
       const type = this.current.typeChecker.getTypeAtLocation(parameter);
       typeNode = this.current.typeChecker.typeToTypeNode(type) as ts.TypeNode;
     }
-    return new TypeResolver(typeNode, this.current, parameter, extractEnum).resolve();
+    return new TypeResolver(typeNode, this.current, parameter).resolve();
   }
 }

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -235,7 +235,19 @@ export class SpecGenerator2 extends SpecGenerator {
       required: source.required,
     } as Swagger.Parameter;
 
-    const parameterType = this.getSwaggerType(source.type);
+    let type = source.type;
+
+    if (source.in !== 'body' && source.type.dataType === 'refEnum') {
+      // swagger does not support referencing enums
+      // (exept for body parameters), so we have to inline it
+
+      type = {
+        dataType: 'enum',
+        enums: source.type.enums,
+      };
+    }
+
+    const parameterType = this.getSwaggerType(type);
     if (parameterType.format) {
       parameter.format = this.throwIfNotDataFormat(parameterType.format);
     }

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -85,7 +85,7 @@ export class GetTestController extends Controller {
     @Query() stringParam: string,
     @Query() numberParam: number,
     @Query() optionalStringParam = '',
-  ): Promise<TestModel> {
+  ) {
     const model = new ModelService().getModel();
     model.optionalString = optionalStringParam;
     model.numberValue = numberPathParam;

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import 'mocha';
 import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
 import { Tsoa } from '../../../../src/metadataGeneration/tsoa';
+import { SpecGenerator2 } from '../../../../src/swagger/specGenerator2';
+import { getDefaultOptions } from '../../../fixtures/defaultOptions';
 
 describe('Metadata generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
@@ -293,7 +295,7 @@ describe('Metadata generation', () => {
       expect(genderParam.parameterName).to.equal('gender');
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
-      expect(genderParam.type.dataType).to.equal('enum');
+      expect(genderParam.type.dataType).to.equal('refEnum');
 
       const nicknamesParam = method.parameters[6] as Tsoa.ArrayParameter;
       expect(nicknamesParam.in).to.equal('query');
@@ -360,7 +362,7 @@ describe('Metadata generation', () => {
       expect(genderParam.parameterName).to.equal('gender');
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
-      expect(genderParam.type.dataType).to.equal('enum');
+      expect(genderParam.type.dataType).to.equal('refEnum');
     });
 
     it('should generate an header parameter', () => {
@@ -417,7 +419,7 @@ describe('Metadata generation', () => {
       expect(genderParam.parameterName).to.equal('gender');
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
-      expect(genderParam.type.dataType).to.equal('enum');
+      expect(genderParam.type.dataType).to.equal('refEnum');
     });
 
     it('should generate an request parameter', () => {
@@ -473,6 +475,27 @@ describe('Metadata generation', () => {
       expect(parameter.name).to.equal('firstname');
       expect(parameter.parameterName).to.equal('firstname');
       expect(parameter.required).to.be.true;
+    });
+
+    it('Should inline enums for TS Enums in path, query and header when using Swagger', () => {
+      const spec = new SpecGenerator2(parameterMetadata, getDefaultOptions()).GetSpec();
+      const method = spec.paths['/ParameterTest/Path/{firstname}/{last_name}/{age}/{weight}/{human}/{gender}']['get'];
+
+      if (!method || !method.parameters) {
+        throw new Error("Method or it's parameters are not defined!");
+      }
+
+      const genderParam = method.parameters.find(p => p.name === 'gender');
+
+      if (!genderParam) {
+        throw new Error('genderParam not defined!');
+      }
+
+      expect(genderParam.in).to.equal('path');
+      expect(genderParam.name).to.equal('gender');
+      expect(genderParam.description).to.equal('Gender description');
+      expect(genderParam.required).to.be.true;
+      expect(genderParam.enum).to.deep.equal(['MALE', 'FEMALE']);
     });
   });
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

The enum gets also rendered as a definition which is not used. I think this is fine, however, we may remove it.

### What? Why?

Swagger2 does not support $ref to link to enum definitions in header, query or path parameters.
Body does apparently work.
In order to generate proper definitions, at the time, a new argument was introduced for the type resolver.
However, this causes a lot of additional complexity. Instead of handling this issue in the resolver, I moved it to the Spec2 Generator, where it's a lot easier to inline the referenced TS Enum

