### PR TITLE
Add unknown type (2.x)

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -83,7 +83,7 @@ export class TypeResolver {
       return intersectionMetaType;
     }
 
-    if (this.typeNode.kind === ts.SyntaxKind.AnyKeyword) {
+    if (this.typeNode.kind === ts.SyntaxKind.AnyKeyword || this.typeNode.kind === ts.SyntaxKind.UnknownKeyword) {
       const literallyAny: Tsoa.AnyType = {
         dataType: 'any',
       };

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -57,6 +57,7 @@ export interface TestModel extends Model {
   dateValue?: Date;
   optionalString?: string;
   anyType?: any;
+  unknownType?: unknown;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
   modelsObjectIndirectNS?: TestSubModelContainerNamespace.TestSubModelContainer;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -385,6 +385,11 @@ describe('Definition generation', () => {
           anyType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema.additionalProperties).to.eq(true, 'because the "unknown" type always allows more properties be definition');
+          },
+          unknownType: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
+            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "any" type always allows more properties be definition');
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -553,6 +553,11 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "any" type always allows more properties be definition');
           },
+          unknownType: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
+            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.additionalProperties).to.eq(true, 'because the "unknown" type always allows more properties be definition');
+          },
           modelsObjectIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

Closes #452

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

`unknown` and `any` are treated equally at the moment.
This should not be an issue since the main difference should be how ts handles type checking, which tsoa doesn't care about. 
However, this means there's no new validation logic (same as `any`) or dataType etc.

### Compatibility

New, backwards compatible feature, so I'm targeting `master`.
Will be ported for 3.x aswell.