### PR TITLE
Fix OpenAPI3 QueryArrays

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -290,10 +290,6 @@ export class SpecGenerator3 extends SpecGenerator {
       parameter.schema.format = this.throwIfNotDataFormat(parameterType.format);
     }
 
-    if (parameter.in === 'query' && parameterType.type === 'array') {
-      (parameter as Swagger.QueryParameter).collectionFormat = 'multi';
-    }
-
     if (parameterType.$ref) {
       parameter.schema = parameterType as Swagger.Schema;
       return parameter;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [ ] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [ ] This PR is associated with an existing issue?

OpenAPI 3 uses the equivalent of `collectionFormat: 'multi'` for arrays in querystrings by default (`{style: 'form', explode: true }`).
However, the key `collectionFormat` is no longer allowed and should therefore not be set.

Allowed fields: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#style-values
Defaults: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-10