### PR TITLE
Change default behavior when no host is defined

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -117,10 +117,10 @@ export class SpecGenerator3 extends SpecGenerator {
   private buildServers() {
     const basePath = normalisePath(this.config.basePath as string, '/', undefined, false);
     const scheme = this.config.schemes ? this.config.schemes[0] : 'https';
-    const host = this.config.host || 'localhost:3000';
+    const url = this.config.host ? `${scheme}://${this.config.host}${basePath}` : basePath;
     return [
       {
-        url: `${scheme}://${host}${basePath}`,
+        url,
       } as Swagger.Server,
     ];
   }

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -74,6 +74,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(specDefault.spec).to.not.have.property('basePath');
       expect(specDefault.spec.servers[0].url).to.match(/\/v1/);
     });
+
+    it('should have relative URL when no host is defined', () => {
+      const optionsWithNoHost = Object.assign<{}, SwaggerConfig>({}, defaultOptions);
+      delete optionsWithNoHost.host;
+
+      const spec: Swagger.Spec3 = new SpecGenerator3(metadata, optionsWithNoHost).GetSpec();
+      expect(spec.servers[0].url).to.equal('/v1');
+    });
   });
 
   describe('security', () => {


### PR DESCRIPTION
In OpenAPI 3.0 definitions of an url can be absolute and contain an host, or
relative. This commit changes the bahavior of tsoa to generate a
relative url when no host is defined.

In version 2 of this lib when no host was defined it was as default set
to localhost:3000. The possibility to also generate relative urls
without breaking backwards compatability it was chosen to only generate
such urls when host is set tu 'null'.

For spec versoin 2 the urls where always relative, so this commit
realignes the behavior again.

Fixes #555

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [X] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [X] This PR is associated with an existing issue?

**Closing issues**

closes #555

### If this is a new feature submission:

Since this is changing the default behavior should we maybe mention it somewhere? (e.g. release notes?) and if so where?