### PR TITLE
Add Null Keyword

### DIFF
--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -159,7 +159,7 @@ export namespace Tsoa {
    */
   export interface EnumType extends TypeBase {
     dataType: 'enum';
-    enums: Array<string | number | boolean>;
+    enums: Array<string | number | boolean | null>;
   }
 
   export interface ArrayType extends TypeBase {

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -41,6 +41,14 @@ export class TypeResolver {
       return primitiveType;
     }
 
+    if (this.typeNode.kind === ts.SyntaxKind.NullKeyword) {
+      const enumType: Tsoa.EnumType = {
+        dataType: 'enum',
+        enums: [null],
+      };
+      return enumType;
+    }
+
     if (this.typeNode.kind === ts.SyntaxKind.ArrayType) {
       const arrayMetaType: Tsoa.ArrayType = {
         dataType: 'array',

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -166,10 +166,10 @@ export class TypeResolver {
         if (declaration.name) {
           declaration = this.getModelTypeDeclaration(declaration.name as ts.EntityName);
         }
-        const name = this.contextualizedName(declaration.name ? declaration.name.getText() : 'anonymousClass');
+        const name = this.getRefTypeName(this.referencer.getText());
         return this.handleCachingAndCircularReferences(name, () => {
           if (ts.isTypeAliasDeclaration(declaration)) {
-            return this.getTypeAliasReference(declaration, name, this.referencer!);
+            return this.getTypeAliasReference(declaration, this.current.typeChecker.typeToString(type), this.referencer!);
           } else if (ts.isEnumDeclaration(declaration)) {
             return this.getEnumerateType(declaration.name) as Tsoa.RefEnumType;
           } else {
@@ -184,8 +184,8 @@ export class TypeResolver {
         if (declaration.name) {
           declaration = this.getModelTypeDeclaration(declaration.name) as ts.InterfaceDeclaration | ts.ClassDeclaration;
         }
-        const name = this.contextualizedName(declaration.name ? declaration.name.getText() : 'anonymousClass');
-        return this.handleCachingAndCircularReferences(name, () => this.getModelReference(declaration, name));
+        const name = this.getRefTypeName(this.referencer.getText());
+        return this.handleCachingAndCircularReferences(name, () => this.getModelReference(declaration, this.current.typeChecker.typeToString(type)));
       } else {
         try {
           return new TypeResolver(this.current.typeChecker.typeToTypeNode(type)!, this.current, this.typeNode, this.context, this.referencer).resolve();

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -23,7 +23,7 @@ export class ValidationService {
 
   public ValidateParam(property: TsoaRoute.PropertySchema, rawValue: any, name = '', fieldErrors: FieldErrors, parent = '', minimalSwaggerConfig: SwaggerConfigRelatedToRoutes) {
     let value = rawValue;
-    if (value === undefined || value === null) {
+    if (value === undefined) {
       if (property.default !== undefined) {
         value = property.default;
       } else if (property.required) {

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -130,7 +130,7 @@ export class ValidationService {
 
     Object.keys(nestedProperties).forEach(key => {
       const validatedProp = this.ValidateParam(nestedProperties[key], value[key], key, fieldErrors, parent + name + '.', swaggerConfig);
-      if (validatedProp) {
+      if (validatedProp !== undefined) {
         value[key] = validatedProp;
       }
     });

--- a/src/routeGeneration/tsoa-route.ts
+++ b/src/routeGeneration/tsoa-route.ts
@@ -45,7 +45,7 @@ export namespace TsoaRoute {
     ref?: string;
     required?: boolean;
     array?: PropertySchema;
-    enums?: Array<string | number | boolean>;
+    enums?: Array<string | number | boolean | null>;
     type?: PropertySchema;
     subSchemas?: PropertySchema[];
     validators?: ValidatorSchema;

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -193,7 +193,7 @@ export abstract class SpecGenerator {
 
   protected determineTypesUsedInEnum(anEnum: Array<string | number | boolean | null>) {
     const typesUsedInEnum = anEnum.reduce((theSet, curr) => {
-      const typeUsed = typeof curr;
+      const typeUsed = curr === null ? 'number' : typeof curr;
       theSet.add(typeUsed);
       return theSet;
     }, new Set<'string' | 'number' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'object' | 'function'>());
@@ -201,9 +201,5 @@ export abstract class SpecGenerator {
     return typesUsedInEnum;
   }
 
-  protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema {
-    const types = this.determineTypesUsedInEnum(enumType.enums);
-    const type = types.size === 1 ? types.values().next().value : 'string';
-    return { type, enum: enumType.enums.map(member => String(member)) };
-  }
+  protected abstract getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema2 | Swagger.Schema3;
 }

--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -191,7 +191,7 @@ export abstract class SpecGenerator {
     };
   }
 
-  protected determineTypesUsedInEnum(anEnum: Array<string | number>) {
+  protected determineTypesUsedInEnum(anEnum: Array<string | number | boolean | null>) {
     const typesUsedInEnum = anEnum.reduce((theSet, curr) => {
       const typeUsed = typeof curr;
       theSet.add(typeUsed);
@@ -202,6 +202,8 @@ export abstract class SpecGenerator {
   }
 
   protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema {
-    return { type: 'string', enum: enumType.enums.map(member => String(member)) };
+    const types = this.determineTypesUsedInEnum(enumType.enums);
+    const type = types.size === 1 ? types.values().next().value : 'string';
+    return { type, enum: enumType.enums.map(member => String(member)) };
   }
 }

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -321,10 +321,6 @@ export class SpecGenerator2 extends SpecGenerator {
           });
       }
 
-      if (!property.required) {
-        swaggerType['x-nullable'] = true;
-      }
-
       properties[property.name] = swaggerType as Swagger.Schema;
     });
 

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -332,12 +332,26 @@ export class SpecGenerator2 extends SpecGenerator {
   }
 
   protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
+    // Backwards compatible representation of a literal enumeration
     if (type.types.every(subType => subType.dataType === 'enum')) {
       const mergedEnum: Tsoa.EnumType = { dataType: 'enum', enums: [] };
       type.types.forEach(t => {
         mergedEnum.enums = [...mergedEnum.enums, ...(t as Tsoa.EnumType).enums];
       });
       return this.getSwaggerTypeForEnumType(mergedEnum);
+    } else if (type.types.length === 2 && type.types.find(typeInUnion => typeInUnion.dataType === 'enum' && typeInUnion.enums.includes(null))) {
+      // Backwards compatible representation of dataType or null, $ref does not allow any sibling attributes, so we have to bail out
+      const nullEnumIndex = type.types.findIndex(type => type.dataType === 'enum' && type.enums.includes(null));
+      const typeIndex = nullEnumIndex === 1 ? 0 : 1;
+      const swaggerType = this.getSwaggerType(type.types[typeIndex]);
+      const isRef = !!swaggerType.$ref;
+
+      if (isRef) {
+        return { type: 'object' };
+      } else {
+        swaggerType['x-nullable'] = true;
+        return swaggerType;
+      }
     } else if (process.env.NODE_ENV !== 'tsoa_test') {
       // tslint:disable-next-line: no-console
       console.warn('Swagger 2.0 does not support union types beyond string literals.\n' + 'If you would like to take advantage of this, please change tsoa.json\'s "specVersion" to 3.');
@@ -391,5 +405,12 @@ export class SpecGenerator2 extends SpecGenerator {
       throw new Error(badEnumErrorMessage());
     }
     return enumTypeForSwagger;
+  }
+
+  protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema2 {
+    const types = this.determineTypesUsedInEnum(enumType.enums);
+    const type = types.size === 1 ? types.values().next().value : 'string';
+    const nullable = enumType.enums.includes(null) ? true : false;
+    return { type, enum: enumType.enums.map(member => String(member)), ['x-nullable']: nullable };
   }
 }

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -378,10 +378,6 @@ export class SpecGenerator3 extends SpecGenerator {
           });
       }
 
-      if (!property.required) {
-        swaggerType.nullable = true;
-      }
-
       properties[property.name] = swaggerType as Swagger.Schema;
     });
 

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -399,4 +399,17 @@ export class SpecGenerator3 extends SpecGenerator {
   protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType) {
     return { allOf: type.types.map(x => this.getSwaggerType(x)) };
   }
+
+  protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema3 {
+    const types = this.determineTypesUsedInEnum(enumType.enums);
+
+    if (types.size === 1) {
+      const type = types.values().next().value;
+      const nullable = enumType.enums.includes(null) ? true : false;
+      return { type, enum: enumType.enums.map(member => String(member)), nullable };
+    } else {
+      const valuesDelimited = Array.from(types).join(',');
+      throw new Error(`Enums can only have string or number values, but enum had ${valuesDelimited}`);
+    }
+  }
 }

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -232,6 +232,10 @@ export namespace Swagger {
     allOf?: BaseSchema[];
   }
 
+  export interface Schema2 extends Schema {
+    ['x-nullable']?: boolean;
+  }
+
   export interface Schema extends BaseSchema {
     type: DataType;
     format?: DataFormat;

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -402,6 +402,13 @@ export class ValidateModel {
     forwardGenericAlias: ForwardGenericAlias<boolean, TypeAliasModel1>;
   };
 
+  public nullableTypes: {
+    numberOrNull: number | null;
+    wordOrNull: Maybe<Word>;
+    maybeString: Maybe<string>;
+    justNull: null;
+  };
+
   public nestedObject: {
     /**
      * @isFloat Invalid float error message.

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -127,7 +127,16 @@ export interface TestModel extends Model {
   };
 
   defaultGenericModel?: GenericModel;
+
+  nullableTypes?: {
+    numberOrNull: number | null;
+    wordOrNull: Maybe<Word>;
+    maybeString: Maybe<string>;
+    justNull: null;
+  };
 }
+
+type Maybe<T> = T | null;
 
 export interface TypeAliasModel1 {
   value1: string;

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -539,6 +539,13 @@ describe('Express Server', () => {
         forwardGenericAlias: { value1: 'value1' },
       };
 
+      bodyModel.nullableTypes = {
+        numberOrNull: null,
+        wordOrNull: null,
+        maybeString: null,
+        justNull: null,
+      };
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -657,6 +664,13 @@ describe('Express Server', () => {
         forwardGenericAlias: 123,
       } as any;
 
+      bodyModel.nullableTypes = {
+        // numberOrNull
+        wordOrNull: '',
+        maybeString: 1,
+        justNull: undefined,
+      } as any;
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -758,6 +772,14 @@ describe('Express Server', () => {
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
           expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
           expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
+          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+          expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
+          );
+          expect(body.fields['body.nullableTypes.wordOrNull'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.wordOrNull":{"message":"minLength 1","value":""}},{"body.nullableTypes.wordOrNull":{"message":"should be one of the following; [null]","value":""}}]`,
+          );
+          expect(body.fields['body.nullableTypes.justNull'].message).to.equal("'justNull' is required");
         },
         400,
       );

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -540,7 +540,7 @@ describe('Express Server', () => {
       };
 
       bodyModel.nullableTypes = {
-        numberOrNull: null,
+        numberOrNull: ('null' as unknown) as null,
         wordOrNull: null,
         maybeString: null,
         justNull: null,
@@ -599,6 +599,11 @@ describe('Express Server', () => {
           expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
           expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
           expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+          expect(body.nullableTypes.numberOrNull).to.equal(null);
+          expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+          expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+          expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
         },
         200,
       );

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -577,6 +577,13 @@ describe('Express Server', () => {
         forwardGenericAlias: { value1: 'value1' },
       };
 
+      bodyModel.nullableTypes = {
+        numberOrNull: null,
+        wordOrNull: null,
+        maybeString: null,
+        justNull: null,
+      };
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -695,6 +702,13 @@ describe('Express Server', () => {
         forwardGenericAlias: 123,
       } as any;
 
+      bodyModel.nullableTypes = {
+        // numberOrNull
+        wordOrNull: '',
+        maybeString: 1,
+        justNull: undefined,
+      } as any;
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -797,6 +811,14 @@ describe('Express Server', () => {
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
           expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
           expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
+          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+          expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
+          );
+          expect(body.fields['body.nullableTypes.wordOrNull'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.wordOrNull":{"message":"minLength 1","value":""}},{"body.nullableTypes.wordOrNull":{"message":"should be one of the following; [null]","value":""}}]`,
+          );
+          expect(body.fields['body.nullableTypes.justNull'].message).to.equal("'justNull' is required");
         },
         400,
       );

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -578,7 +578,7 @@ describe('Express Server', () => {
       };
 
       bodyModel.nullableTypes = {
-        numberOrNull: null,
+        numberOrNull: ('null' as unknown) as null,
         wordOrNull: null,
         maybeString: null,
         justNull: null,
@@ -637,6 +637,11 @@ describe('Express Server', () => {
           expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
           expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
           expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+          expect(body.nullableTypes.numberOrNull).to.equal(null);
+          expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+          expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+          expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
         },
         200,
       );

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -513,7 +513,7 @@ describe('Hapi Server', () => {
       };
 
       bodyModel.nullableTypes = {
-        numberOrNull: null,
+        numberOrNull: ('null' as unknown) as null,
         wordOrNull: null,
         maybeString: null,
         justNull: null,
@@ -572,6 +572,11 @@ describe('Hapi Server', () => {
           expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
           expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
           expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+          expect(body.nullableTypes.numberOrNull).to.equal(null);
+          expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+          expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+          expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
         },
         200,
       );

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -512,6 +512,13 @@ describe('Hapi Server', () => {
         forwardGenericAlias: { value1: 'value1' },
       };
 
+      bodyModel.nullableTypes = {
+        numberOrNull: null,
+        wordOrNull: null,
+        maybeString: null,
+        justNull: null,
+      };
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -630,6 +637,13 @@ describe('Hapi Server', () => {
         forwardGenericAlias: 123,
       } as any;
 
+      bodyModel.nullableTypes = {
+        // numberOrNull
+        wordOrNull: '',
+        maybeString: 1,
+        justNull: undefined,
+      } as any;
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -732,6 +746,14 @@ describe('Hapi Server', () => {
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
           expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
           expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
+          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+          expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
+          );
+          expect(body.fields['body.nullableTypes.wordOrNull'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.wordOrNull":{"message":"minLength 1","value":""}},{"body.nullableTypes.wordOrNull":{"message":"should be one of the following; [null]","value":""}}]`,
+          );
+          expect(body.fields['body.nullableTypes.justNull'].message).to.equal("'justNull' is required");
         },
         400,
       );

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -234,6 +234,13 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
         forwardGenericAlias: { value1: 'value1' },
       };
 
+      bodyModel.nullableTypes = {
+        numberOrNull: null,
+        wordOrNull: null,
+        maybeString: null,
+        justNull: null,
+      };
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -235,7 +235,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       };
 
       bodyModel.nullableTypes = {
-        numberOrNull: null,
+        numberOrNull: ('null' as unknown) as null,
         wordOrNull: null,
         maybeString: null,
         justNull: null,
@@ -294,6 +294,11 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
           expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
           expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
           expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+          expect(body.nullableTypes.numberOrNull).to.equal(null);
+          expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+          expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+          expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
         },
         200,
       );

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -490,6 +490,13 @@ describe('Koa Server', () => {
         forwardGenericAlias: { value1: 'value1' },
       };
 
+      bodyModel.nullableTypes = {
+        numberOrNull: null,
+        wordOrNull: null,
+        maybeString: null,
+        justNull: null,
+      };
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -608,6 +615,13 @@ describe('Koa Server', () => {
         forwardGenericAlias: 123,
       } as any;
 
+      bodyModel.nullableTypes = {
+        // numberOrNull
+        wordOrNull: '',
+        maybeString: 1,
+        justNull: undefined,
+      } as any;
+
       return verifyPostRequest(
         basePath + `/Validate/body`,
         bodyModel,
@@ -710,6 +724,14 @@ describe('Koa Server', () => {
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
           expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
           expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
+          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+          expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
+          );
+          expect(body.fields['body.nullableTypes.wordOrNull'].message).to.equal(
+            `Could not match the union against any of the items. Issues: [{"body.nullableTypes.wordOrNull":{"message":"minLength 1","value":""}},{"body.nullableTypes.wordOrNull":{"message":"should be one of the following; [null]","value":""}}]`,
+          );
+          expect(body.fields['body.nullableTypes.justNull'].message).to.equal("'justNull' is required");
         },
         400,
       );

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -491,7 +491,7 @@ describe('Koa Server', () => {
       };
 
       bodyModel.nullableTypes = {
-        numberOrNull: null,
+        numberOrNull: ('null' as unknown) as null,
         wordOrNull: null,
         maybeString: null,
         justNull: null,
@@ -550,6 +550,11 @@ describe('Koa Server', () => {
           expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
           expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
           expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+          expect(body.nullableTypes.numberOrNull).to.equal(null);
+          expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+          expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+          expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
         },
         200,
       );

--- a/tests/integration/openapi3-express.spec.ts
+++ b/tests/integration/openapi3-express.spec.ts
@@ -75,7 +75,7 @@ describe('OpenAPI3 Express Server', () => {
     };
 
     bodyModel.nullableTypes = {
-      numberOrNull: null,
+      numberOrNull: ('null' as unknown) as null,
       wordOrNull: null,
       maybeString: null,
       justNull: null,
@@ -134,6 +134,12 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
         expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
         expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
+
+        expect(body.nullableTypes.numberOrNull).to.equal(null);
+        expect(body.nullableTypes.wordOrNull).to.equal(bodyModel.nullableTypes.wordOrNull);
+        expect(body.nullableTypes.maybeString).to.equal(bodyModel.nullableTypes.maybeString);
+        expect(body.nullableTypes.justNull).to.equal(bodyModel.nullableTypes.justNull);
+
         expect(body.fields).to.equal(undefined);
       },
       200,

--- a/tests/integration/openapi3-express.spec.ts
+++ b/tests/integration/openapi3-express.spec.ts
@@ -74,6 +74,13 @@ describe('OpenAPI3 Express Server', () => {
       forwardGenericAlias: { value1: 'value1' },
     };
 
+    bodyModel.nullableTypes = {
+      numberOrNull: null,
+      wordOrNull: null,
+      maybeString: null,
+      justNull: null,
+    };
+
     return verifyPostRequest(
       basePath + `/Validate/body`,
       bodyModel,
@@ -197,6 +204,13 @@ describe('OpenAPI3 Express Server', () => {
         id2: 2,
       },
       forwardGenericAlias: 123,
+    } as any;
+
+    bodyModel.nullableTypes = {
+      // numberOrNull
+      wordOrNull: '',
+      maybeString: 1,
+      justNull: undefined,
     } as any;
 
     return verifyPostRequest(
@@ -324,6 +338,14 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.typeAliases.unionIntersectionAlias4'].message).to.equal(
           `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias4":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.unionIntersectionAlias4.value1\\":{\\"message\\":\\"'value1' is required\\"}},{\\"body.typeAliases.unionIntersectionAlias4.value2\\":{\\"message\\":\\"invalid string value\\",\\"value\\":2}}]","value":{"value2":2,"value4":"four"}}}]`,
         );
+        expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+        expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
+          `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
+        );
+        expect(body.fields['body.nullableTypes.wordOrNull'].message).to.equal(
+          `Could not match the union against any of the items. Issues: [{"body.nullableTypes.wordOrNull":{"message":"minLength 1","value":""}},{"body.nullableTypes.wordOrNull":{"message":"should be one of the following; [null]","value":""}}]`,
+        );
+        expect(body.fields['body.nullableTypes.justNull'].message).to.equal("'justNull' is required");
       },
       400,
     );

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -231,13 +231,13 @@ describe('Definition generation', () => {
           enumValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/definitions/EnumIndexValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           enumArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -247,7 +247,7 @@ describe('Definition generation', () => {
           enumNumberValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/definitions/EnumNumberValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
 
             const validatedDefinition = getValidatedDefinition('EnumNumberValue', currentSpec);
@@ -258,7 +258,7 @@ describe('Definition generation', () => {
           enumStringNumberValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/definitions/EnumStringNumberValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
 
             const validatedDefinition = getValidatedDefinition('EnumStringNumberValue', currentSpec);
@@ -269,7 +269,7 @@ describe('Definition generation', () => {
           enumStringNumberArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -279,7 +279,7 @@ describe('Definition generation', () => {
           enumNumberArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -290,7 +290,7 @@ describe('Definition generation', () => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema.$ref).to.eq('#/definitions/EnumStringValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
 
             const validatedDefinition = getValidatedDefinition('EnumStringValue', currentSpec);
             expect(validatedDefinition.type).to.eq('string');
@@ -300,7 +300,7 @@ describe('Definition generation', () => {
           enumStringArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -345,7 +345,7 @@ describe('Definition generation', () => {
           },
           unionPrimetiveType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(false, `for property ${propertyName}[x-nullable]`);
             if (!propertySchema.enum) {
               throw new Error(`There was no 'enum' property on ${propertyName}.`);
             }
@@ -358,7 +358,7 @@ describe('Definition generation', () => {
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(false, `for property ${propertyName}[x-nullable]`);
             if (!propertySchema.enum) {
               throw new Error(`There was no 'enum' property on ${propertyName}.`);
             }
@@ -367,71 +367,71 @@ describe('Definition generation', () => {
           },
           dateValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema.format).to.eq('date-time', `for property ${propertyName}.format`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           optionalString: (propertyName, propertySchema) => {
             // should generate an optional property from an optional property
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema).to.not.haveOwnProperty('format', `for property ${propertyName}`);
           },
           anyType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "unknown" type always allows more properties be definition');
           },
           unknownType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "any" type always allows more properties be definition');
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace.TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS2: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace.InnerNamespace.TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS_Alias: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace_TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsObjectIndirectNS2_Alias: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainerNamespace_InnerNamespace_TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsArrayIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubArrayModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           modelsEnumIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubEnumModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           typeAliasCase1: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TypeAliasModelCase1', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           TypeAliasCase2: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TypeAliasModelCase2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
           },
           genericMultiNested: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/GenericRequest_GenericRequest_TypeAliasModel1__', `for property ${propertyName}.$ref`);
@@ -489,12 +489,11 @@ describe('Definition generation', () => {
                       additionalProperties: {
                         $ref: '#/definitions/TypeAliasModel1',
                       },
-                      'x-nullable': true,
                     },
                     allNestedOptional: {
                       properties: {
-                        one: { type: 'string', default: undefined, description: undefined, format: undefined, 'x-nullable': true },
-                        two: { type: 'string', default: undefined, description: undefined, format: undefined, 'x-nullable': true },
+                        one: { type: 'string', default: undefined, description: undefined, format: undefined },
+                        two: { type: 'string', default: undefined, description: undefined, format: undefined },
                       },
                       type: 'object',
                       default: undefined,
@@ -502,14 +501,13 @@ describe('Definition generation', () => {
                       format: undefined,
                     },
                     bool: { type: 'boolean', default: undefined, description: undefined, format: undefined },
-                    optional: { type: 'number', format: 'double', default: undefined, description: undefined, 'x-nullable': true },
+                    optional: { type: 'number', format: 'double', default: undefined, description: undefined },
                   },
                   default: undefined,
                   description: undefined,
                   format: undefined,
                   required: ['allNestedOptional', 'bool'],
                   type: 'object',
-                  'x-nullable': true,
                 },
               },
               required: ['name'],
@@ -525,7 +523,7 @@ describe('Definition generation', () => {
               properties: {
                 word: { $ref: '#/definitions/Word', description: undefined, format: undefined },
                 fourtyTwo: { $ref: '#/definitions/FourtyTwo', description: undefined, format: undefined },
-                dateAlias: { $ref: '#/definitions/DateAlias', description: undefined, format: undefined, 'x-nullable': true },
+                dateAlias: { $ref: '#/definitions/DateAlias', description: undefined, format: undefined },
                 unionAlias: { $ref: '#/definitions/UnionAlias', description: undefined, format: undefined },
                 intersectionAlias: { $ref: '#/definitions/IntersectionAlias', description: undefined, format: undefined },
                 nOLAlias: { $ref: '#/definitions/NolAlias', description: undefined, format: undefined },
@@ -535,7 +533,6 @@ describe('Definition generation', () => {
               },
               required: ['forwardGenericAlias', 'genericAlias2', 'genericAlias', 'nOLAlias', 'intersectionAlias', 'unionAlias', 'fourtyTwo', 'word'],
               type: 'object',
-              'x-nullable': true,
             });
 
             const wordSchema = getValidatedDefinition('Word', currentSpec);
@@ -614,24 +611,23 @@ describe('Definition generation', () => {
             expect(propertySchema).to.deep.eq(
               {
                 properties: {
-                  omit: { $ref: '#/definitions/Omit_ErrorResponseModel.status_', description: undefined, format: undefined, 'x-nullable': true },
-                  omitHidden: { $ref: '#/definitions/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined, 'x-nullable': true },
-                  partial: { $ref: '#/definitions/Partial_Account_', description: undefined, format: undefined, 'x-nullable': true },
-                  excludeToEnum: { $ref: '#/definitions/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined, 'x-nullable': true },
-                  excludeToAlias: { $ref: '#/definitions/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined, 'x-nullable': true },
-                  excludeLiteral: { $ref: '#/definitions/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined, 'x-nullable': true },
-                  excludeToInterface: { $ref: '#/definitions/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined, 'x-nullable': true },
-                  excludeTypeToPrimitive: { $ref: '#/definitions/NonNullable_number~OR~null_', description: undefined, format: undefined, 'x-nullable': true },
-                  pick: { $ref: '#/definitions/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined, 'x-nullable': true },
-                  readonlyClass: { $ref: '#/definitions/Readonly_TestClassModel_', description: undefined, format: undefined, 'x-nullable': true },
-                  defaultArgs: { $ref: '#/definitions/DefaultTestModel', description: undefined, format: undefined, 'x-nullable': true },
-                  heritageCheck: { $ref: '#/definitions/HeritageTestModel', description: undefined, format: undefined, 'x-nullable': true },
+                  omit: { $ref: '#/definitions/Omit_ErrorResponseModel.status_', description: undefined, format: undefined },
+                  omitHidden: { $ref: '#/definitions/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined },
+                  partial: { $ref: '#/definitions/Partial_Account_', description: undefined, format: undefined },
+                  excludeToEnum: { $ref: '#/definitions/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined },
+                  excludeToAlias: { $ref: '#/definitions/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined },
+                  excludeLiteral: { $ref: '#/definitions/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined },
+                  excludeToInterface: { $ref: '#/definitions/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined },
+                  excludeTypeToPrimitive: { $ref: '#/definitions/NonNullable_number~OR~null_', description: undefined, format: undefined },
+                  pick: { $ref: '#/definitions/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined },
+                  readonlyClass: { $ref: '#/definitions/Readonly_TestClassModel_', description: undefined, format: undefined },
+                  defaultArgs: { $ref: '#/definitions/DefaultTestModel', description: undefined, format: undefined },
+                  heritageCheck: { $ref: '#/definitions/HeritageTestModel', description: undefined, format: undefined },
                 },
                 type: 'object',
                 default: undefined,
                 description: undefined,
                 format: undefined,
-                'x-nullable': true,
               },
               `for property ${propertyName}`,
             );
@@ -690,7 +686,7 @@ describe('Definition generation', () => {
             const partial = getValidatedDefinition('Partial_Account_', currentSpec);
             expect(partial).to.deep.eq(
               {
-                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined, 'x-nullable': true } },
+                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined } },
                 type: 'object',
                 description: 'Make all properties in T optional',
                 default: undefined,
@@ -805,14 +801,14 @@ describe('Definition generation', () => {
             expect(readonlyClassSchema).to.deep.eq(
               {
                 properties: {
-                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined, 'x-nullable': true },
+                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined },
                   id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined, 'x-nullable': true },
+                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined },
                   readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
                   publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
                   stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+', 'x-nullable': true },
-                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, 'x-nullable': true },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+' },
+                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined },
                   publicStringProperty: {
                     type: 'string',
                     minLength: 3,
@@ -822,7 +818,7 @@ describe('Definition generation', () => {
                     description: 'This is a description of a public string property',
                     format: undefined,
                   },
-                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, 'x-nullable': true },
+                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined },
                   account: { $ref: '#/definitions/Account', format: undefined, description: undefined },
                 },
                 required: ['account', 'publicStringProperty', 'stringProperty', 'publicConstructorVar', 'readonlyConstructorArgument', 'id'],
@@ -858,7 +854,6 @@ describe('Definition generation', () => {
                     description: undefined,
                     format: undefined,
                     type: 'string',
-                    'x-nullable': true,
                   },
                   value4: {
                     default: undefined,
@@ -896,7 +891,6 @@ describe('Definition generation', () => {
               },
               required: ['justNull', 'maybeString', 'wordOrNull', 'numberOrNull'],
               type: 'object',
-              ['x-nullable']: true,
             });
 
             const maybeString = getValidatedDefinition('Maybe_string_', currentSpec);
@@ -1208,8 +1202,8 @@ describe('Definition generation', () => {
           const definition = getValidatedDefinition('GenericModel_TestModelArray_', currentSpec).properties;
 
           expect(definition!.result).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined });
-          expect(definition!.union).to.deep.equal({ type: 'object', description: undefined, format: undefined, default: undefined, 'x-nullable': true });
-          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequest_TestModelArray_', description: undefined, format: undefined, 'x-nullable': true });
+          expect(definition!.union).to.deep.equal({ type: 'object', description: undefined, format: undefined, default: undefined });
+          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequest_TestModelArray_', description: undefined, format: undefined });
 
           const ref = getValidatedDefinition('GenericRequest_TestModelArray_', currentSpec).properties;
           expect(ref!.name).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
@@ -1228,7 +1222,6 @@ describe('Definition generation', () => {
             $ref: '#/definitions/ThingContainerWithTitle_TestModelArray_',
             description: undefined,
             format: undefined,
-            'x-nullable': true,
           });
 
           const ref = getValidatedDefinition('ThingContainerWithTitle_TestModelArray_', currentSpec).properties;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -357,7 +357,7 @@ describe('Definition generation', () => {
             expect(propertySchema.enum).to.include('false', `for property ${propertyName}.enum`);
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {
-            expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
+            expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);
             expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
             if (!propertySchema.enum) {
               throw new Error(`There was no 'enum' property on ${propertyName}.`);

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -334,7 +334,7 @@ describe('Definition generation', () => {
             expect(validatedDefinition.enum).to.include('', `for property ${propertyName}.enum`);
             expect(validatedDefinition.enum).to.include('Foo', `for property ${propertyName}.enum`);
             expect(validatedDefinition.enum).to.include('Bar', `for property ${propertyName}.enum`);
-            expect(validatedDefinition['x-nullable']).to.eq(undefined, `for property ${propertyName}[x-nullable]`);
+            expect(validatedDefinition['x-nullable']).to.eq(false, `for property ${propertyName}[x-nullable]`);
           },
           strLiteralArr: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
@@ -752,6 +752,7 @@ describe('Definition generation', () => {
                 description: 'Exclude from T those types that are assignable to U',
                 default: undefined,
                 example: undefined,
+                ['x-nullable']: false,
               },
               `for definition linked by ${propertyName}`,
             );
@@ -873,6 +874,36 @@ describe('Definition generation', () => {
               },
               `for schema linked by property ${propertyName}`,
             );
+          },
+          nullableTypes: (propertyName, propertySchema) => {
+            expect(propertyName).to.equal('nullableTypes');
+            expect(propertySchema).to.deep.equal({
+              default: undefined,
+              description: undefined,
+              format: undefined,
+              properties: {
+                maybeString: { $ref: '#/definitions/Maybe_string_', description: undefined, format: undefined },
+                wordOrNull: { $ref: '#/definitions/Maybe_Word_', description: undefined, format: undefined },
+                numberOrNull: { type: 'number', format: 'double', description: undefined, default: undefined, ['x-nullable']: true },
+                justNull: {
+                  default: undefined,
+                  description: undefined,
+                  enum: ['null'],
+                  format: undefined,
+                  type: 'number',
+                  ['x-nullable']: true,
+                },
+              },
+              required: ['justNull', 'maybeString', 'wordOrNull', 'numberOrNull'],
+              type: 'object',
+              ['x-nullable']: true,
+            });
+
+            const maybeString = getValidatedDefinition('Maybe_string_', currentSpec);
+            expect(maybeString).to.deep.eq({ type: 'string', description: undefined, example: undefined, default: undefined, ['x-nullable']: true }, `for schema linked by property ${propertyName}`);
+
+            const maybeWord = getValidatedDefinition('Maybe_Word_', currentSpec);
+            expect(maybeWord).to.deep.eq({ type: 'object', description: undefined, example: undefined, default: undefined }, `for schema linked by property ${propertyName}`);
           },
         };
 

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -529,7 +529,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           unionPrimetiveType: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq({
-              oneOf: [{ type: 'string', enum: ['String'] }, { type: 'string', enum: ['1'] }, { type: 'string', enum: ['20'] }, { type: 'string', enum: ['true'] }, { type: 'string', enum: ['false'] }],
+              oneOf: [
+                { type: 'string', enum: ['String'] },
+                { type: 'number', enum: ['1'] },
+                { type: 'number', enum: ['20'] },
+                { type: 'boolean', enum: ['true'] },
+                { type: 'boolean', enum: ['false'] },
+              ],
               nullable: true,
               default: undefined,
               description: undefined,
@@ -537,7 +543,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             });
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {
-            expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
+            expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);
             expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}[x-nullable]`);
             if (!propertySchema.enum) {
               throw new Error(`There was no 'enum' property on ${propertyName}.`);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -514,7 +514,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const componentSchema = getComponentSchema('StrLiteral', currentSpec);
             expect(componentSchema).to.deep.eq({
-              oneOf: [{ type: 'string', enum: [''] }, { type: 'string', enum: ['Foo'] }, { type: 'string', enum: ['Bar'] }],
+              oneOf: [{ type: 'string', enum: [''], nullable: false }, { type: 'string', enum: ['Foo'], nullable: false }, { type: 'string', enum: ['Bar'], nullable: false }],
               default: undefined,
               description: undefined,
               example: undefined,
@@ -530,11 +530,11 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           unionPrimetiveType: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq({
               oneOf: [
-                { type: 'string', enum: ['String'] },
-                { type: 'number', enum: ['1'] },
-                { type: 'number', enum: ['20'] },
-                { type: 'boolean', enum: ['true'] },
-                { type: 'boolean', enum: ['false'] },
+                { type: 'string', enum: ['String'], nullable: false },
+                { type: 'number', enum: ['1'], nullable: false },
+                { type: 'number', enum: ['20'], nullable: false },
+                { type: 'boolean', enum: ['true'], nullable: false },
+                { type: 'boolean', enum: ['false'], nullable: false },
               ],
               nullable: true,
               default: undefined,
@@ -904,15 +904,15 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(excludeLiteral).to.deep.eq(
               {
                 oneOf: [
-                  { type: 'string', enum: ['id'] },
-                  { type: 'string', enum: ['publicStringProperty'] },
-                  { type: 'string', enum: ['optionalPublicStringProperty'] },
-                  { type: 'string', enum: ['emailPattern'] },
-                  { type: 'string', enum: ['stringProperty'] },
-                  { type: 'string', enum: ['publicConstructorVar'] },
-                  { type: 'string', enum: ['readonlyConstructorArgument'] },
-                  { type: 'string', enum: ['optionalPublicConstructorVar'] },
-                  { type: 'string', enum: ['defaultValue1'] },
+                  { type: 'string', enum: ['id'], nullable: false },
+                  { type: 'string', enum: ['publicStringProperty'], nullable: false },
+                  { type: 'string', enum: ['optionalPublicStringProperty'], nullable: false },
+                  { type: 'string', enum: ['emailPattern'], nullable: false },
+                  { type: 'string', enum: ['stringProperty'], nullable: false },
+                  { type: 'string', enum: ['publicConstructorVar'], nullable: false },
+                  { type: 'string', enum: ['readonlyConstructorArgument'], nullable: false },
+                  { type: 'string', enum: ['optionalPublicConstructorVar'], nullable: false },
+                  { type: 'string', enum: ['defaultValue1'], nullable: false },
                 ],
                 description: 'Exclude from T those types that are assignable to U',
                 default: undefined,
@@ -1025,6 +1025,42 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
               },
+              `for schema linked by property ${propertyName}`,
+            );
+          },
+          nullableTypes: (propertyName, propertySchema) => {
+            expect(propertyName).to.equal('nullableTypes');
+            expect(propertySchema).to.deep.equal({
+              default: undefined,
+              description: undefined,
+              format: undefined,
+              properties: {
+                maybeString: { $ref: '#/components/schemas/Maybe_string_', description: undefined, format: undefined },
+                wordOrNull: { $ref: '#/components/schemas/Maybe_Word_', description: undefined, format: undefined },
+                numberOrNull: { oneOf: [{ type: 'number', format: 'double' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, format: undefined, default: undefined },
+                justNull: {
+                  default: undefined,
+                  description: undefined,
+                  enum: ['null'],
+                  format: undefined,
+                  nullable: true,
+                  type: 'number',
+                },
+              },
+              required: ['justNull', 'maybeString', 'wordOrNull', 'numberOrNull'],
+              type: 'object',
+              nullable: true,
+            });
+
+            const maybeString = getComponentSchema('Maybe_string_', currentSpec);
+            expect(maybeString).to.deep.eq(
+              { oneOf: [{ type: 'string' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, default: undefined, example: undefined },
+              `for schema linked by property ${propertyName}`,
+            );
+
+            const maybeWord = getComponentSchema('Maybe_Word_', currentSpec);
+            expect(maybeWord).to.deep.eq(
+              { oneOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, default: undefined, example: undefined },
               `for schema linked by property ${propertyName}`,
             );
           },

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -273,7 +273,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           throw new Error('testModel.properties should have been a truthy object');
         }
         expect(testModel.properties.optionalString).to.not.have.property('x-nullable');
-        expect(testModel.properties.optionalString.nullable).to.be.true;
+        expect(testModel.properties.optionalString.nullable).to.be.undefined;
       });
     });
   });
@@ -365,15 +365,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                       default: undefined,
                       description: undefined,
                       format: undefined,
-                      nullable: true,
                       additionalProperties: {
                         $ref: '#/components/schemas/TypeAliasModel1',
                       },
                     },
                     allNestedOptional: {
                       properties: {
-                        one: { type: 'string', default: undefined, description: undefined, format: undefined, nullable: true },
-                        two: { type: 'string', default: undefined, description: undefined, format: undefined, nullable: true },
+                        one: { type: 'string', default: undefined, description: undefined, format: undefined },
+                        two: { type: 'string', default: undefined, description: undefined, format: undefined },
                       },
                       type: 'object',
                       default: undefined,
@@ -381,14 +380,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                       format: undefined,
                     },
                     bool: { type: 'boolean', default: undefined, description: undefined, format: undefined },
-                    optional: { format: 'double', type: 'number', default: undefined, description: undefined, nullable: true },
+                    optional: { format: 'double', type: 'number', default: undefined, description: undefined },
                   },
                   required: ['allNestedOptional', 'bool'],
                   type: 'object',
                   default: undefined,
                   description: undefined,
                   format: undefined,
-                  nullable: true,
                 },
               },
               required: ['name'],
@@ -422,13 +420,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/components/schemas/EnumIndexValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           enumArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -438,7 +436,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumNumberValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/components/schemas/EnumNumberValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
 
             const schema = getComponentSchema('EnumNumberValue', currentSpec);
@@ -448,7 +446,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumStringNumberValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema.$ref).to.eq('#/components/schemas/EnumStringNumberValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
 
             const schema = getComponentSchema('EnumStringNumberValue', currentSpec);
@@ -458,7 +456,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumStringNumberArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -468,7 +466,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumNumberArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -479,7 +477,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema.$ref).to.eq('#/components/schemas/EnumStringValue', `for property ${propertyName}.$ref`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
 
             const schema = getComponentSchema('EnumStringValue', currentSpec);
             expect(schema.type).to.eq('string');
@@ -488,7 +486,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           enumStringArray: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('array', `for property ${propertyName}.type`);
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             if (!propertySchema.items) {
               throw new Error(`There was no 'items' property on ${propertyName}.`);
@@ -536,7 +534,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 { type: 'boolean', enum: ['true'], nullable: false },
                 { type: 'boolean', enum: ['false'], nullable: false },
               ],
-              nullable: true,
               default: undefined,
               description: undefined,
               format: undefined,
@@ -544,7 +541,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}[x-nullable]`);
+            expect(propertySchema.nullable).to.eq(false, `for property ${propertyName}.nullable`);
             if (!propertySchema.enum) {
               throw new Error(`There was no 'enum' property on ${propertyName}.`);
             }
@@ -553,71 +550,71 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           dateValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema.format).to.eq('date-time', `for property ${propertyName}.format`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           optionalString: (propertyName, propertySchema) => {
             // should generate an optional property from an optional property
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
             expect(propertySchema).to.not.haveOwnProperty('format', `for property ${propertyName}`);
           },
           anyType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "any" type always allows more properties be definition');
           },
           unknownType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
             expect(propertySchema.additionalProperties).to.eq(true, 'because the "unknown" type always allows more properties be definition');
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace.TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS2: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace.InnerNamespace.TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS_Alias: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace_TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsObjectIndirectNS2_Alias: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainerNamespace_InnerNamespace_TestSubModelContainer2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsArrayIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubArrayModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           modelsEnumIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubEnumModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           typeAliasCase1: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TypeAliasModelCase1', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           TypeAliasCase2: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TypeAliasModelCase2', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
-            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}.nullable`);
+            expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
           },
           genericMultiNested: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/GenericRequest_GenericRequest_TypeAliasModel1__', `for property ${propertyName}.$ref`);
@@ -686,7 +683,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               properties: {
                 word: { $ref: '#/components/schemas/Word', description: undefined, format: undefined },
                 fourtyTwo: { $ref: '#/components/schemas/FourtyTwo', description: undefined, format: undefined },
-                dateAlias: { $ref: '#/components/schemas/DateAlias', description: undefined, format: undefined, nullable: true },
+                dateAlias: { $ref: '#/components/schemas/DateAlias', description: undefined, format: undefined },
                 unionAlias: { $ref: '#/components/schemas/UnionAlias', description: undefined, format: undefined },
                 intersectionAlias: { $ref: '#/components/schemas/IntersectionAlias', description: undefined, format: undefined },
                 nOLAlias: { $ref: '#/components/schemas/NolAlias', description: undefined, format: undefined },
@@ -696,7 +693,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               required: ['forwardGenericAlias', 'genericAlias2', 'genericAlias', 'nOLAlias', 'intersectionAlias', 'unionAlias', 'fourtyTwo', 'word'],
               type: 'object',
-              nullable: true,
             });
 
             const wordSchema = getComponentSchema('Word', currentSpec);
@@ -780,24 +776,23 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema).to.deep.eq(
               {
                 properties: {
-                  omit: { $ref: '#/components/schemas/Omit_ErrorResponseModel.status_', description: undefined, format: undefined, nullable: true },
-                  omitHidden: { $ref: '#/components/schemas/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined, nullable: true },
-                  partial: { $ref: '#/components/schemas/Partial_Account_', description: undefined, format: undefined, nullable: true },
-                  excludeToEnum: { $ref: '#/components/schemas/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined, nullable: true },
-                  excludeToAlias: { $ref: '#/components/schemas/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined, nullable: true },
-                  excludeLiteral: { $ref: '#/components/schemas/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined, nullable: true },
-                  excludeToInterface: { $ref: '#/components/schemas/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined, nullable: true },
-                  excludeTypeToPrimitive: { $ref: '#/components/schemas/NonNullable_number~OR~null_', description: undefined, format: undefined, nullable: true },
-                  pick: { $ref: '#/components/schemas/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined, nullable: true },
-                  readonlyClass: { $ref: '#/components/schemas/Readonly_TestClassModel_', description: undefined, format: undefined, nullable: true },
-                  defaultArgs: { $ref: '#/components/schemas/DefaultTestModel', description: undefined, format: undefined, nullable: true },
-                  heritageCheck: { $ref: '#/components/schemas/HeritageTestModel', description: undefined, format: undefined, nullable: true },
+                  omit: { $ref: '#/components/schemas/Omit_ErrorResponseModel.status_', description: undefined, format: undefined },
+                  omitHidden: { $ref: '#/components/schemas/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined },
+                  partial: { $ref: '#/components/schemas/Partial_Account_', description: undefined, format: undefined },
+                  excludeToEnum: { $ref: '#/components/schemas/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined },
+                  excludeToAlias: { $ref: '#/components/schemas/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined },
+                  excludeLiteral: { $ref: '#/components/schemas/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined },
+                  excludeToInterface: { $ref: '#/components/schemas/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined },
+                  excludeTypeToPrimitive: { $ref: '#/components/schemas/NonNullable_number~OR~null_', description: undefined, format: undefined },
+                  pick: { $ref: '#/components/schemas/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined },
+                  readonlyClass: { $ref: '#/components/schemas/Readonly_TestClassModel_', description: undefined, format: undefined },
+                  defaultArgs: { $ref: '#/components/schemas/DefaultTestModel', description: undefined, format: undefined },
+                  heritageCheck: { $ref: '#/components/schemas/HeritageTestModel', description: undefined, format: undefined },
                 },
                 type: 'object',
                 default: undefined,
                 description: undefined,
                 format: undefined,
-                nullable: true,
               },
               `for property ${propertyName}`,
             );
@@ -856,7 +851,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const partial = getComponentSchema('Partial_Account_', currentSpec);
             expect(partial).to.deep.eq(
               {
-                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined, nullable: true } },
+                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined } },
                 type: 'object',
                 description: 'Make all properties in T optional',
                 default: undefined,
@@ -969,14 +964,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(readonlyClassSchema).to.deep.eq(
               {
                 properties: {
-                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined, nullable: true },
+                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined },
                   id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined, nullable: true },
+                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined },
                   readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
                   publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
                   stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+', nullable: true },
-                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, nullable: true },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+' },
+                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined },
                   publicStringProperty: {
                     type: 'string',
                     minLength: 3,
@@ -986,7 +981,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     description: 'This is a description of a public string property',
                     format: undefined,
                   },
-                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, nullable: true },
+                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined },
                   account: { $ref: '#/components/schemas/Account', format: undefined, description: undefined },
                 },
                 required: ['account', 'publicStringProperty', 'stringProperty', 'publicConstructorVar', 'readonlyConstructorArgument', 'id'],
@@ -1018,7 +1013,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   value4: { type: 'string', description: undefined, format: undefined, default: undefined },
-                  name: { type: 'string', description: undefined, format: undefined, default: undefined, nullable: true },
+                  name: { type: 'string', description: undefined, format: undefined, default: undefined },
                 },
                 required: ['value4'],
                 type: 'object',
@@ -1049,7 +1044,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               required: ['justNull', 'maybeString', 'wordOrNull', 'numberOrNull'],
               type: 'object',
-              nullable: true,
             });
 
             const maybeString = getComponentSchema('Maybe_string_', currentSpec);


### PR DESCRIPTION
### Goals

1. Support TypeScript's null keyword
2. Represent null as a "nullable" enum with type `[null]`
3. Distinguish between nullable (`null`) and required/optional (`undefined`)
4. Support Swagger whenever possible*

\* OpenAPI can use anyOf, to combine schemas. In case of Swagger, we need to check if we are combining a non-$ref type with `null`. In this case we can set `x-nullable: true`. Otherwise, we need to bail out since {$ref: '', ['x-nullable']: true} does not work/will be ignored (sibling values along $ref are ignored).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

Closes #557, #479, #497 (presumably), #257 (presumably), #510

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Breaks compat