### PR TITLE
correctly propagate field name in validateModel

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -641,12 +641,13 @@ export class ValidationService {
       }
 
       if (modelDefinition.dataType === 'refAlias') {
-        const parentName = modelDefinition.type.ref ? parent + name + '.' : parent;
-        return this.ValidateParam(modelDefinition.type, value, name, fieldErrors, parentName, swaggerConfig);
+        return this.ValidateParam(modelDefinition.type, value, name, fieldErrors, parent, swaggerConfig);
       }
 
+      const fieldPath = parent + name;
+
       if (!(value instanceof Object)) {
-        fieldErrors[parent + name] = {
+        fieldErrors[fieldPath] = {
           message: `invalid object`,
           value,
         };
@@ -662,7 +663,7 @@ export class ValidationService {
 
         // process value only if it exists inside of value or if it is required
         if (key in value || property.required) {
-          value[key] = this.ValidateParam(property, value[key], key, fieldErrors, parent, swaggerConfig);
+          value[key] = this.ValidateParam(property, value[key], key, fieldErrors, fieldPath + '.', swaggerConfig);
         }
       });
 
@@ -678,13 +679,13 @@ export class ValidationService {
         Object.keys(value).forEach((key: string) => {
           if (isAnExcessProperty(key)) {
             if (swaggerConfig.noImplicitAdditionalProperties === 'throw-on-extras') {
-              fieldErrors[parent + key] = {
+              fieldErrors[`${fieldPath}.${key}`] = {
                 message: `"${key}" is an excess property and therefore is not allowed`,
                 value: key,
               };
             } else if (swaggerConfig.noImplicitAdditionalProperties === true) {
               warnAdditionalPropertiesDeprecation(swaggerConfig.noImplicitAdditionalProperties);
-              fieldErrors[parent + key] = {
+              fieldErrors[`${fieldPath}.${key}`] = {
                 message: `"${key}" is an excess property and therefore is not allowed`,
                 value: key,
               };
@@ -703,11 +704,11 @@ export class ValidationService {
       } else {
         Object.keys(value).forEach((key: string) => {
           if (isAnExcessProperty(key)) {
-            const validatedValue = this.ValidateParam(additionalProperties, value[key], key, fieldErrors, parent, swaggerConfig);
+            const validatedValue = this.ValidateParam(additionalProperties, value[key], key, fieldErrors, fieldPath + '.', swaggerConfig);
             if (validatedValue !== undefined) {
               value[key] = validatedValue;
             } else {
-              fieldErrors[parent + key] = {
+              fieldErrors[`${fieldPath}.${key}`] = {
                 message: `No matching model found in additionalProperties to validate ${key}`,
                 value: key,
               };

--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -192,7 +192,7 @@ export function RegisterRoutes(app: express.Express) {
                 case 'header':
                     return validationService.ValidateParam(args[key], request.header(name), name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'body':
-                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, name + '.', {{{json minimalSwaggerConfig}}});
+                    return validationService.ValidateParam(args[key], request.body, name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'body-prop':
                     return validationService.ValidateParam(args[key], request.body[name], name, fieldErrors, 'body.', {{{json minimalSwaggerConfig}}});
             }

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -198,7 +198,7 @@ export function RegisterRoutes(server: any) {
             case 'header':
                 return validationService.ValidateParam(args[key], request.headers[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body':
-                return validationService.ValidateParam(args[key], request.payload, name, errorFields, name + '.', {{{json minimalSwaggerConfig}}});
+                return validationService.ValidateParam(args[key], request.payload, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
              case 'body-prop':
                 return validationService.ValidateParam(args[key], request.payload[name], name, errorFields, 'body.', {{{json minimalSwaggerConfig}}});
             }

--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -199,7 +199,7 @@ export function RegisterRoutes(router: KoaRouter) {
             case 'header':
                 return validationService.ValidateParam(args[key], context.request.headers[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body':
-                return validationService.ValidateParam(args[key], context.request.body, name, errorFields, name + '.', {{{json minimalSwaggerConfig}}});
+                return validationService.ValidateParam(args[key], context.request.body, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'body-prop':
                 return validationService.ValidateParam(args[key], context.request.body[name], name, errorFields, 'body.', {{{json minimalSwaggerConfig}}});
             }

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -703,7 +703,7 @@ describe('Express Server', () => {
               'Issues: [{"body.mixedUnion":{"message":"invalid string value","value":123}},' +
               '{"body.mixedUnion":{"message":"invalid object","value":123}}]',
           );
-          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
+          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.intersection.value2":{"message":"\'value2\' is required"}}]');
           expect(body.fields['body.singleBooleanEnum'].message).to.equal('should be one of the following; [true]');
           expect(body.fields['body.nestedObject.floatValue'].message).to.equal('Invalid float error message.');
           expect(body.fields['body.nestedObject.floatValue'].value).to.equal(bodyModel.floatValue);
@@ -746,13 +746,13 @@ describe('Express Server', () => {
               '{"body.nestedObject.mixedUnion":{"message":"invalid object","value":123}}]',
           );
           expect(body.fields['body.nestedObject.intersection'].message).to.equal(
-            'Could not match the intersection against every type. Issues: [{"body.nestedObject.value2":{"message":"\'value2\' is required"}}]',
+            'Could not match the intersection against every type. Issues: [{"body.nestedObject.intersection.value2":{"message":"\'value2\' is required"}}]',
           );
           expect(body.fields['body.typeAliases.word'].message).to.equal('minLength 1');
           expect(body.fields['body.typeAliases.fourtyTwo'].message).to.equal('min 42');
           expect(body.fields['body.typeAliases.unionAlias'].message).to.contain('Could not match the union against any of the items');
           expect(body.fields['body.typeAliases.intersectionAlias'].message).to.equal(
-            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.value1":{"message":"'value1' is required"}}]`,
+            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}}]`,
           );
           expect(body.fields['body.typeAliases.nOLAlias'].message).to.equal('invalid object');
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -676,7 +676,7 @@ describe('Hapi Server', () => {
               'Issues: [{"body.mixedUnion":{"message":"invalid string value","value":123}},' +
               '{"body.mixedUnion":{"message":"invalid object","value":123}}]',
           );
-          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
+          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.intersection.value2":{"message":"\'value2\' is required"}}]');
           expect(body.fields['body.singleBooleanEnum'].message).to.equal('should be one of the following; [true]');
 
           expect(body.fields['body.nestedObject.floatValue'].message).to.equal('Invalid float error message.');
@@ -720,13 +720,13 @@ describe('Hapi Server', () => {
               '{"body.nestedObject.mixedUnion":{"message":"invalid object","value":123}}]',
           );
           expect(body.fields['body.nestedObject.intersection'].message).to.equal(
-            'Could not match the intersection against every type. Issues: [{"body.nestedObject.value2":{"message":"\'value2\' is required"}}]',
+            'Could not match the intersection against every type. Issues: [{"body.nestedObject.intersection.value2":{"message":"\'value2\' is required"}}]',
           );
           expect(body.fields['body.typeAliases.word'].message).to.equal('minLength 1');
           expect(body.fields['body.typeAliases.fourtyTwo'].message).to.equal('min 42');
           expect(body.fields['body.typeAliases.unionAlias'].message).to.contain('Could not match the union against any of the items');
           expect(body.fields['body.typeAliases.intersectionAlias'].message).to.equal(
-            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.value1":{"message":"'value1' is required"}}]`,
+            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}}]`,
           );
           expect(body.fields['body.typeAliases.nOLAlias'].message).to.equal('invalid object');
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -654,7 +654,7 @@ describe('Koa Server', () => {
               'Issues: [{"body.mixedUnion":{"message":"invalid string value","value":123}},' +
               '{"body.mixedUnion":{"message":"invalid object","value":123}}]',
           );
-          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
+          expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.intersection.value2":{"message":"\'value2\' is required"}}]');
           expect(body.fields['body.singleBooleanEnum'].message).to.equal('should be one of the following; [true]');
 
           expect(body.fields['body.nestedObject.floatValue'].message).to.equal('Invalid float error message.');
@@ -698,13 +698,13 @@ describe('Koa Server', () => {
               '{"body.nestedObject.mixedUnion":{"message":"invalid object","value":123}}]',
           );
           expect(body.fields['body.nestedObject.intersection'].message).to.equal(
-            'Could not match the intersection against every type. Issues: [{"body.nestedObject.value2":{"message":"\'value2\' is required"}}]',
+            'Could not match the intersection against every type. Issues: [{"body.nestedObject.intersection.value2":{"message":"\'value2\' is required"}}]',
           );
           expect(body.fields['body.typeAliases.word'].message).to.equal('minLength 1');
           expect(body.fields['body.typeAliases.fourtyTwo'].message).to.equal('min 42');
           expect(body.fields['body.typeAliases.unionAlias'].message).to.contain('Could not match the union against any of the items');
           expect(body.fields['body.typeAliases.intersectionAlias'].message).to.equal(
-            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.value1":{"message":"'value1' is required"}}]`,
+            `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}}]`,
           );
           expect(body.fields['body.typeAliases.nOLAlias'].message).to.equal('invalid object');
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');

--- a/tests/integration/openapi3-express.spec.ts
+++ b/tests/integration/openapi3-express.spec.ts
@@ -238,7 +238,9 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
-        expect(body.fields['body.intersection'].message).to.deep.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
+        expect(body.fields['body.intersection'].message).to.deep.equal(
+          'Could not match the intersection against every type. Issues: [{"body.intersection.value2":{"message":"\'value2\' is required"}}]',
+        );
         expect(body.fields['body.intersection'].value).to.deep.equal(bodyModel.intersection);
         expect(body.fields['body.intersectionNoAdditional'].message).to.deep.equal('Could not match intersection against any of the possible combinations: [["value1","value2"]]');
         expect(body.fields['body.intersectionNoAdditional'].value).to.deep.equal(bodyModel.intersectionNoAdditional);
@@ -247,7 +249,7 @@ describe('OpenAPI3 Express Server', () => {
             'Issues: [{"body.mixedUnion":{"message":"invalid string value","value":123}},' +
             '{"body.mixedUnion":{"message":"invalid object","value":123}}]',
         );
-        expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
+        expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.intersection.value2":{"message":"\'value2\' is required"}}]');
         expect(body.fields['body.singleBooleanEnum'].message).to.equal('should be one of the following; [true]');
 
         expect(body.fields['body.nestedObject.floatValue'].message).to.equal('Invalid float error message.');
@@ -291,13 +293,13 @@ describe('OpenAPI3 Express Server', () => {
             '{"body.nestedObject.mixedUnion":{"message":"invalid object","value":123}}]',
         );
         expect(body.fields['body.nestedObject.intersection'].message).to.equal(
-          'Could not match the intersection against every type. Issues: [{"body.nestedObject.value2":{"message":"\'value2\' is required"}}]',
+          'Could not match the intersection against every type. Issues: [{"body.nestedObject.intersection.value2":{"message":"\'value2\' is required"}}]',
         );
         expect(body.fields['body.typeAliases.word'].message).to.equal('minLength 1');
         expect(body.fields['body.typeAliases.fourtyTwo'].message).to.equal('min 42');
         expect(body.fields['body.typeAliases.unionAlias'].message).to.contain('Could not match the union against any of the items');
         expect(body.fields['body.typeAliases.intersectionAlias'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.value1":{"message":"'value1' is required"}}]`,
+          `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}},{"body.typeAliases.intersectionAlias.value1":{"message":"'value1' is required"}}]`,
         );
         expect(body.fields['body.typeAliases.nOLAlias'].message).to.equal('invalid object');
         expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
@@ -305,22 +307,22 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.typeAliases.genericAlias2.id2'].message).to.equal('"id2" is an excess property and therefore is not allowed');
         expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
         expect(body.fields['body.typeAliases.intersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.value3":{"message":"'value3' is required"}}]`,
+          `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias2.value3":{"message":"'value3' is required"}}]`,
         );
         expect(body.fields['body.typeAliases.intersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.value3":{"message":"'value3' is required"}}]`,
+          `Could not match the intersection against every type. Issues: [{"body.typeAliases.intersectionAlias2.value3":{"message":"'value3' is required"}}]`,
         );
         expect(body.fields['body.typeAliases.unionIntersectionAlias1'].message).to.equal(
           'Could not match intersection against any of the possible combinations: [["value1","value3"],["value1","value4"],["value2","value3"],["value2","value4"]]',
         );
         expect(body.fields['body.typeAliases.unionIntersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias2":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.value3\\":{\\"message\\":\\"'value3' is required\\"}},{\\"body.typeAliases.unionIntersectionAlias2.value4\\":{\\"message\\":\\"'value4' is required\\"}}]","value":{"value1":"one"}}}]`,
+          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias2":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.unionIntersectionAlias2.value3\\":{\\"message\\":\\"'value3' is required\\"}},{\\"body.typeAliases.unionIntersectionAlias2.value4\\":{\\"message\\":\\"'value4' is required\\"}}]","value":{"value1":"one"}}}]`,
         );
         expect(body.fields['body.typeAliases.unionIntersectionAlias3'].message).to.equal(
           'Could not match intersection against any of the possible combinations: [["value1","value3"],["value1","value4"],["value2","value3"],["value2","value4"]]',
         );
         expect(body.fields['body.typeAliases.unionIntersectionAlias4'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias4":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.value1\\":{\\"message\\":\\"'value1' is required\\"}},{\\"body.typeAliases.value2\\":{\\"message\\":\\"invalid string value\\",\\"value\\":2}}]","value":{"value2":2,"value4":"four"}}}]`,
+          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias4":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.unionIntersectionAlias4.value1\\":{\\"message\\":\\"'value1' is required\\"}},{\\"body.typeAliases.unionIntersectionAlias4.value2\\":{\\"message\\":\\"invalid string value\\",\\"value\\":2}}]","value":{"value2":2,"value4":"four"}}}]`,
         );
       },
       400,

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -322,7 +322,7 @@ describe('ValidationService', () => {
         {},
       );
 
-      expect(error.a.message).to.equal(`'a' is required`);
+      expect(error['body.a'].message).to.equal(`'a' is required`);
     });
   });
 
@@ -849,6 +849,27 @@ describe('ValidationService', () => {
       expect(error[`${name}.$0`].value).to.equal('A');
       expect(error[`${name}.$2`].message).to.equal('invalid integer number');
       expect(error[`${name}.$2`].value).to.equal(true);
+    });
+
+    it('should invalid array nested value', () => {
+      const name = 'name';
+      const value = [{ a: 123 }, { a: 'bcd' }];
+      const error = {};
+      const result = new ValidationService({
+        ExampleModel: {
+          dataType: 'refObject',
+          properties: {
+            a: { dataType: 'string', required: true },
+          },
+        },
+      }).validateArray(name, value, error, {}, { ref: 'ExampleModel' });
+      expect(result).to.deep.equal([{ a: undefined }, { a: 'bcd' }]);
+      expect(error).to.deep.equal({
+        [`${name}.$0.a`]: {
+          message: 'invalid string value',
+          value: 123,
+        },
+      });
     });
 
     it('should array minItems validate', () => {


### PR DESCRIPTION
Additionally stop adding a parent for body and body-prop at the getValidatedArgs entry point since it's now being added for each model ref.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**
closes #605 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
None that I'm aware.  I do want to discuss some other changes but we can do that over in the issue.

**Test plan**

I added two tests to get a better understanding of how errors look when they're returned from `header` and `body-prop` type requests.  These were essentially just used to make sure i preserved the existing behavior.

I added one test to demonstrate that returning nested objects within array's did not give the expected field names within the error response.  I used this test provide faith that the new solution is working as intended.

I fixed numerous tests to use the correct field names for targeting the fields which are actually in error.