### PR TITLE
Pick, Omit and Partial Support #372

### DIFF
--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -13,6 +13,20 @@ export class GetTestController extends Controller {
   @Get()
   @SuccessResponse('200', 'Returns TestModel')
   @Example<TestModel>({
+    exPick3: "exPick3",
+    pickModel: {
+      item1: "item1",
+      item4: "item4"
+    },
+    omitModel: {
+      item1: 'item1',
+      item2: false,
+    },
+    optionalModel: {
+      item1: 'item1',
+      item2: false,
+      item3: 'item3',
+    },
     and: { value1: 'foo', value2: 'bar' },
     boolArray: [true, false],
     boolValue: true,

--- a/tests/fixtures/inversify/managedService.ts
+++ b/tests/fixtures/inversify/managedService.ts
@@ -5,6 +5,20 @@ import { TestModel, TestSubModel } from '../testModel';
 export class ManagedService {
   public getModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -3,6 +3,20 @@ import { TestClassModel, TestModel, TestSubModel } from '../testModel';
 export class ModelService {
   public getModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -21,7 +21,10 @@
  *   "stringValue": "a string"
  * }
  */
-export interface TestModel extends Model {
+export interface TestModel extends Partial<ExtendedPick>, Model {
+  optionalModel: Partial<TestPartial>;
+  omitModel: Omit<TestOmit, "item3" | "item4">;
+  pickModel: Pick<TestPick, "item1" | "item4">;
   and: TypeAliasModel1 & TypeAliasModel2;
   /**
    * This is a description of this model property, numberValue
@@ -94,8 +97,31 @@ export interface TestModel extends Model {
       };
     };
   };
-
   defaultGenericModel?: GenericModel;
+}
+
+export interface ExtendedPick {
+  exPick3: "exPick3";
+}
+interface TestPartial {
+  item1: string;
+  item2?: boolean;
+  item3?: string;
+  item4: string;
+}
+
+interface TestPick {
+  item1: string;
+  item2?: boolean;
+  item3?: string;
+  item4: string;
+}
+
+export interface TestOmit {
+  item1: string;
+  item2?: boolean;
+  item3?: string;
+  item4: string;
 }
 
 export interface TypeAliasModel1 {
@@ -221,7 +247,7 @@ export class ParameterTestModel {
   public nicknames?: string[];
 }
 
-export class ValidateCustomErrorModel {}
+export class ValidateCustomErrorModel { }
 
 export class ValidateModel {
   /**

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -1043,6 +1043,20 @@ describe('Express Server', () => {
 
   function getFakeModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1071,6 +1071,20 @@ describe('Express Server', () => {
 
   function getFakeModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -973,6 +973,20 @@ describe('Hapi Server', () => {
 
   function getFakeModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,

--- a/tests/integration/inversify-server.spec.ts
+++ b/tests/integration/inversify-server.spec.ts
@@ -23,6 +23,20 @@ describe('Inversify Express Server', () => {
     // hook in a new getModel method returning id = 2
     managedService.getModel = () => {
       return {
+        exPick3: "exPick3",
+        pickModel: {
+          item1: "item1",
+          item4: "item4"
+        },
+        omitModel: {
+          item1: 'item1',
+          item2: false,
+        },
+        optionalModel: {
+          item1: 'item1',
+          item2: false,
+          item3: 'item3',
+        },
         and: { value1: 'foo', value2: 'bar' },
         boolArray: [true, false],
         boolValue: true,

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -443,6 +443,20 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
 
   function getFakeModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -965,6 +965,20 @@ describe('Koa Server', () => {
 
   function getFakeModel(): TestModel {
     return {
+      exPick3: "exPick3",
+      pickModel: {
+        item1: "item1",
+        item4: "item4"
+      },
+      omitModel: {
+        item1: 'item1',
+        item2: false,
+      },
+      optionalModel: {
+        item1: 'item1',
+        item2: false,
+        item3: 'item3',
+      },
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -506,6 +506,34 @@ describe('Definition generation', () => {
               type: 'object',
             });
           },
+          optionalModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.equal({
+              '$ref': "#/definitions/TestPartial",
+              description: undefined,
+              format: undefined,
+            });
+          },
+          omitModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.equal({
+              '$ref': "#/definitions/TestOmit",
+              description: undefined,
+              format: undefined,
+            });
+          },
+          pickModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.equal({
+              '$ref': "#/definitions/TestPick",
+              description: undefined,
+              format: undefined,
+            });
+          },
+          exPick3: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.equal({
+              '$ref': "#/definitions/TestPick",
+              description: undefined,
+              format: undefined,
+            });
+          },
         };
 
         Object.keys(assertionsPerProperty).forEach(aPropertyName => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -298,6 +298,41 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
          * By creating a record of "keyof T" we ensure that contributors will need add a test for any new property that is added to the model
          */
         const assertionsPerProperty: Record<keyof TestModel, (propertyName: string, schema: Swagger.Spec) => void> = {
+          optionalModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.include({ $ref: '#/components/schemas/TestPartial' }, `for property ${propertyName}.$ref`);
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            const schemas = currentSpec.spec.components.schemas;
+            expect(schemas).to.not.be.undefined;
+            if (schemas) {
+              expect(schemas.TestPartial.required).to.be.undefined;
+              expect(schemas.TestPartial.properties).to.have.property('item1');
+              expect(schemas.TestPartial.properties).to.have.property('item2');
+              expect(schemas.TestPartial.properties).to.have.property('item3');
+              expect(schemas.TestPartial.properties).to.have.property('item4');
+            }
+          },
+          omitModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.include({ $ref: '#/components/schemas/TestOmit' }, `for property ${propertyName}.$ref`);
+            const schemas = currentSpec.spec.components.schemas;
+            expect(schemas).to.not.be.undefined;
+            if (schemas) {
+              expect(schemas.TestOmit).to.not.be.undefined;
+              expect(schemas.TestOmit.properties).to.have.property('item1');
+              expect(schemas.TestOmit.properties).to.have.property('item2');
+            }
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+          },
+          pickModel: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.include({ $ref: '#/components/schemas/TestPick' }, `for property ${propertyName}.$ref`);
+            const schemas = currentSpec.spec.components.schemas;
+            expect(schemas).to.not.be.undefined;
+            if (schemas) {
+              expect(schemas.TestPick).to.not.be.undefined;
+              expect(schemas.TestPick.properties).to.have.property('item1');
+              expect(schemas.TestPick.properties).to.have.property('item4');
+            }
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+          },
           id: (propertyName, propertySchema) => {
             // should generate properties from extended interface
             expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);


### PR DESCRIPTION
Addresses Issue
https://github.com/lukeautry/tsoa/issues/372

This PR adds utility type support for Pick, Partial and Omit.

Currently, this is working when the utility type is used in the body of the interface. My test cases are failing when the utility type is used in the declaration. 

e.g.
```
export interface Record {
   goodType: string
   redactType: string
}

// Fails tests
export interface RedactedRecord extends Pick<Record, "goodType"> {}

// passes tests 
export interface TestUtilities{
   // creates appropriate reference objects and adds them to the schemas and the generated 
   OpenApi spec.
   pickRedaction: Pick<Record, "goodType">
   partialTest: Partial<Record>
   omitTest: Omit<Record, "redactType">
}
```

If some comments can guide me in on where to make the changes for the declaration level use of utility type or point me at how to use the TS architecture to do this in a better way than what I am, please point.

Thanks.