### PR TITLE
allow quoting of patterns with "`" #563

### DIFF
--- a/src/utils/validatorUtils.ts
+++ b/src/utils/validatorUtils.ts
@@ -83,11 +83,11 @@ export function getParameterValidators(parameter: ts.ParameterDeclaration, param
           break;
         case 'pattern':
           if (typeof value !== 'string') {
-            throw new GenerateMetadataError(`${name} patameter use string.`);
+            throw new GenerateMetadataError(`${name} parameter use string.`);
           }
           validateObj[name] = {
             errorMsg: getErrorMsg(comment),
-            value,
+            value: removeSurroundingQuotes(value),
           };
           break;
         default:
@@ -173,11 +173,11 @@ export function getPropertyValidators(property: ts.PropertyDeclaration | ts.Type
           break;
         case 'pattern':
           if (typeof value !== 'string') {
-            throw new GenerateMetadataError(`${name} patameter use string.`);
+            throw new GenerateMetadataError(`${name} parameter use string.`);
           }
           validateObj[name] = {
             errorMsg: getErrorMsg(comment),
-            value,
+            value: removeSurroundingQuotes(value),
           };
           break;
         default:
@@ -219,4 +219,11 @@ function getParameterTagSupport() {
     'minDate',
     'maxDate',
   ];
+}
+
+function removeSurroundingQuotes(str: string) {
+  if (str.startsWith('`') && str.endsWith('`')) {
+    return str.substring(1, str.length - 1);
+  }
+  return str;
 }

--- a/src/utils/validatorUtils.ts
+++ b/src/utils/validatorUtils.ts
@@ -225,5 +225,8 @@ function removeSurroundingQuotes(str: string) {
   if (str.startsWith('`') && str.endsWith('`')) {
     return str.substring(1, str.length - 1);
   }
+  if (str.startsWith('```') && str.endsWith('```')) {
+    return str.substring(3, str.length - 3);
+  }
   return str;
 }

--- a/tests/fixtures/controllers/validateController.ts
+++ b/tests/fixtures/controllers/validateController.ts
@@ -16,6 +16,7 @@ export interface ValidateStringResponse {
   minLength: string;
   maxLength: string;
   patternValue: string;
+  quotedPatternValue: string;
 }
 
 @Route('Validate')
@@ -99,13 +100,15 @@ export class ValidateController {
    * @minLength minLength 5
    * @maxLength maxLength 3
    * @pattern patternValue ^[a-zA-Z]+$
+   * @pattern quotedPatternValue `^([A-Z])(?!@)$`
    */
   @Get('parameter/string')
-  public stringValidate(@Query() minLength: string, @Query() maxLength: string, @Query() patternValue: string): Promise<ValidateStringResponse> {
+  public stringValidate(@Query() minLength: string, @Query() maxLength: string, @Query() patternValue: string, @Query() quotedPatternValue: string): Promise<ValidateStringResponse> {
     return Promise.resolve({
       maxLength,
       minLength,
       patternValue,
+      quotedPatternValue,
     });
   }
   /**

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -352,7 +352,10 @@ export class ValidateModel {
    *  @pattern ^[a-zA-Z]+$
    */
   public stringPatternAZaz: string;
-
+  /**
+   * @pattern `^([A-Z])(?!@)$`
+   */
+  public quotedStringPatternA: string;
   /**
    * @maxItems 5
    */
@@ -447,7 +450,10 @@ export class ValidateModel {
      *  @pattern ^[a-zA-Z]+$
      */
     stringPatternAZaz: string;
-
+    /**
+     * @pattern `^([A-Z])(?!@)$`
+     */
+    quotedStringPatternA: string;
     /**
      * @maxItems 5
      */
@@ -553,7 +559,7 @@ export class TestClassModel extends TestClassBaseModel {
   public optionalPublicStringProperty?: string;
   /**
    * @format email
-   * @pattern ^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$
+   * @pattern `^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`
    */
   public emailPattern?: string;
   /* tslint:disable-next-line */

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -445,24 +445,25 @@ describe('Express Server', () => {
       );
     });
 
-    it('should valid minLength, maxLength and pattern validation of string type', () => {
+    it('should valid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf`,
+        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf&quotedPatternValue=A`,
         (err, res) => {
           const { body } = res;
 
           expect(body.minLength).to.equal('abcdef');
           expect(body.maxLength).to.equal('ab');
           expect(body.patternValue).to.equal('aBcDf');
+          expect(body.quotedPatternValue).to.equal('A');
         },
         200,
       );
     });
 
-    it('should invalid minLength, maxLength and pattern validation of string type', () => {
+    it('should invalid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       const value = '1234';
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}`,
+        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}&quotedPatternValue=A@`,
         (err, res) => {
           const body = JSON.parse(err.text);
 
@@ -472,6 +473,8 @@ describe('Express Server', () => {
           expect(body.fields.maxLength.value).to.equal(value);
           expect(body.fields.patternValue.message).to.equal("Not match in '^[a-zA-Z]+$'");
           expect(body.fields.patternValue.value).to.equal(value);
+          expect(body.fields.quotedPatternValue.message).to.equal("Not match in '^([A-Z])(?!@)$'");
+          expect(body.fields.quotedPatternValue.value).to.equal('A@');
         },
         400,
       );
@@ -493,6 +496,7 @@ describe('Express Server', () => {
       bodyModel.stringMax10Lenght = 'abcdef';
       bodyModel.stringMin5Lenght = 'abcdef';
       bodyModel.stringPatternAZaz = 'aBcD';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
@@ -517,6 +521,7 @@ describe('Express Server', () => {
         stringMax10Lenght: 'abcdef',
         stringMin5Lenght: 'abcdef',
         stringPatternAZaz: 'aBcD',
+        quotedStringPatternA: 'A',
 
         arrayMax5Item: [0, 1, 2, 3],
         arrayMin2Item: [0, 1],
@@ -560,6 +565,7 @@ describe('Express Server', () => {
           expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
           expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
           expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+          expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
           expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
           expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -584,6 +590,7 @@ describe('Express Server', () => {
           expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
           expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
           expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+          expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
           expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
           expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);
@@ -612,6 +619,7 @@ describe('Express Server', () => {
       bodyModel.stringMax10Lenght = 'abcdefghijk';
       bodyModel.stringMin5Lenght = 'abcd';
       bodyModel.stringPatternAZaz = 'ab01234';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
@@ -635,6 +643,7 @@ describe('Express Server', () => {
         stringMax10Lenght: 'abcdefghijk',
         stringMin5Lenght: 'abcd',
         stringPatternAZaz: 'ab01234',
+        quotedStringPatternA: 'A@',
 
         arrayMax5Item: [0, 1, 2, 3, 4, 6, 7, 8, 9],
         arrayMin2Item: [0],
@@ -705,6 +714,7 @@ describe('Express Server', () => {
           );
           expect(body.fields['body.intersection'].message).to.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
           expect(body.fields['body.singleBooleanEnum'].message).to.equal('should be one of the following; [true]');
+
           expect(body.fields['body.nestedObject.floatValue'].message).to.equal('Invalid float error message.');
           expect(body.fields['body.nestedObject.floatValue'].value).to.equal(bodyModel.floatValue);
           expect(body.fields['body.nestedObject.doubleValue'].message).to.equal('Invalid double error message.');

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -483,24 +483,25 @@ describe('Express Server', () => {
       );
     });
 
-    it('should valid minLength, maxLength and pattern validation of string type', () => {
+    it('should valid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf`,
+        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf&quotedPatternValue=A`,
         (err, res) => {
           const { body } = res;
 
           expect(body.minLength).to.equal('abcdef');
           expect(body.maxLength).to.equal('ab');
           expect(body.patternValue).to.equal('aBcDf');
+          expect(body.quotedPatternValue).to.equal('A');
         },
         200,
       );
     });
 
-    it('should invalid minLength, maxLength and pattern validation of string type', () => {
+    it('should invalid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       const value = '1234';
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}`,
+        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}&quotedPatternValue=A@`,
         (err, res) => {
           const body = JSON.parse(err.text);
 
@@ -510,6 +511,8 @@ describe('Express Server', () => {
           expect(body.fields.maxLength.value).to.equal(value);
           expect(body.fields.patternValue.message).to.equal("Not match in '^[a-zA-Z]+$'");
           expect(body.fields.patternValue.value).to.equal(value);
+          expect(body.fields.quotedPatternValue.message).to.equal("Not match in '^([A-Z])(?!@)$'");
+          expect(body.fields.quotedPatternValue.value).to.equal('A@');
         },
         400,
       );
@@ -531,6 +534,7 @@ describe('Express Server', () => {
       bodyModel.stringMax10Lenght = 'abcdef';
       bodyModel.stringMin5Lenght = 'abcdef';
       bodyModel.stringPatternAZaz = 'aBcD';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
@@ -555,6 +559,7 @@ describe('Express Server', () => {
         stringMax10Lenght: 'abcdef',
         stringMin5Lenght: 'abcdef',
         stringPatternAZaz: 'aBcD',
+        quotedStringPatternA: 'A',
 
         arrayMax5Item: [0, 1, 2, 3],
         arrayMin2Item: [0, 1],
@@ -598,6 +603,7 @@ describe('Express Server', () => {
           expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
           expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
           expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+          expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
           expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
           expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -622,6 +628,7 @@ describe('Express Server', () => {
           expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
           expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
           expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+          expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
           expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
           expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);
@@ -650,6 +657,7 @@ describe('Express Server', () => {
       bodyModel.stringMax10Lenght = 'abcdefghijk';
       bodyModel.stringMin5Lenght = 'abcd';
       bodyModel.stringPatternAZaz = 'ab01234';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
@@ -673,6 +681,7 @@ describe('Express Server', () => {
         stringMax10Lenght: 'abcdefghijk',
         stringMin5Lenght: 'abcd',
         stringPatternAZaz: 'ab01234',
+        quotedStringPatternA: 'A@',
 
         arrayMax5Item: [0, 1, 2, 3, 4, 6, 7, 8, 9],
         arrayMin2Item: [0],

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -418,24 +418,25 @@ describe('Hapi Server', () => {
       );
     });
 
-    it('should valid minLength, maxLength and pattern validation of string type', () => {
+    it('should valid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf`,
+        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf&quotedPatternValue=A`,
         (err, res) => {
           const { body } = res;
 
           expect(body.minLength).to.equal('abcdef');
           expect(body.maxLength).to.equal('ab');
           expect(body.patternValue).to.equal('aBcDf');
+          expect(body.quotedPatternValue).to.equal('A');
         },
         200,
       );
     });
 
-    it('should invalid minLength, maxLength and pattern validation of string type', () => {
+    it('should invalid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       const value = '1234';
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}`,
+        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}&quotedPatternValue=A@`,
         (err, res) => {
           const body = JSON.parse(err.text);
 
@@ -445,6 +446,8 @@ describe('Hapi Server', () => {
           expect(body.fields.maxLength.value).to.equal(value);
           expect(body.fields.patternValue.message).to.equal("Not match in '^[a-zA-Z]+$'");
           expect(body.fields.patternValue.value).to.equal(value);
+          expect(body.fields.quotedPatternValue.message).to.equal("Not match in '^([A-Z])(?!@)$'");
+          expect(body.fields.quotedPatternValue.value).to.equal('A@');
         },
         400,
       );
@@ -466,6 +469,7 @@ describe('Hapi Server', () => {
       bodyModel.stringMax10Lenght = 'abcdef';
       bodyModel.stringMin5Lenght = 'abcdef';
       bodyModel.stringPatternAZaz = 'aBcD';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
@@ -490,6 +494,7 @@ describe('Hapi Server', () => {
         stringMax10Lenght: 'abcdef',
         stringMin5Lenght: 'abcdef',
         stringPatternAZaz: 'aBcD',
+        quotedStringPatternA: 'A',
 
         arrayMax5Item: [0, 1, 2, 3],
         arrayMin2Item: [0, 1],
@@ -533,6 +538,7 @@ describe('Hapi Server', () => {
           expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
           expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
           expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+          expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
           expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
           expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -557,6 +563,7 @@ describe('Hapi Server', () => {
           expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
           expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
           expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+          expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
           expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
           expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);
@@ -585,6 +592,7 @@ describe('Hapi Server', () => {
       bodyModel.stringMax10Lenght = 'abcdefghijk';
       bodyModel.stringMin5Lenght = 'abcd';
       bodyModel.stringPatternAZaz = 'ab01234';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
@@ -608,6 +616,7 @@ describe('Hapi Server', () => {
         stringMax10Lenght: 'abcdefghijk',
         stringMin5Lenght: 'abcd',
         stringPatternAZaz: 'ab01234',
+        quotedStringPatternA: 'A@',
 
         arrayMax5Item: [0, 1, 2, 3, 4, 6, 7, 8, 9],
         arrayMin2Item: [0],

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -188,6 +188,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       bodyModel.stringMax10Lenght = 'abcdef';
       bodyModel.stringMin5Lenght = 'abcdef';
       bodyModel.stringPatternAZaz = 'aBcD';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
@@ -212,6 +213,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
         stringMax10Lenght: 'abcdef',
         stringMin5Lenght: 'abcdef',
         stringPatternAZaz: 'aBcD',
+        quotedStringPatternA: 'A',
 
         arrayMax5Item: [0, 1, 2, 3],
         arrayMin2Item: [0, 1],
@@ -255,6 +257,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
           expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
           expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
           expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+          expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
           expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
           expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -279,6 +282,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
           expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
           expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
           expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+          expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
           expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
           expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -396,24 +396,25 @@ describe('Koa Server', () => {
       );
     });
 
-    it('should valid minLength, maxLength and pattern validation of string type', () => {
+    it('should valid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf`,
+        basePath + `/Validate/parameter/string?minLength=abcdef&maxLength=ab&patternValue=aBcDf&quotedPatternValue=A`,
         (err, res) => {
           const { body } = res;
 
           expect(body.minLength).to.equal('abcdef');
           expect(body.maxLength).to.equal('ab');
           expect(body.patternValue).to.equal('aBcDf');
+          expect(body.quotedPatternValue).to.equal('A');
         },
         200,
       );
     });
 
-    it('should invalid minLength, maxLength and pattern validation of string type', () => {
+    it('should invalid minLength, maxLength and pattern (quoted/unquoted) validation of string type', () => {
       const value = '1234';
       return verifyGetRequest(
-        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}`,
+        basePath + `/Validate/parameter/string?minLength=${value}&maxLength=${value}&patternValue=${value}&quotedPatternValue=A@`,
         (err, res) => {
           const body = JSON.parse(err.text);
 
@@ -423,6 +424,8 @@ describe('Koa Server', () => {
           expect(body.fields.maxLength.value).to.equal(value);
           expect(body.fields.patternValue.message).to.equal("Not match in '^[a-zA-Z]+$'");
           expect(body.fields.patternValue.value).to.equal(value);
+          expect(body.fields.quotedPatternValue.message).to.equal("Not match in '^([A-Z])(?!@)$'");
+          expect(body.fields.quotedPatternValue.value).to.equal('A@');
         },
         400,
       );
@@ -444,6 +447,7 @@ describe('Koa Server', () => {
       bodyModel.stringMax10Lenght = 'abcdef';
       bodyModel.stringMin5Lenght = 'abcdef';
       bodyModel.stringPatternAZaz = 'aBcD';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3];
       bodyModel.arrayMin2Item = [0, 1];
@@ -468,6 +472,7 @@ describe('Koa Server', () => {
         stringMax10Lenght: 'abcdef',
         stringMin5Lenght: 'abcdef',
         stringPatternAZaz: 'aBcD',
+        quotedStringPatternA: 'A',
 
         arrayMax5Item: [0, 1, 2, 3],
         arrayMin2Item: [0, 1],
@@ -511,6 +516,7 @@ describe('Koa Server', () => {
           expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
           expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
           expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+          expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
           expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
           expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -535,6 +541,7 @@ describe('Koa Server', () => {
           expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
           expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
           expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+          expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
           expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
           expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);
@@ -563,6 +570,7 @@ describe('Koa Server', () => {
       bodyModel.stringMax10Lenght = 'abcdefghijk';
       bodyModel.stringMin5Lenght = 'abcd';
       bodyModel.stringPatternAZaz = 'ab01234';
+      bodyModel.quotedStringPatternA = 'A';
 
       bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       bodyModel.arrayMin2Item = [0];
@@ -586,6 +594,7 @@ describe('Koa Server', () => {
         stringMax10Lenght: 'abcdefghijk',
         stringMin5Lenght: 'abcd',
         stringPatternAZaz: 'ab01234',
+        quotedStringPatternA: 'A@',
 
         arrayMax5Item: [0, 1, 2, 3, 4, 6, 7, 8, 9],
         arrayMin2Item: [0],

--- a/tests/integration/openapi3-express.spec.ts
+++ b/tests/integration/openapi3-express.spec.ts
@@ -23,6 +23,7 @@ describe('OpenAPI3 Express Server', () => {
     bodyModel.stringMax10Lenght = 'abcdef';
     bodyModel.stringMin5Lenght = 'abcdef';
     bodyModel.stringPatternAZaz = 'aBcD';
+    bodyModel.quotedStringPatternA = 'A';
 
     bodyModel.arrayMax5Item = [0, 1, 2, 3];
     bodyModel.arrayMin2Item = [0, 1];
@@ -47,6 +48,7 @@ describe('OpenAPI3 Express Server', () => {
       stringMax10Lenght: 'abcdef',
       stringMin5Lenght: 'abcdef',
       stringPatternAZaz: 'aBcD',
+      quotedStringPatternA: 'A',
 
       arrayMax5Item: [0, 1, 2, 3],
       arrayMin2Item: [0, 1],
@@ -60,11 +62,6 @@ describe('OpenAPI3 Express Server', () => {
       word: 'word',
       fourtyTwo: 42,
       intersectionAlias: { value1: 'value1', value2: 'value2' },
-      intersectionAlias2: { value1: 'value1', value2: 'value2', value3: 'string' },
-      unionIntersectionAlias1: { value1: 'one', value3: 'three' },
-      unionIntersectionAlias2: { value1: 'one', value4: 'four' },
-      unionIntersectionAlias3: { value2: 'two', value3: 'three' },
-      unionIntersectionAlias4: { value2: 'two', value4: 'four' },
       unionAlias: { value2: 'value2' },
       nOLAlias: { value1: 'value1', value2: 'value2' },
       genericAlias: 'genericString',
@@ -95,6 +92,7 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.stringMax10Lenght).to.equal(bodyModel.stringMax10Lenght);
         expect(body.stringMin5Lenght).to.equal(bodyModel.stringMin5Lenght);
         expect(body.stringPatternAZaz).to.equal(bodyModel.stringPatternAZaz);
+        expect(body.quotedStringPatternA).to.equal(bodyModel.quotedStringPatternA);
 
         expect(body.arrayMax5Item).to.deep.equal(bodyModel.arrayMax5Item);
         expect(body.arrayMin2Item).to.deep.equal(bodyModel.arrayMin2Item);
@@ -119,6 +117,7 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.nestedObject.stringMax10Lenght).to.equal(bodyModel.nestedObject.stringMax10Lenght);
         expect(body.nestedObject.stringMin5Lenght).to.equal(bodyModel.nestedObject.stringMin5Lenght);
         expect(body.nestedObject.stringPatternAZaz).to.equal(bodyModel.nestedObject.stringPatternAZaz);
+        expect(body.nestedObject.quotedStringPatternA).to.equal(bodyModel.nestedObject.quotedStringPatternA);
 
         expect(body.nestedObject.arrayMax5Item).to.deep.equal(bodyModel.nestedObject.arrayMax5Item);
         expect(body.nestedObject.arrayMin2Item).to.deep.equal(bodyModel.nestedObject.arrayMin2Item);
@@ -127,7 +126,6 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.nestedObject.mixedUnion).to.deep.equal(bodyModel.nestedObject.mixedUnion);
         expect(body.nestedObject.intersection).to.deep.equal(bodyModel.nestedObject.intersection);
         expect(body.typeAliases).to.deep.equal(bodyModel.typeAliases);
-        expect(body.fields).to.equal(undefined);
       },
       200,
     );
@@ -148,14 +146,14 @@ describe('OpenAPI3 Express Server', () => {
     bodyModel.stringMax10Lenght = 'abcdefghijk';
     bodyModel.stringMin5Lenght = 'abcd';
     bodyModel.stringPatternAZaz = 'ab01234';
+    bodyModel.quotedStringPatternA = 'A';
 
     bodyModel.arrayMax5Item = [0, 1, 2, 3, 4, 6, 7, 8, 9];
     bodyModel.arrayMin2Item = [0];
     bodyModel.arrayUniqueItem = [0, 0, 1, 1];
-    bodyModel.intersection = { value1: '' } as any;
-    bodyModel.intersectionNoAdditional = { value1: '', value2: '', value3: 123, value4: 123 } as any;
     bodyModel.model = 1 as any;
     bodyModel.mixedUnion = 123 as any;
+    bodyModel.intersection = { value1: 'one' } as any;
     bodyModel.singleBooleanEnum = false as true;
 
     bodyModel.nestedObject = {
@@ -172,6 +170,7 @@ describe('OpenAPI3 Express Server', () => {
       stringMax10Lenght: 'abcdefghijk',
       stringMin5Lenght: 'abcd',
       stringPatternAZaz: 'ab01234',
+      quotedStringPatternA: 'A@',
 
       arrayMax5Item: [0, 1, 2, 3, 4, 6, 7, 8, 9],
       arrayMin2Item: [0],
@@ -185,11 +184,6 @@ describe('OpenAPI3 Express Server', () => {
       word: '',
       fourtyTwo: 41,
       intersectionAlias: { value2: 'value2' },
-      intersectionAlias2: { value1: 'value1', value2: 'value2', value4: 'test' },
-      unionIntersectionAlias1: { value1: 'one', value2: 'two', value3: 'three' },
-      unionIntersectionAlias2: { value1: 'one' },
-      unionIntersectionAlias3: { value1: 'one', value2: 'two', value3: 'three' },
-      unionIntersectionAlias4: { value2: 2, value4: 'four' },
       unionAlias: {},
       nOLAlias: true,
       genericAlias: new ValidateModel(),
@@ -238,10 +232,8 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.arrayMin2Item'].value).to.deep.equal(bodyModel.arrayMin2Item);
         expect(body.fields['body.arrayUniqueItem'].message).to.equal('required unique array');
         expect(body.fields['body.arrayUniqueItem'].value).to.deep.equal(bodyModel.arrayUniqueItem);
-        expect(body.fields['body.intersection'].message).to.deep.equal('Could not match the intersection against every type. Issues: [{"body.value2":{"message":"\'value2\' is required"}}]');
-        expect(body.fields['body.intersection'].value).to.deep.equal(bodyModel.intersection);
-        expect(body.fields['body.intersectionNoAdditional'].message).to.deep.equal('Could not match intersection against any of the possible combinations: [["value1","value2"]]');
-        expect(body.fields['body.intersectionNoAdditional'].value).to.deep.equal(bodyModel.intersectionNoAdditional);
+        expect(body.fields['body.model'].message).to.equal('invalid object');
+        expect(body.fields['body.model'].value).to.deep.equal(bodyModel.model);
         expect(body.fields['body.mixedUnion'].message).to.equal(
           'Could not match the union against any of the items. ' +
             'Issues: [{"body.mixedUnion":{"message":"invalid string value","value":123}},' +
@@ -302,26 +294,7 @@ describe('OpenAPI3 Express Server', () => {
         expect(body.fields['body.typeAliases.nOLAlias'].message).to.equal('invalid object');
         expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
         expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
-        expect(body.fields['body.typeAliases.genericAlias2.id2'].message).to.equal('"id2" is an excess property and therefore is not allowed');
         expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
-        expect(body.fields['body.typeAliases.intersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.value3":{"message":"'value3' is required"}}]`,
-        );
-        expect(body.fields['body.typeAliases.intersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.value3":{"message":"'value3' is required"}}]`,
-        );
-        expect(body.fields['body.typeAliases.unionIntersectionAlias1'].message).to.equal(
-          'Could not match intersection against any of the possible combinations: [["value1","value3"],["value1","value4"],["value2","value3"],["value2","value4"]]',
-        );
-        expect(body.fields['body.typeAliases.unionIntersectionAlias2'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias2":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.value3\\":{\\"message\\":\\"'value3' is required\\"}},{\\"body.typeAliases.unionIntersectionAlias2.value4\\":{\\"message\\":\\"'value4' is required\\"}}]","value":{"value1":"one"}}}]`,
-        );
-        expect(body.fields['body.typeAliases.unionIntersectionAlias3'].message).to.equal(
-          'Could not match intersection against any of the possible combinations: [["value1","value3"],["value1","value4"],["value2","value3"],["value2","value4"]]',
-        );
-        expect(body.fields['body.typeAliases.unionIntersectionAlias4'].message).to.equal(
-          `Could not match the intersection against every type. Issues: [{"body.typeAliases.unionIntersectionAlias4":{"message":"Could not match the union against any of the items. Issues: [{\\"body.typeAliases.value1\\":{\\"message\\":\\"'value1' is required\\"}},{\\"body.typeAliases.value2\\":{\\"message\\":\\"invalid string value\\",\\"value\\":2}}]","value":{"value2":2,"value4":"four"}}}]`,
-        );
       },
       400,
     );

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -810,7 +810,7 @@ describe('Definition generation', () => {
                   readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
                   publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
                   stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+', 'x-nullable': true },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$', 'x-nullable': true },
                   optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, 'x-nullable': true },
                   publicStringProperty: {
                     type: 'string',

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -419,7 +419,7 @@ describe('Metadata generation', () => {
       expect(genderParam.parameterName).to.equal('gender');
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
-      expect(genderParam.type.dataType).to.equal('enum');
+      expect(genderParam.type.dataType).to.equal('refEnum');
     });
 
     it('should generate an header parameter', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -969,7 +969,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
                   publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
                   stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+', nullable: true },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$', nullable: true },
                   optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, nullable: true },
                   publicStringProperty: {
                     type: 'string',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

closes #563

**Test plan**
* Added test properties that specifically test regex that contain @ symbols.
* Bugfix solves issue with email property test where only half the regex was included.