### PR TITLE
Fix GH Actions CI

### DIFF
--- a/.github/workflows/runTestsOnPush.yml
+++ b/.github/workflows/runTestsOnPush.yml
@@ -9,12 +9,12 @@ jobs:
     - name: Build
       uses: Borales/actions-yarn@master
       with:
-        args: install
+        cmd: install
     - name: Lint
       uses: Borales/actions-yarn@master
       with:
-        args: lint
+        cmd: lint
     - name: Test
       uses: Borales/actions-yarn@master
       with:
-        args: test
+        cmd: test


### PR DESCRIPTION
CI Didn't actually run the yarn commands, it just ran `yarn` for all steps without args.