### PR TITLE
added @example support for parameters / properties

### DIFF
--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import { getDecoratorName, getDecoratorTextValue } from './../utils/decoratorUtils';
+import { getJSDocTags } from './../utils/jsDocUtils';
 import { getParameterValidators } from './../utils/validatorUtils';
 import { GenerateMetadataError } from './exceptions';
 import { getInitializerValue } from './initializer-value';
@@ -55,6 +56,7 @@ export class ParameterGenerator {
     return {
       default: getInitializerValue(parameter.initializer, type),
       description: this.getParameterDescription(parameter),
+      example: this.getParameterExample(parameter, parameterName),
       in: 'body-prop',
       name: getDecoratorTextValue(this.parameter, ident => ident.text === 'BodyProp') || parameterName,
       parameterName,
@@ -76,6 +78,7 @@ export class ParameterGenerator {
       description: this.getParameterDescription(parameter),
       in: 'body',
       name: parameterName,
+      example: this.getParameterExample(parameter, parameterName),
       parameterName,
       required: !parameter.questionToken && !parameter.initializer,
       type,
@@ -94,6 +97,7 @@ export class ParameterGenerator {
     return {
       default: getInitializerValue(parameter.initializer, type),
       description: this.getParameterDescription(parameter),
+      example: this.getParameterExample(parameter, parameterName),
       in: 'header',
       name: getDecoratorTextValue(this.parameter, ident => ident.text === 'Header') || parameterName,
       parameterName,
@@ -110,6 +114,7 @@ export class ParameterGenerator {
     const commonProperties = {
       default: getInitializerValue(parameter.initializer, type),
       description: this.getParameterDescription(parameter),
+      example: this.getParameterExample(parameter, parameterName),
       in: 'query' as 'query',
       name: getDecoratorTextValue(this.parameter, ident => ident.text === 'Query') || parameterName,
       parameterName,
@@ -154,6 +159,7 @@ export class ParameterGenerator {
     return {
       default: getInitializerValue(parameter.initializer, type),
       description: this.getParameterDescription(parameter),
+      example: this.getParameterExample(parameter, parameterName),
       in: 'path',
       name: pathName,
       parameterName,
@@ -175,6 +181,16 @@ export class ParameterGenerator {
     }
 
     return undefined;
+  }
+
+  private getParameterExample(node: ts.ParameterDeclaration, parameterName: string) {
+    const example = getJSDocTags(node.parent, tag => tag.tagName.text === 'example' && !!tag.comment && tag.comment.startsWith(parameterName)).map(tag => (tag.comment || '').split(' ')[1])[0];
+
+    if (example) {
+      return JSON.parse(example);
+    } else {
+      return undefined;
+    }
   }
 
   private supportBodyMethod(method: string) {

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -29,6 +29,7 @@ export namespace Tsoa {
 
   export interface Parameter {
     parameterName: string;
+    example?: any;
     description?: string;
     in: 'query' | 'header' | 'path' | 'formData' | 'body' | 'body-prop' | 'request';
     name: string;
@@ -62,6 +63,7 @@ export namespace Tsoa {
     default?: any;
     description?: string;
     format?: string;
+    example?: any;
     name: string;
     type: Type;
     required: boolean;

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -29,7 +29,7 @@ export namespace Tsoa {
 
   export interface Parameter {
     parameterName: string;
-    example?: any;
+    example?: unknown;
     description?: string;
     in: 'query' | 'header' | 'path' | 'formData' | 'body' | 'body-prop' | 'request';
     name: string;
@@ -63,7 +63,7 @@ export namespace Tsoa {
     default?: any;
     description?: string;
     format?: string;
-    example?: any;
+    example?: unknown;
     name: string;
     type: Type;
     required: boolean;
@@ -225,7 +225,7 @@ export namespace Tsoa {
     description?: string;
     dataType: RefTypeLiteral;
     refName: string;
-    example?: any;
+    example?: unknown;
   }
 
   export interface UnionType extends TypeBase {

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -103,6 +103,7 @@ export class TypeResolver {
         .reduce((res, propertySignature: ts.PropertySignature) => {
           const type = new TypeResolver(propertySignature.type as ts.TypeNode, this.current, propertySignature, this.context).resolve();
           const property: Tsoa.Property = {
+            example: this.getNodeExample(propertySignature),
             default: getJSDocComment(propertySignature, 'default'),
             description: this.getNodeDescription(propertySignature),
             format: this.getNodeFormat(propertySignature),
@@ -718,6 +719,7 @@ export class TypeResolver {
     const property: Tsoa.Property = {
       default: getJSDocComment(propertySignature, 'default'),
       description: this.getNodeDescription(propertySignature),
+      example: this.getNodeExample(propertySignature),
       format: this.getNodeFormat(propertySignature),
       name: identifier.text,
       required,
@@ -752,6 +754,7 @@ export class TypeResolver {
     const property: Tsoa.Property = {
       default: getInitializerValue(propertyDeclaration.initializer, type),
       description: this.getNodeDescription(propertyDeclaration),
+      example: this.getNodeExample(propertyDeclaration),
       format: this.getNodeFormat(propertyDeclaration),
       name: identifier.text,
       required,

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -193,15 +193,16 @@ export class SpecGenerator2 extends SpecGenerator {
   }
 
   private buildBodyPropParameter(controllerName: string, method: Tsoa.Method) {
-    const properties = {} as { [name: string]: Swagger.Schema | Swagger.BaseSchema };
+    const properties = {} as { [name: string]: Swagger.Schema };
     const required: string[] = [];
 
     method.parameters
       .filter(p => p.in === 'body-prop')
       .forEach(p => {
-        properties[p.name] = this.getSwaggerType(p.type);
+        properties[p.name] = this.getSwaggerType(p.type) as Swagger.Schema2;
         properties[p.name].default = p.default;
         properties[p.name].description = p.description;
+        properties[p.name].example = p.example;
 
         if (p.required) {
           required.push(p.name);
@@ -231,6 +232,7 @@ export class SpecGenerator2 extends SpecGenerator {
     let parameter = {
       default: source.default,
       description: source.description,
+      example: source.example,
       in: source.in,
       name: source.name,
       required: source.required,
@@ -305,9 +307,10 @@ export class SpecGenerator2 extends SpecGenerator {
     const properties: { [propertyName: string]: Swagger.Schema } = {};
 
     source.forEach(property => {
-      const swaggerType = this.getSwaggerType(property.type);
+      const swaggerType = this.getSwaggerType(property.type) as Swagger.Schema2;
       const format = property.format as Swagger.DataFormat;
       swaggerType.description = property.description;
+      swaggerType.example = property.example;
       swaggerType.format = format || swaggerType.format;
       if (!swaggerType.$ref) {
         swaggerType.default = property.default;

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -315,6 +315,7 @@ export class SpecGenerator3 extends SpecGenerator {
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter {
     const parameter = {
       description: source.description,
+      example: source.example,
       in: source.in,
       name: source.name,
       required: source.required,
@@ -365,6 +366,7 @@ export class SpecGenerator3 extends SpecGenerator {
       const swaggerType = this.getSwaggerType(property.type) as Swagger.Schema3;
       const format = property.format as Swagger.DataFormat;
       swaggerType.description = property.description;
+      swaggerType.example = property.example;
       swaggerType.format = format || swaggerType.format;
       if (!swaggerType.$ref) {
         swaggerType.default = property.default;

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -91,7 +91,7 @@ export namespace Swagger {
     in: 'query' | 'header' | 'path' | 'formData' | 'body';
     required?: boolean;
     description?: string;
-    example?: any;
+    example?: unknown;
     schema: Schema;
     type: DataType;
     format?: DataFormat;
@@ -246,7 +246,7 @@ export namespace Swagger {
     readOnly?: boolean;
     xml?: XML;
     externalDocs?: ExternalDocs;
-    example?: { [exampleName: string]: Example };
+    example?: unknown;
     required?: string[];
   }
 

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -91,6 +91,7 @@ export namespace Swagger {
     in: 'query' | 'header' | 'path' | 'formData' | 'body';
     required?: boolean;
     description?: string;
+    example?: any;
     schema: Schema;
     type: DataType;
     format?: DataFormat;

--- a/src/utils/jsDocUtils.ts
+++ b/src/utils/jsDocUtils.ts
@@ -10,7 +10,7 @@ export function getJSDocDescription(node: ts.Node) {
 }
 
 export function getJSDocComment(node: ts.Node, tagName: string) {
-  const tags = getJSDocTags(node, tag => tag.tagName.text === tagName);
+  const tags = getJSDocTags(node, tag => tag.tagName.text === tagName || tag.tagName.escapedText === tagName);
   if (tags.length === 0) {
     return;
   }

--- a/tests/fixtures/controllers/validateController.ts
+++ b/tests/fixtures/controllers/validateController.ts
@@ -101,6 +101,7 @@ export class ValidateController {
    * @maxLength maxLength 3
    * @pattern patternValue ^[a-zA-Z]+$
    * @pattern quotedPatternValue `^([A-Z])(?!@)$`
+   * @example quotedPatternValue "A"
    */
   @Get('parameter/string')
   public stringValidate(@Query() minLength: string, @Query() maxLength: string, @Query() patternValue: string, @Query() quotedPatternValue: string): Promise<ValidateStringResponse> {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -29,6 +29,7 @@ export interface TestModel extends Model {
   numberValue: number;
   numberArray: number[];
   /**
+   * @example "letmein"
    * @format password
    */
   stringValue: string;

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -129,6 +129,14 @@ export interface TestModel extends Model {
 
   defaultGenericModel?: GenericModel;
 
+  /**
+   * @example {
+   *   "numberOrNull": null,
+   *   "wordOrNull": null,
+   *   "maybeString": null,
+   *   "justNull": null
+   * }
+   */
   nullableTypes?: {
     numberOrNull: number | null;
     wordOrNull: Maybe<Word>;
@@ -567,6 +575,7 @@ export class TestClassModel extends TestClassBaseModel {
    * @minLength 3
    * @maxLength 20
    * @pattern ^[a-zA-Z]+$
+   * @example "classPropExample"
    */
   public publicStringProperty: string;
   /**

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -825,7 +825,7 @@ describe('Definition generation', () => {
                     default: undefined,
                     description: 'This is a description of a public string property',
                     format: undefined,
-                    example: undefined,
+                    example: 'classPropExample',
                   },
                   defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, example: undefined },
                   account: { $ref: '#/definitions/Account', format: undefined, description: undefined, example: undefined },
@@ -886,7 +886,12 @@ describe('Definition generation', () => {
             expect(propertySchema).to.deep.equal({
               default: undefined,
               description: undefined,
-              example: undefined,
+              example: {
+                justNull: null,
+                maybeString: null,
+                numberOrNull: null,
+                wordOrNull: null,
+              },
               format: undefined,
               properties: {
                 maybeString: { $ref: '#/definitions/Maybe_string_', description: undefined, format: undefined, example: undefined },

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -176,6 +176,7 @@ describe('Definition generation', () => {
           },
           stringValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
+            expect(propertySchema.example).to.eq('letmein', `for property ${propertyName}.example`);
             expect(propertySchema.format).to.eq('password', `for property ${propertyName}.format`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
@@ -476,8 +477,9 @@ describe('Definition generation', () => {
               default: undefined,
               description: undefined,
               format: undefined,
+              example: undefined,
               properties: {
-                name: { type: 'string', default: undefined, description: undefined, format: undefined },
+                name: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
                 nested: {
                   properties: {
                     additionals: {
@@ -486,26 +488,29 @@ describe('Definition generation', () => {
                       default: undefined,
                       description: undefined,
                       format: undefined,
+                      example: undefined,
                       additionalProperties: {
                         $ref: '#/definitions/TypeAliasModel1',
                       },
                     },
                     allNestedOptional: {
                       properties: {
-                        one: { type: 'string', default: undefined, description: undefined, format: undefined },
-                        two: { type: 'string', default: undefined, description: undefined, format: undefined },
+                        one: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                        two: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
                       },
                       type: 'object',
                       default: undefined,
                       description: undefined,
                       format: undefined,
+                      example: undefined,
                     },
-                    bool: { type: 'boolean', default: undefined, description: undefined, format: undefined },
-                    optional: { type: 'number', format: 'double', default: undefined, description: undefined },
+                    bool: { type: 'boolean', default: undefined, description: undefined, format: undefined, example: undefined },
+                    optional: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined },
                   },
                   default: undefined,
                   description: undefined,
                   format: undefined,
+                  example: undefined,
                   required: ['allNestedOptional', 'bool'],
                   type: 'object',
                 },
@@ -519,17 +524,18 @@ describe('Definition generation', () => {
             expect(propertySchema).to.deep.equal({
               default: undefined,
               description: undefined,
+              example: undefined,
               format: undefined,
               properties: {
-                word: { $ref: '#/definitions/Word', description: undefined, format: undefined },
-                fourtyTwo: { $ref: '#/definitions/FourtyTwo', description: undefined, format: undefined },
-                dateAlias: { $ref: '#/definitions/DateAlias', description: undefined, format: undefined },
-                unionAlias: { $ref: '#/definitions/UnionAlias', description: undefined, format: undefined },
-                intersectionAlias: { $ref: '#/definitions/IntersectionAlias', description: undefined, format: undefined },
-                nOLAlias: { $ref: '#/definitions/NolAlias', description: undefined, format: undefined },
-                genericAlias: { $ref: '#/definitions/GenericAlias_string_', description: undefined, format: undefined },
-                genericAlias2: { $ref: '#/definitions/GenericAlias_Model_', description: undefined, format: undefined },
-                forwardGenericAlias: { $ref: '#/definitions/ForwardGenericAlias_boolean.TypeAliasModel1_', description: undefined, format: undefined },
+                word: { $ref: '#/definitions/Word', description: undefined, format: undefined, example: undefined },
+                fourtyTwo: { $ref: '#/definitions/FourtyTwo', description: undefined, format: undefined, example: undefined },
+                dateAlias: { $ref: '#/definitions/DateAlias', description: undefined, format: undefined, example: undefined },
+                unionAlias: { $ref: '#/definitions/UnionAlias', description: undefined, format: undefined, example: undefined },
+                intersectionAlias: { $ref: '#/definitions/IntersectionAlias', description: undefined, format: undefined, example: undefined },
+                nOLAlias: { $ref: '#/definitions/NolAlias', description: undefined, format: undefined, example: undefined },
+                genericAlias: { $ref: '#/definitions/GenericAlias_string_', description: undefined, format: undefined, example: undefined },
+                genericAlias2: { $ref: '#/definitions/GenericAlias_Model_', description: undefined, format: undefined, example: undefined },
+                forwardGenericAlias: { $ref: '#/definitions/ForwardGenericAlias_boolean.TypeAliasModel1_', description: undefined, format: undefined, example: undefined },
               },
               required: ['forwardGenericAlias', 'genericAlias2', 'genericAlias', 'nOLAlias', 'intersectionAlias', 'unionAlias', 'fourtyTwo', 'word'],
               type: 'object',
@@ -576,8 +582,8 @@ describe('Definition generation', () => {
             const nolAliasSchema = getValidatedDefinition('NolAlias', currentSpec);
             expect(nolAliasSchema).to.deep.eq({
               properties: {
-                value1: { type: 'string', default: undefined, description: undefined, format: undefined },
-                value2: { type: 'string', default: undefined, description: undefined, format: undefined },
+                value1: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                value2: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
               },
               required: ['value2', 'value1'],
               type: 'object',
@@ -611,21 +617,22 @@ describe('Definition generation', () => {
             expect(propertySchema).to.deep.eq(
               {
                 properties: {
-                  omit: { $ref: '#/definitions/Omit_ErrorResponseModel.status_', description: undefined, format: undefined },
-                  omitHidden: { $ref: '#/definitions/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined },
-                  partial: { $ref: '#/definitions/Partial_Account_', description: undefined, format: undefined },
-                  excludeToEnum: { $ref: '#/definitions/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined },
-                  excludeToAlias: { $ref: '#/definitions/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined },
-                  excludeLiteral: { $ref: '#/definitions/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined },
-                  excludeToInterface: { $ref: '#/definitions/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined },
-                  excludeTypeToPrimitive: { $ref: '#/definitions/NonNullable_number~OR~null_', description: undefined, format: undefined },
-                  pick: { $ref: '#/definitions/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined },
-                  readonlyClass: { $ref: '#/definitions/Readonly_TestClassModel_', description: undefined, format: undefined },
-                  defaultArgs: { $ref: '#/definitions/DefaultTestModel', description: undefined, format: undefined },
-                  heritageCheck: { $ref: '#/definitions/HeritageTestModel', description: undefined, format: undefined },
+                  omit: { $ref: '#/definitions/Omit_ErrorResponseModel.status_', description: undefined, format: undefined, example: undefined },
+                  omitHidden: { $ref: '#/definitions/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined, example: undefined },
+                  partial: { $ref: '#/definitions/Partial_Account_', description: undefined, format: undefined, example: undefined },
+                  excludeToEnum: { $ref: '#/definitions/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined, example: undefined },
+                  excludeToAlias: { $ref: '#/definitions/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined, example: undefined },
+                  excludeLiteral: { $ref: '#/definitions/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined, example: undefined },
+                  excludeToInterface: { $ref: '#/definitions/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined, example: undefined },
+                  excludeTypeToPrimitive: { $ref: '#/definitions/NonNullable_number~OR~null_', description: undefined, format: undefined, example: undefined },
+                  pick: { $ref: '#/definitions/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined, example: undefined },
+                  readonlyClass: { $ref: '#/definitions/Readonly_TestClassModel_', description: undefined, format: undefined, example: undefined },
+                  defaultArgs: { $ref: '#/definitions/DefaultTestModel', description: undefined, format: undefined, example: undefined },
+                  heritageCheck: { $ref: '#/definitions/HeritageTestModel', description: undefined, format: undefined, example: undefined },
                 },
                 type: 'object',
                 default: undefined,
+                example: undefined,
                 description: undefined,
                 format: undefined,
               },
@@ -646,7 +653,7 @@ describe('Definition generation', () => {
             const omitReference = getValidatedDefinition('Pick_ErrorResponseModel.Exclude_keyofErrorResponseModel.status__', currentSpec);
             expect(omitReference).to.deep.eq(
               {
-                properties: { message: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2 } },
+                properties: { message: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2, example: undefined } },
                 required: ['message'],
                 type: 'object',
                 description: 'From T, pick a set of properties whose keys are in the union K',
@@ -671,8 +678,8 @@ describe('Definition generation', () => {
             expect(omitHiddenReference).to.deep.eq(
               {
                 properties: {
-                  id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  stringPropDec2: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2 },
+                  id: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined },
+                  stringPropDec2: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2, example: undefined },
                 },
                 required: ['stringPropDec2', 'id'],
                 type: 'object',
@@ -686,7 +693,7 @@ describe('Definition generation', () => {
             const partial = getValidatedDefinition('Partial_Account_', currentSpec);
             expect(partial).to.deep.eq(
               {
-                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined } },
+                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined } },
                 type: 'object',
                 description: 'Make all properties in T optional',
                 default: undefined,
@@ -720,7 +727,7 @@ describe('Definition generation', () => {
             const excludeToAliasTypeAlias4 = getValidatedDefinition('TypeAlias4', currentSpec);
             expect(excludeToAliasTypeAlias4).to.deep.eq(
               {
-                properties: { value4: { type: 'string', default: undefined, description: undefined, format: undefined } },
+                properties: { value4: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined } },
                 required: ['value4'],
                 type: 'object',
                 default: undefined,
@@ -786,6 +793,7 @@ describe('Definition generation', () => {
                     default: undefined,
                     description: undefined,
                     format: undefined,
+                    example: undefined,
                   },
                 },
                 required: ['list'],
@@ -801,14 +809,14 @@ describe('Definition generation', () => {
             expect(readonlyClassSchema).to.deep.eq(
               {
                 properties: {
-                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined },
-                  id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
-                  stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$' },
-                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined },
+                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined, example: undefined },
+                  id: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined },
+                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined, example: undefined },
+                  stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$', example: undefined },
+                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, example: undefined },
                   publicStringProperty: {
                     type: 'string',
                     minLength: 3,
@@ -817,9 +825,10 @@ describe('Definition generation', () => {
                     default: undefined,
                     description: 'This is a description of a public string property',
                     format: undefined,
+                    example: undefined,
                   },
-                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined },
-                  account: { $ref: '#/definitions/Account', format: undefined, description: undefined },
+                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, example: undefined },
+                  account: { $ref: '#/definitions/Account', format: undefined, description: undefined, example: undefined },
                 },
                 required: ['account', 'publicStringProperty', 'stringProperty', 'publicConstructorVar', 'readonlyConstructorArgument', 'id'],
                 type: 'object',
@@ -835,8 +844,8 @@ describe('Definition generation', () => {
               {
                 description: undefined,
                 properties: {
-                  t: { $ref: '#/definitions/GenericRequest_Word_', description: undefined, format: undefined },
-                  u: { $ref: '#/definitions/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined },
+                  t: { $ref: '#/definitions/GenericRequest_Word_', description: undefined, format: undefined, example: undefined },
+                  u: { $ref: '#/definitions/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined, example: undefined },
                 },
                 required: ['t', 'u'],
                 type: 'object',
@@ -853,12 +862,14 @@ describe('Definition generation', () => {
                     default: undefined,
                     description: undefined,
                     format: undefined,
+                    example: undefined,
                     type: 'string',
                   },
                   value4: {
                     default: undefined,
                     description: undefined,
                     format: undefined,
+                    example: undefined,
                     type: 'string',
                   },
                 },
@@ -875,16 +886,18 @@ describe('Definition generation', () => {
             expect(propertySchema).to.deep.equal({
               default: undefined,
               description: undefined,
+              example: undefined,
               format: undefined,
               properties: {
-                maybeString: { $ref: '#/definitions/Maybe_string_', description: undefined, format: undefined },
-                wordOrNull: { $ref: '#/definitions/Maybe_Word_', description: undefined, format: undefined },
-                numberOrNull: { type: 'number', format: 'double', description: undefined, default: undefined, ['x-nullable']: true },
+                maybeString: { $ref: '#/definitions/Maybe_string_', description: undefined, format: undefined, example: undefined },
+                wordOrNull: { $ref: '#/definitions/Maybe_Word_', description: undefined, format: undefined, example: undefined },
+                numberOrNull: { type: 'number', format: 'double', description: undefined, default: undefined, ['x-nullable']: true, example: undefined },
                 justNull: {
                   default: undefined,
                   description: undefined,
                   enum: ['null'],
                   format: undefined,
+                  example: undefined,
                   type: 'number',
                   ['x-nullable']: true,
                 },
@@ -1201,18 +1214,18 @@ describe('Definition generation', () => {
         it('should propagate generics', () => {
           const definition = getValidatedDefinition('GenericModel_TestModelArray_', currentSpec).properties;
 
-          expect(definition!.result).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined });
-          expect(definition!.union).to.deep.equal({ type: 'object', description: undefined, format: undefined, default: undefined });
-          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequest_TestModelArray_', description: undefined, format: undefined });
+          expect(definition!.result).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, example: undefined, default: undefined });
+          expect(definition!.union).to.deep.equal({ type: 'object', description: undefined, format: undefined, default: undefined, example: undefined });
+          expect(definition!.nested).to.deep.equal({ $ref: '#/definitions/GenericRequest_TestModelArray_', description: undefined, format: undefined, example: undefined });
 
           const ref = getValidatedDefinition('GenericRequest_TestModelArray_', currentSpec).properties;
-          expect(ref!.name).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
-          expect(ref!.value).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined });
+          expect(ref!.name).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined, example: undefined });
+          expect(ref!.value).to.deep.equal({ items: { $ref: '#/definitions/TestModel' }, type: 'array', description: undefined, format: undefined, default: undefined, example: undefined });
         });
         it('should not propagate dangling context', () => {
           const definition = getValidatedDefinition('DanglingContext_number_', currentSpec).properties;
 
-          expect(definition!.number).to.deep.equal({ type: 'number', format: 'double', description: undefined, default: undefined });
+          expect(definition!.number).to.deep.equal({ type: 'number', format: 'double', description: undefined, default: undefined, example: undefined });
           expect(definition!.shouldBeString!.$ref).to.deep.equal('#/definitions/TSameNameDifferentValue');
         });
         it('should check heritage clauses for type args', () => {
@@ -1222,13 +1235,15 @@ describe('Definition generation', () => {
             $ref: '#/definitions/ThingContainerWithTitle_TestModelArray_',
             description: undefined,
             format: undefined,
+            example: undefined,
           });
 
           const ref = getValidatedDefinition('ThingContainerWithTitle_TestModelArray_', currentSpec).properties;
-          expect(ref!.title).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
+          expect(ref!.title).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined, example: undefined });
           expect(ref!.t).to.deep.equal({
             default: undefined,
             description: undefined,
+            example: undefined,
             format: undefined,
             items: {
               $ref: '#/definitions/TestModel',
@@ -1236,13 +1251,14 @@ describe('Definition generation', () => {
             type: 'array',
           });
 
-          expect(ref!.id).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined });
+          expect(ref!.id).to.deep.equal({ type: 'string', description: undefined, format: undefined, default: undefined, example: undefined });
           expect(ref!.list).to.deep.equal({
             items: { type: 'number', format: 'double' },
             type: 'array',
             description: undefined,
             format: undefined,
             default: undefined,
+            example: undefined,
           });
         });
       });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -356,6 +356,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                   description: undefined,
                   format: undefined,
+                  example: undefined,
                 },
                 nested: {
                   properties: {
@@ -365,28 +366,31 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                       default: undefined,
                       description: undefined,
                       format: undefined,
+                      example: undefined,
                       additionalProperties: {
                         $ref: '#/components/schemas/TypeAliasModel1',
                       },
                     },
                     allNestedOptional: {
                       properties: {
-                        one: { type: 'string', default: undefined, description: undefined, format: undefined },
-                        two: { type: 'string', default: undefined, description: undefined, format: undefined },
+                        one: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                        two: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
                       },
                       type: 'object',
                       default: undefined,
                       description: undefined,
                       format: undefined,
+                      example: undefined,
                     },
-                    bool: { type: 'boolean', default: undefined, description: undefined, format: undefined },
-                    optional: { format: 'double', type: 'number', default: undefined, description: undefined },
+                    bool: { type: 'boolean', default: undefined, description: undefined, format: undefined, example: undefined },
+                    optional: { format: 'double', type: 'number', default: undefined, description: undefined, example: undefined },
                   },
                   required: ['allNestedOptional', 'bool'],
                   type: 'object',
                   default: undefined,
                   description: undefined,
                   format: undefined,
+                  example: undefined,
                 },
               },
               required: ['name'],
@@ -534,6 +538,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 { type: 'boolean', enum: ['true'], nullable: false },
                 { type: 'boolean', enum: ['false'], nullable: false },
               ],
+              example: undefined,
               default: undefined,
               description: undefined,
               format: undefined,
@@ -680,16 +685,17 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               default: undefined,
               description: undefined,
               format: undefined,
+              example: undefined,
               properties: {
-                word: { $ref: '#/components/schemas/Word', description: undefined, format: undefined },
-                fourtyTwo: { $ref: '#/components/schemas/FourtyTwo', description: undefined, format: undefined },
-                dateAlias: { $ref: '#/components/schemas/DateAlias', description: undefined, format: undefined },
-                unionAlias: { $ref: '#/components/schemas/UnionAlias', description: undefined, format: undefined },
-                intersectionAlias: { $ref: '#/components/schemas/IntersectionAlias', description: undefined, format: undefined },
-                nOLAlias: { $ref: '#/components/schemas/NolAlias', description: undefined, format: undefined },
-                genericAlias: { $ref: '#/components/schemas/GenericAlias_string_', description: undefined, format: undefined },
-                genericAlias2: { $ref: '#/components/schemas/GenericAlias_Model_', description: undefined, format: undefined },
-                forwardGenericAlias: { $ref: '#/components/schemas/ForwardGenericAlias_boolean.TypeAliasModel1_', description: undefined, format: undefined },
+                word: { $ref: '#/components/schemas/Word', description: undefined, format: undefined, example: undefined },
+                fourtyTwo: { $ref: '#/components/schemas/FourtyTwo', description: undefined, format: undefined, example: undefined },
+                dateAlias: { $ref: '#/components/schemas/DateAlias', description: undefined, format: undefined, example: undefined },
+                unionAlias: { $ref: '#/components/schemas/UnionAlias', description: undefined, format: undefined, example: undefined },
+                intersectionAlias: { $ref: '#/components/schemas/IntersectionAlias', description: undefined, format: undefined, example: undefined },
+                nOLAlias: { $ref: '#/components/schemas/NolAlias', description: undefined, format: undefined, example: undefined },
+                genericAlias: { $ref: '#/components/schemas/GenericAlias_string_', description: undefined, format: undefined, example: undefined },
+                genericAlias2: { $ref: '#/components/schemas/GenericAlias_Model_', description: undefined, format: undefined, example: undefined },
+                forwardGenericAlias: { $ref: '#/components/schemas/ForwardGenericAlias_boolean.TypeAliasModel1_', description: undefined, format: undefined, example: undefined },
               },
               required: ['forwardGenericAlias', 'genericAlias2', 'genericAlias', 'nOLAlias', 'intersectionAlias', 'unionAlias', 'fourtyTwo', 'word'],
               type: 'object',
@@ -725,8 +731,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               allOf: [
                 {
                   properties: {
-                    value1: { type: 'string', default: undefined, description: undefined, format: undefined },
-                    value2: { type: 'string', default: undefined, description: undefined, format: undefined },
+                    value1: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                    value2: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
                   },
                   required: ['value2', 'value1'],
                   type: 'object',
@@ -741,8 +747,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const nolAliasSchema = getComponentSchema('NolAlias', currentSpec);
             expect(nolAliasSchema).to.deep.eq({
               properties: {
-                value1: { type: 'string', default: undefined, description: undefined, format: undefined },
-                value2: { type: 'string', default: undefined, description: undefined, format: undefined },
+                value1: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                value2: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
               },
               required: ['value2', 'value1'],
               type: 'object',
@@ -776,23 +782,24 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema).to.deep.eq(
               {
                 properties: {
-                  omit: { $ref: '#/components/schemas/Omit_ErrorResponseModel.status_', description: undefined, format: undefined },
-                  omitHidden: { $ref: '#/components/schemas/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined },
-                  partial: { $ref: '#/components/schemas/Partial_Account_', description: undefined, format: undefined },
-                  excludeToEnum: { $ref: '#/components/schemas/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined },
-                  excludeToAlias: { $ref: '#/components/schemas/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined },
-                  excludeLiteral: { $ref: '#/components/schemas/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined },
-                  excludeToInterface: { $ref: '#/components/schemas/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined },
-                  excludeTypeToPrimitive: { $ref: '#/components/schemas/NonNullable_number~OR~null_', description: undefined, format: undefined },
-                  pick: { $ref: '#/components/schemas/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined },
-                  readonlyClass: { $ref: '#/components/schemas/Readonly_TestClassModel_', description: undefined, format: undefined },
-                  defaultArgs: { $ref: '#/components/schemas/DefaultTestModel', description: undefined, format: undefined },
-                  heritageCheck: { $ref: '#/components/schemas/HeritageTestModel', description: undefined, format: undefined },
+                  omit: { $ref: '#/components/schemas/Omit_ErrorResponseModel.status_', description: undefined, format: undefined, example: undefined },
+                  omitHidden: { $ref: '#/components/schemas/Omit_PrivateModel.stringPropDec1_', description: undefined, format: undefined, example: undefined },
+                  partial: { $ref: '#/components/schemas/Partial_Account_', description: undefined, format: undefined, example: undefined },
+                  excludeToEnum: { $ref: '#/components/schemas/Exclude_EnumUnion.EnumNumberValue_', description: undefined, format: undefined, example: undefined },
+                  excludeToAlias: { $ref: '#/components/schemas/Exclude_ThreeOrFour.TypeAliasModel3_', description: undefined, format: undefined, example: undefined },
+                  excludeLiteral: { $ref: '#/components/schemas/Exclude_keyofTestClassModel.account~OR~defaultValue2_', description: undefined, format: undefined, example: undefined },
+                  excludeToInterface: { $ref: '#/components/schemas/Exclude_OneOrTwo.TypeAliasModel1_', description: undefined, format: undefined, example: undefined },
+                  excludeTypeToPrimitive: { $ref: '#/components/schemas/NonNullable_number~OR~null_', description: undefined, format: undefined, example: undefined },
+                  pick: { $ref: '#/components/schemas/Pick_ThingContainerWithTitle_string_.list_', description: undefined, format: undefined, example: undefined },
+                  readonlyClass: { $ref: '#/components/schemas/Readonly_TestClassModel_', description: undefined, format: undefined, example: undefined },
+                  defaultArgs: { $ref: '#/components/schemas/DefaultTestModel', description: undefined, format: undefined, example: undefined },
+                  heritageCheck: { $ref: '#/components/schemas/HeritageTestModel', description: undefined, format: undefined, example: undefined },
                 },
                 type: 'object',
                 default: undefined,
                 description: undefined,
                 format: undefined,
+                example: undefined,
               },
               `for property ${propertyName}`,
             );
@@ -811,7 +818,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const omitReference = getComponentSchema('Pick_ErrorResponseModel.Exclude_keyofErrorResponseModel.status__', currentSpec);
             expect(omitReference).to.deep.eq(
               {
-                properties: { message: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2 } },
+                properties: { message: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2, example: undefined } },
                 required: ['message'],
                 type: 'object',
                 description: 'From T, pick a set of properties whose keys are in the union K',
@@ -836,8 +843,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(omitHiddenReference).to.deep.eq(
               {
                 properties: {
-                  id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  stringPropDec2: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2 },
+                  id: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined },
+                  stringPropDec2: { type: 'string', default: undefined, description: undefined, format: undefined, minLength: 2, example: undefined },
                 },
                 required: ['stringPropDec2', 'id'],
                 type: 'object',
@@ -851,7 +858,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const partial = getComponentSchema('Partial_Account_', currentSpec);
             expect(partial).to.deep.eq(
               {
-                properties: { id: { type: 'number', format: 'double', default: undefined, description: undefined } },
+                properties: { id: { type: 'number', format: 'double', default: undefined, example: undefined, description: undefined } },
                 type: 'object',
                 description: 'Make all properties in T optional',
                 default: undefined,
@@ -885,7 +892,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const excludeToAliasTypeAlias4 = getComponentSchema('TypeAlias4', currentSpec);
             expect(excludeToAliasTypeAlias4).to.deep.eq(
               {
-                properties: { value4: { type: 'string', default: undefined, description: undefined, format: undefined } },
+                properties: { value4: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined } },
                 required: ['value4'],
                 type: 'object',
                 default: undefined,
@@ -949,6 +956,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                     description: undefined,
                     format: undefined,
+                    example: undefined,
                   },
                 },
                 required: ['list'],
@@ -964,14 +972,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(readonlyClassSchema).to.deep.eq(
               {
                 properties: {
-                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined },
-                  id: { type: 'number', format: 'double', default: undefined, description: undefined },
-                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined },
-                  stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined },
-                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$' },
-                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined },
+                  defaultValue1: { type: 'string', default: 'Default Value 1', description: undefined, format: undefined, example: undefined },
+                  id: { type: 'number', format: 'double', default: undefined, description: undefined, example: undefined },
+                  optionalPublicConstructorVar: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  readonlyConstructorArgument: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  publicConstructorVar: { type: 'string', default: undefined, description: 'This is a description for publicConstructorVar', format: undefined, example: undefined },
+                  stringProperty: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
+                  emailPattern: { type: 'string', default: undefined, description: undefined, format: 'email', pattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$', example: undefined },
+                  optionalPublicStringProperty: { type: 'string', minLength: 0, maxLength: 10, default: undefined, description: undefined, format: undefined, example: undefined },
                   publicStringProperty: {
                     type: 'string',
                     minLength: 3,
@@ -980,9 +988,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                     description: 'This is a description of a public string property',
                     format: undefined,
+                    example: undefined,
                   },
-                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined },
-                  account: { $ref: '#/components/schemas/Account', format: undefined, description: undefined },
+                  defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, example: undefined },
+                  account: { $ref: '#/components/schemas/Account', format: undefined, description: undefined, example: undefined },
                 },
                 required: ['account', 'publicStringProperty', 'stringProperty', 'publicConstructorVar', 'readonlyConstructorArgument', 'id'],
                 type: 'object',
@@ -998,8 +1007,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 description: undefined,
                 properties: {
-                  t: { $ref: '#/components/schemas/GenericRequest_Word_', description: undefined, format: undefined },
-                  u: { $ref: '#/components/schemas/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined },
+                  t: { $ref: '#/components/schemas/GenericRequest_Word_', description: undefined, format: undefined, example: undefined },
+                  u: { $ref: '#/components/schemas/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined, example: undefined },
                 },
                 required: ['t', 'u'],
                 type: 'object',
@@ -1012,8 +1021,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(heritageCheck).to.deep.eq(
               {
                 properties: {
-                  value4: { type: 'string', description: undefined, format: undefined, default: undefined },
-                  name: { type: 'string', description: undefined, format: undefined, default: undefined },
+                  value4: { type: 'string', description: undefined, format: undefined, example: undefined, default: undefined },
+                  name: { type: 'string', description: undefined, format: undefined, example: undefined, default: undefined },
                 },
                 required: ['value4'],
                 type: 'object',
@@ -1028,14 +1037,22 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema).to.deep.equal({
               default: undefined,
               description: undefined,
+              example: undefined,
               format: undefined,
               properties: {
-                maybeString: { $ref: '#/components/schemas/Maybe_string_', description: undefined, format: undefined },
-                wordOrNull: { $ref: '#/components/schemas/Maybe_Word_', description: undefined, format: undefined },
-                numberOrNull: { oneOf: [{ type: 'number', format: 'double' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, format: undefined, default: undefined },
+                maybeString: { $ref: '#/components/schemas/Maybe_string_', description: undefined, format: undefined, example: undefined },
+                wordOrNull: { $ref: '#/components/schemas/Maybe_Word_', description: undefined, format: undefined, example: undefined },
+                numberOrNull: {
+                  oneOf: [{ type: 'number', format: 'double' }, { type: 'number', enum: ['null'], nullable: true }],
+                  description: undefined,
+                  format: undefined,
+                  default: undefined,
+                  example: undefined,
+                },
                 justNull: {
                   default: undefined,
                   description: undefined,
+                  example: undefined,
                   enum: ['null'],
                   format: undefined,
                   nullable: true,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -988,7 +988,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                     description: 'This is a description of a public string property',
                     format: undefined,
-                    example: undefined,
+                    example: 'classPropExample',
                   },
                   defaultValue2: { type: 'string', default: 'Default Value 2', description: undefined, format: undefined, example: undefined },
                   account: { $ref: '#/components/schemas/Account', format: undefined, description: undefined, example: undefined },
@@ -1037,7 +1037,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema).to.deep.equal({
               default: undefined,
               description: undefined,
-              example: undefined,
+              example: {
+                justNull: null,
+                maybeString: null,
+                numberOrNull: null,
+                wordOrNull: null,
+              },
               format: undefined,
               properties: {
                 maybeString: { $ref: '#/components/schemas/Maybe_string_', description: undefined, format: undefined, example: undefined },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**
closes #615 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Test plan**

Checks that @example tags on either properties or parameters generated examples.