### PR TITLE
Aliased void Api Response types document 200 response instead of 204

### DIFF
--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { isVoidType } from '../utils/isVoidType';
 import { getDecorators } from './../utils/decoratorUtils';
 import { getJSDocComment, getJSDocDescription, isExistJSDocTag } from './../utils/jsDocUtils';
 import { GenerateMetadataError } from './exceptions';
@@ -144,11 +145,12 @@ export class MethodGenerator {
 
   private getMethodSuccessResponse(type: Tsoa.Type): Tsoa.Response {
     const decorators = this.getDecoratorsByIdentifier(this.node, 'SuccessResponse');
+
     if (!decorators || !decorators.length) {
       return {
-        description: type.dataType === 'void' ? 'No content' : 'Ok',
+        description: isVoidType(type) ? 'No content' : 'Ok',
         examples: this.getMethodSuccessExamples(),
-        name: type.dataType === 'void' ? '204' : '200',
+        name: isVoidType(type) ? '204' : '200',
         schema: type,
       };
     }

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -1,5 +1,6 @@
 import { Tsoa } from '../metadataGeneration/tsoa';
 import { assertNever } from '../utils/assertNever';
+import { isVoidType } from '../utils/isVoidType';
 import { SwaggerConfig } from './../config';
 import { convertColonPathParams, normalisePath } from './../utils/pathUtils';
 import { SpecGenerator } from './specGenerator';
@@ -179,7 +180,7 @@ export class SpecGenerator2 extends SpecGenerator {
       swaggerResponses[res.name] = {
         description: res.description,
       };
-      if (res.schema && res.schema.dataType !== 'void') {
+      if (res.schema && !isVoidType(res.schema)) {
         swaggerResponses[res.name].schema = this.getSwaggerType(res.schema);
       }
       if (res.examples) {

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -1,5 +1,6 @@
 import { Tsoa } from '../metadataGeneration/tsoa';
 import { assertNever } from '../utils/assertNever';
+import { isVoidType } from '../utils/isVoidType';
 import { SwaggerConfig } from './../config';
 import { convertColonPathParams, normalisePath } from './../utils/pathUtils';
 import { SpecGenerator } from './specGenerator';
@@ -268,7 +269,7 @@ export class SpecGenerator3 extends SpecGenerator {
         },
         description: res.description,
       };
-      if (res.schema && res.schema.dataType !== 'void') {
+      if (res.schema && !isVoidType(res.schema)) {
         /* tslint:disable:no-string-literal */
         (swaggerResponses[res.name].content || {})['application/json']['schema'] = this.getSwaggerType(res.schema);
       }

--- a/src/utils/isVoidType.ts
+++ b/src/utils/isVoidType.ts
@@ -1,0 +1,11 @@
+import { Tsoa } from '../metadataGeneration/tsoa';
+
+export const isVoidType = (type: Tsoa.Type): boolean => {
+  if (type.dataType === 'void') {
+    return true;
+  } else if (type.dataType === 'refAlias') {
+    return isVoidType(type.type);
+  } else {
+    return false;
+  }
+};

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -106,4 +106,10 @@ export class MethodController extends Controller {
   public async returnAnyType(): Promise<any> {
     return 'Hello Word';
   }
+
+  @Get('returnAliasedVoidType')
+  public async returnAliasedVoidType(): Promise<VoidAlias1> {}
 }
+
+type VoidAlias1 = VoidAlias2;
+type VoidAlias2 = void;

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -46,6 +46,7 @@ describe('Metadata generation', () => {
       'summaryMethod',
       'oauthAndAPIkeySecurity',
       'returnAnyType',
+      'returnAliasedVoidType',
     ];
 
     it('should only generate the defined methods', () => {
@@ -161,6 +162,19 @@ describe('Metadata generation', () => {
       const mainResponse = method.responses[0];
       expect(mainResponse.name).to.equal('201');
       expect(mainResponse.description).to.equal('Created');
+    });
+
+    it('should generate 204 response on aliased voids', () => {
+      const method = controller.methods.find(m => m.name === 'returnAliasedVoidType');
+      if (!method) {
+        throw new Error('Method returnAliasedVoidType not defined!');
+      }
+
+      expect(method.responses.length).to.equal(1);
+
+      const mainResponse = method.responses[0];
+      expect(mainResponse.name).to.equal('204');
+      expect(mainResponse.description).to.equal('No content');
     });
 
     it('should generate api security', () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

Closes #603 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
None I'm aware of