### PR TITLE
Heller/feature/oapi 3x hosts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,7 @@ export const validateSwaggerConfig = async (config: SwaggerConfig): Promise<Swag
   if (config.specVersion === 2 && config.hosts) {
     throw new Error('Multiple hosts are only supported in the 3.0 spec.');
   }
-  if ((config.specVersion === 3 && config.schemes) || config.host) {
+  if (config.specVersion === 3 && (config.schemes || config.host)) {
     throw new Error('config.host is deprecated OAPI3 standard uses config.hosts, an array of full URLS, e.g. https://mydomain.com');
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,13 @@ export const validateSwaggerConfig = async (config: SwaggerConfig): Promise<Swag
   if (!(await fsExists(config.entryFile))) {
     throw new Error(`EntryFile not found: ${config.entryFile} - Please check your tsoa config.`);
   }
+  if (config.specVersion === 2 && config.hosts) {
+    throw new Error('Multiple hosts are only supported in the 3.0 spec.');
+  }
+  if ((config.specVersion === 3 && config.schemes) || config.host) {
+    throw new Error('config.host is deprecated OAPI3 standard uses config.hosts, an array of full URLS, e.g. https://mydomain.com');
+  }
+
   config.version = config.version || (await versionDefault());
 
   config.specVersion = config.specVersion || 2;

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export interface SwaggerConfig {
   /**
    * API hosts array, e.g. [https://locahost:3000, https://myapi.com]
    */
-  hosts?: string[];
+  servers?: OpenAPI3Server[];
 
   /**
    * API version number; defaults to npm package version

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,8 +49,14 @@ export interface SwaggerConfig {
 
   /**
    * API host, expressTemplat e.g. localhost:3000 or myapi.com, use null for relative urls
+   * OAPI2 compliant
    */
   host?: string | null;
+
+  /**
+   * API hosts array, e.g. [https://locahost:3000, https://myapi.com]
+   */
+  hosts?: string[];
 
   /**
    * API version number; defaults to npm package version

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -116,21 +116,15 @@ export class SpecGenerator3 extends SpecGenerator {
 
   private buildServers() {
     const basePath = normalisePath(this.config.basePath as string, '/', undefined, false);
-    const scheme = this.config.schemes ? this.config.schemes[0] : 'https';
 
-    let url;
-    if (this.config.host === null) {
-      url = basePath;
+    let urls;
+    if (!this.config.hosts || this.config.hosts.length === 0) {
+      urls = [`${basePath}`];
     } else {
-      const host = this.config.host || 'localhost:3000';
-      url = `${scheme}://${host}${basePath}`;
+      urls = this.config.hosts;
     }
-
-    return [
-      {
-        url,
-      } as Swagger.Server,
-    ];
+    const servers = urls.map(url => ({ url: `${url}${basePath}` }));
+    return servers;
   }
 
   private buildSchema() {

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -119,7 +119,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     let urls;
     if (!this.config.hosts || this.config.hosts.length === 0) {
-      urls = [`${basePath}`];
+      urls = [''];
     } else {
       urls = this.config.hosts;
     }

--- a/tests/fixtures/defaultOptions.ts
+++ b/tests/fixtures/defaultOptions.ts
@@ -1,10 +1,26 @@
 import { SwaggerConfig } from './../../src/config';
-export function getDefaultOptions(outputDirectory: string = '', entryFile: string = ''): SwaggerConfig {
+export function getDefaultOptions(outputDirectory: string = '', entryFile: string = '', opapiSpec: number = 2): SwaggerConfig {
+  const specSpecific =
+    opapiSpec === 3
+      ? {
+          // OAPI configs
+          hosts: ['http://localhost:3000', 'http://myapi.com'],
+          swagger: {
+            specVersion: 3,
+          },
+        }
+      : {
+          // OAPI 2.0 configs
+          host: 'localhost:3000',
+          swagger: {
+            specVersion: 3,
+          },
+        };
   return {
+    ...specSpecific,
     basePath: '/v1',
     description: 'Description of a test API',
     entryFile,
-    host: 'localhost:3000',
     license: 'MIT',
     name: 'Test API',
     outputDirectory,

--- a/tests/fixtures/defaultOptions.ts
+++ b/tests/fixtures/defaultOptions.ts
@@ -5,19 +5,14 @@ export function getDefaultOptions(outputDirectory: string = '', entryFile: strin
       ? {
           // OAPI configs
           hosts: ['http://localhost:3000', 'http://myapi.com'],
-          swagger: {
-            specVersion: 3,
-          },
         }
       : {
           // OAPI 2.0 configs
           host: 'localhost:3000',
-          swagger: {
-            specVersion: 3,
-          },
         };
   return {
     ...specSpecific,
+    specVersion: opapiSpec === 3 ? 3 : 2,
     basePath: '/v1',
     description: 'Description of a test API',
     entryFile,

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -42,7 +42,7 @@ const defaultOptions = (opapiSpec: number = 3): SwaggerConfig => {
   };
 };
 
-const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions(), {
+const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions(3), {
   noImplicitAdditionalProperties: 'throw-on-extras',
   outputDirectory: './distForNoAdditional',
 });
@@ -76,7 +76,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'express',
           routesDir: './tests/fixtures/express',
         },
-        defaultOptions(3),
+        defaultOptions(2),
         undefined,
         undefined,
         metadata,

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -5,31 +5,44 @@ import { SwaggerConfig } from '../src/config';
 import { generateRoutes } from '../src/module/generate-routes';
 import { Timer } from './utils/timer';
 
-const defaultOptions: SwaggerConfig = {
-  basePath: '/v1',
-  entryFile: './tests/fixtures/express/server.ts',
-  host: 'localhost:3000',
-  noImplicitAdditionalProperties: 'silently-remove-extras',
-  outputDirectory: './dist',
-  securityDefinitions: {
-    api_key: {
-      in: 'query',
-      name: 'access_token',
-      type: 'apiKey',
-    },
-    tsoa_auth: {
-      authorizationUrl: 'http://swagger.io/api/oauth/dialog',
-      flow: 'implicit',
-      scopes: {
-        'read:pets': 'read things',
-        'write:pets': 'modify things',
+const defaultOptions = (opapiSpec: number = 3): SwaggerConfig => {
+  const specSpecific =
+    opapiSpec === 3
+      ? {
+          hosts: ['http://localhost:3000', 'http://myapi.com'],
+        }
+      : {
+          // OAPI 2.0 configs
+          host: 'localhost:3000',
+        };
+  return {
+    specVersion: opapiSpec === 3 ? 3 : 2,
+    ...specSpecific,
+    basePath: '/v1',
+    entryFile: './tests/fixtures/express/server.ts',
+    noImplicitAdditionalProperties: 'silently-remove-extras',
+    outputDirectory: './dist',
+    securityDefinitions: {
+      api_key: {
+        in: 'query',
+        name: 'access_token',
+        type: 'apiKey',
       },
-      type: 'oauth2',
+      tsoa_auth: {
+        authorizationUrl: 'http://swagger.io/api/oauth/dialog',
+        flow: 'implicit',
+        scopes: {
+          'read:pets': 'read things',
+          'write:pets': 'modify things',
+        },
+        type: 'oauth2',
+      },
     },
-  },
-  yaml: true,
+    yaml: true,
+  };
 };
-const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
+
+const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions(), {
   noImplicitAdditionalProperties: 'throw-on-extras',
   outputDirectory: './distForNoAdditional',
 });
@@ -63,7 +76,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'express',
           routesDir: './tests/fixtures/express',
         },
-        defaultOptions,
+        defaultOptions(3),
         undefined,
         undefined,
         metadata,
@@ -94,7 +107,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'express',
           routesDir: './tests/fixtures/express-dynamic-controllers',
         },
-        defaultOptions,
+        defaultOptions(),
         undefined,
         undefined,
         metadata,
@@ -109,7 +122,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'koa',
           routesDir: './tests/fixtures/koa',
         },
-        defaultOptions,
+        defaultOptions(),
         undefined,
         undefined,
         metadata,
@@ -139,7 +152,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'hapi',
           routesDir: './tests/fixtures/hapi',
         },
-        defaultOptions,
+        defaultOptions(),
       ),
     ),
     log('Custom Route Generation', () =>
@@ -153,7 +166,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           routesDir: './tests/fixtures/custom',
           routesFileName: 'customRoutes.ts',
         },
-        defaultOptions,
+        defaultOptions(),
         undefined,
         undefined,
         metadata,
@@ -169,7 +182,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
           middleware: 'express',
           routesDir: './tests/fixtures/inversify',
         },
-        defaultOptions,
+        defaultOptions(),
       ),
     ),
   ]);

--- a/tests/unit/swagger/config.spec.ts
+++ b/tests/unit/swagger/config.spec.ts
@@ -65,17 +65,20 @@ describe('Configuration', () => {
     });
 
     it('should accept Spec version 3 when specified', done => {
-      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
-      config.specVersion = 3;
-      validateSwaggerConfig(config).then((configResult: SwaggerConfig) => {
-        expect(configResult.specVersion).to.equal(3);
-        done();
-      });
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json', 3);
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult.specVersion).to.equal(3);
+          done();
+        },
+        error => {
+          throw new Error('Should not get here, expecting a valid spec');
+        },
+      );
     });
     it('should accept multiple hosts in open api 3', done => {
-      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json', 3);
       // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
-      config.specVersion = 3 as any;
       config.hosts = ['https://localhost:3000', 'https://localhost:3002'];
       validateSwaggerConfig(config).then(
         (configResult: SwaggerConfig) => {
@@ -95,20 +98,11 @@ describe('Configuration', () => {
       config.schemes = ['http'];
       validateSwaggerConfig(config).then(
         (configResult: SwaggerConfig) => {
-          expect(configResult).to.not.be.ok;
+          throw new Error('Should not get here, expecting invalid configs');
         },
         err => {
           expect(err).to.be.ok;
-        },
-      );
-      config.hosts = [];
-      validateSwaggerConfig(config).then(
-        (configResult: SwaggerConfig) => {
-          expect(configResult).to.be.ok;
           done();
-        },
-        err => {
-          throw new Error('Should not get here, expecting valid configs');
         },
       );
     });

--- a/tests/unit/swagger/config.spec.ts
+++ b/tests/unit/swagger/config.spec.ts
@@ -72,6 +72,69 @@ describe('Configuration', () => {
         done();
       });
     });
+    it('should accept multiple hosts in open api 3', done => {
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json');
+      // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
+      config.specVersion = 3 as any;
+      config.hosts = ['https://localhost:3000', 'https://localhost:3002'];
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult).to.be.ok;
+          done();
+        },
+        err => {
+          throw new Error('Should not get here, expecting valid configs');
+        },
+      );
+    });
+    it('should not allow host, schema', done => {
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json', 3);
+      // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
+      config.specVersion = 3 as any;
+      config.host = 'localhost:3000';
+      config.schemes = ['http'];
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult).to.not.be.ok;
+        },
+        err => {
+          expect(err).to.be.ok;
+        },
+      );
+      config.hosts = [];
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult).to.be.ok;
+          done();
+        },
+        err => {
+          throw new Error('Should not get here, expecting valid configs');
+        },
+      );
+    });
+    it('should set a default hosts when none are provided in open api 3', done => {
+      const config: SwaggerConfig = getDefaultOptions('some/output/directory', 'tsoa.json', 3);
+      // Do any cast to ignore compile error due to Swagger.SupportedSpecVersion not supporting -2
+      config.specVersion = 3 as any;
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult).to.be.ok;
+        },
+        err => {
+          throw new Error('Should not get here, expecting valid configs');
+        },
+      );
+      config.hosts = [];
+      validateSwaggerConfig(config).then(
+        (configResult: SwaggerConfig) => {
+          expect(configResult).to.be.ok;
+          done();
+        },
+        err => {
+          throw new Error('Should not get here, expecting valid configs');
+        },
+      );
+    });
   });
 
   describe('.validateMutualConfigs', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -14,7 +14,7 @@ import assert = require('assert');
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
 
-  const defaultOptions = getDefaultOptions();
+  const defaultOptions = getDefaultOptions(undefined, undefined, 3);
   const optionsWithNoAdditional = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
     noImplicitAdditionalProperties: 'silently-remove-extras',
   });
@@ -62,20 +62,11 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
   describe('servers', () => {
     it('should replace the parent schemes element', () => {
       expect(specDefault.spec).to.not.have.property('schemes');
-      expect(specDefault.spec.servers[0].url).to.match(/^https/);
+      expect(specDefault.spec.servers[0].url).to.be('http://localhost:3000/v1');
+      expect(specDefault.spec.servers[0].url).to.be('http://myapi.com/v1');
     });
 
-    it('should replace the parent host element', () => {
-      expect(specDefault.spec).to.not.have.property('host');
-      expect(specDefault.spec.servers[0].url).to.match(/localhost:3000/);
-    });
-
-    it('should replace the parent basePath element', () => {
-      expect(specDefault.spec).to.not.have.property('basePath');
-      expect(specDefault.spec.servers[0].url).to.match(/\/v1/);
-    });
-
-    it('setting host to null should result in relative URL', () => {
+    it('setting hosts to null should result in relative URL', () => {
       const optionsWithHostIsNull = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
         host: null,
       });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -62,16 +62,15 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
   describe('servers', () => {
     it('should replace the parent schemes element', () => {
       expect(specDefault.spec).to.not.have.property('schemes');
-      expect(specDefault.spec.servers[0].url).to.be('http://localhost:3000/v1');
-      expect(specDefault.spec.servers[0].url).to.be('http://myapi.com/v1');
+      expect(specDefault.spec.servers[0].url).to.equal('http://localhost:3000/v1');
+      expect(specDefault.spec.servers[1].url).to.equal('http://myapi.com/v1');
     });
 
     it('setting hosts to null should result in relative URL', () => {
       const optionsWithHostIsNull = Object.assign<{}, SwaggerConfig, Partial<SwaggerConfig>>({}, defaultOptions, {
-        host: null,
+        hosts: undefined,
       });
       const spec: Swagger.Spec3 = new SpecGenerator3(metadata, optionsWithHostIsNull).GetSpec();
-
       expect(spec.servers[0].url).to.equal('/v1');
     });
   });


### PR DESCRIPTION
Previous PR here. https://github.com/lukeautry/tsoa/pull/595
Rebranched to avoid a rebase nightmare while moving to 3.x. 

The 3.x Spec was attempting to use the host, scheme to define the endpoints. The new definition in the 3.x spec is just plain old "hosts". E.g. a host is https://myapi.com

CLI validation has been setup to reject 2.x specs that include hosts, and reject 3.x specs that include host or scheme configs. 

It did take a bit of modification of the default configs and adding a spec toggle to the default generators to enforce OAPI 3.x configs. 

test plan = unit test modifications
its getting late...