### PR TITLE
ValidateError should extend Error

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -750,13 +750,6 @@ export interface Exception extends Error {
   status: number;
 }
 
-export class ValidateException implements Exception {
-  public status = 400;
-  public name = 'ValidateException';
-
-  constructor(public fields: FieldErrors, public message: string) {}
-}
-
 export class ValidateError extends Error implements Exception {
   public status = 400;
   public name = 'ValidateError';

--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -750,10 +750,20 @@ export interface Exception extends Error {
   status: number;
 }
 
-export class ValidateError implements Exception {
+export class ValidateException implements Exception {
   public status = 400;
-  public name = 'ValidateError';
+  public name = 'ValidateException';
 
   constructor(public fields: FieldErrors, public message: string) {}
 }
+
+export class ValidateError extends Error implements Exception {
+  public status = 400;
+  public name = 'ValidateError';
+
+  constructor(public fields: FieldErrors, public message: string) {
+    super(message);
+  }
+}
+
 export * from './tsoa-route';

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -2,9 +2,9 @@
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 {{#if canImportByAlias}}
-  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
+  import { Controller, ValidationService, FieldErrors, ValidateException, TsoaRoute } from 'tsoa';
 {{else}}
-  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
+  import { Controller, ValidationService, FieldErrors, ValidateException, TsoaRoute } from '../../../src';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -204,7 +204,7 @@ export function RegisterRoutes(server: any) {
             }
         });
         if (Object.keys(errorFields).length > 0) {
-            throw new ValidateError(errorFields, '');
+            throw new ValidateException(errorFields, '');
         }
         return values;
     }

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -2,9 +2,9 @@
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 {{#if canImportByAlias}}
-  import { Controller, ValidationService, FieldErrors, ValidateException, TsoaRoute } from 'tsoa';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from 'tsoa';
 {{else}}
-  import { Controller, ValidationService, FieldErrors, ValidateException, TsoaRoute } from '../../../src';
+  import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -16,6 +16,7 @@ import { {{name}} } from '{{modulePath}}';
 {{#if authenticationModule}}
 import { hapiAuthentication } from '{{authenticationModule}}';
 {{/if}}
+import { boomify, Payload } from '@hapi/boom';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
@@ -77,9 +78,14 @@ export function RegisterRoutes(server: any) {
                     try {
                         validatedArgs = getValidatedArgs(args, request);
                     } catch (err) {
-                        return h
-                            .response(err)
-                            .code(err.status || 500);
+                        const boomErr = boomify(err);
+                        boomErr.output.statusCode = err.status || 500;
+                        boomErr.output.payload = {
+                            name: err.name,
+                            fields: err.fields,
+                            message: err.message,
+                        } as unknown as Payload;
+                        throw boomErr;
                     }
 
                     {{#if ../../iocModule}}
@@ -204,7 +210,7 @@ export function RegisterRoutes(server: any) {
             }
         });
         if (Object.keys(errorFields).length > 0) {
-            throw new ValidateException(errorFields, '');
+            throw new ValidateError(errorFields, '');
         }
         return values;
     }

--- a/tests/unit/templating/templateHelpers.spec.ts
+++ b/tests/unit/templating/templateHelpers.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import { FieldErrors, TsoaRoute, ValidationService } from '../../../src';
 import { AdditionalProps } from '../../../src/routeGeneration/routeGenerator';
-import { ValidateError, ValidateException } from '../../../src/routeGeneration/templateHelpers';
+import { ValidateError } from '../../../src/routeGeneration/templateHelpers';
 import { TypeAliasModel1, TypeAliasModel2 } from '../../fixtures/testModel';
 
 it('should allow additionalProperties (on a union) if noImplicitAdditionalProperties is set to silently-remove-extras', () => {
@@ -617,8 +617,4 @@ it('should throw if properties on nOl are missing', () => {
 
 it('should throw an Error', () => {
   expect(new ValidateError({}, '')).to.be.an.instanceof(Error);
-});
-
-it('should not throw an Error for hapi', () => {
-  expect(new ValidateException({}, '')).to.not.be.an.instanceof(Error);
 });

--- a/tests/unit/templating/templateHelpers.spec.ts
+++ b/tests/unit/templating/templateHelpers.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import { FieldErrors, TsoaRoute, ValidationService } from '../../../src';
 import { AdditionalProps } from '../../../src/routeGeneration/routeGenerator';
+import { ValidateError, ValidateException } from '../../../src/routeGeneration/templateHelpers';
 import { TypeAliasModel1, TypeAliasModel2 } from '../../fixtures/testModel';
 
 it('should allow additionalProperties (on a union) if noImplicitAdditionalProperties is set to silently-remove-extras', () => {
@@ -612,4 +613,12 @@ it('should throw if properties on nOl are missing', () => {
       value: undefined,
     },
   });
+});
+
+it('should throw an Error', () => {
+  expect(new ValidateError({}, '')).to.be.an.instanceof(Error);
+});
+
+it('should not throw an Error for hapi', () => {
+  expect(new ValidateException({}, '')).to.not.be.an.instanceof(Error);
 });


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**
Closes #658

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
- not ideal to have 2 separate validation error classes
- when I initially updated `ValidateError` to extend `Error`, all server tests passed except hapi, which had this message:
```
  1) Hapi Server
       returns error if missing required query parameter:
     Error: the object {
  "error": "Error: expected 400 \"Bad Request\", got 500 \"Internal Server Error\""
  "response": "Error: cannot GET /v1/GetTest/1/true/test?booleanParam=true&stringParam=test1234 (500)"
} was thrown, throw an Error :)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```
- and the corresponding server side error was:
```
Debug: internal, implementation, error 
    Error: Cannot wrap an error
    at new module.exports (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hoek/lib/error.js:23:19)
    at Object.module.exports [as assert] (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hoek/lib/assert.js:20:11)
    at internals.Toolkit.response (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hapi/lib/toolkit.js:174:14)
    at handler (/Users/alden/Desktop/alden-tsoa/tsoa/tests/fixtures/hapi/routes.ts:1091:14)
    at module.exports.internals.Manager.execute (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hapi/lib/toolkit.js:41:33)
    at Object.internals.handler (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hapi/lib/handler.js:46:48)
    at exports.execute (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hapi/lib/handler.js:31:36)
    at Request._lifecycle (/Users/alden/Desktop/alden-tsoa/tsoa/node_modules/@hapi/hapi/lib/request.js:312:68)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
- which comes from the template here: https://github.com/lukeautry/tsoa/blob/82d02735eacda1842cef2d9587df46c93483a72b/src/routeGeneration/templates/hapi.hbs#L81
- very open to better ideas for fixing this issue if you have them!
<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
- unit tests assert that ValidateError extends Error, which was the primary goal
<!-- explain why the unit tests that you added are demonstrating that the feature works -->