### PR TITLE
feat: handle `Record<>` mapped type

### DIFF
--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -179,7 +179,6 @@ export class TypeResolver {
 
           // Push property
           return {
-            description: this.getSymbolDescription(property),
             name: property.name,
             required,
             type: new TypeResolver(typeNode, this.current, this.typeNode, this.context, this.referencer).resolve(),
@@ -1006,10 +1005,7 @@ export class TypeResolver {
       // TypeScript won't parse jsdoc if the flag is 4, i.e. 'Property'
       symbol.flags = 0;
     }
-    return this.getSymbolDescription(symbol);
-  }
 
-  private getSymbolDescription(symbol: ts.Symbol) {
     const comments = symbol.getDocumentationComment(this.current.typeChecker);
     if (comments.length) {
       return ts.displayPartsToString(comments);

--- a/src/utils/validatorUtils.ts
+++ b/src/utils/validatorUtils.ts
@@ -105,19 +105,9 @@ export function getParameterValidators(parameter: ts.ParameterDeclaration, param
   }, {} as Tsoa.Validators);
 }
 
-export function getPropertyValidators(property: ts.Node): Tsoa.Validators | undefined {
-  const tags = getJSDocTags(property, () => true);
-  return getPropertyValidatorsFromTags(
-    tags.map(tag => ({
-      name: tag.tagName.text,
-      text: tag.comment,
-    })),
-  );
-}
-
-export function getPropertyValidatorsFromTags(tagsList: ts.JSDocTagInfo[]): Tsoa.Validators | undefined {
-  const tags = tagsList.filter(tag => {
-    return getParameterTagSupport().some(value => value === tag.name);
+export function getPropertyValidators(property: ts.PropertyDeclaration | ts.TypeAliasDeclaration | ts.PropertySignature | ts.ParameterDeclaration): Tsoa.Validators | undefined {
+  const tags = getJSDocTags(property, tag => {
+    return getParameterTagSupport().some(value => value === tag.tagName.text);
   });
   function getValue(comment?: string) {
     if (!comment) {
@@ -142,8 +132,8 @@ export function getPropertyValidatorsFromTags(tagsList: ts.JSDocTagInfo[]): Tsoa
   }
 
   return tags.reduce((validateObj, tag) => {
-    const name = tag.name;
-    const comment = tag.text;
+    const name = tag.tagName.text;
+    const comment = tag.comment;
     const value = getValue(comment);
 
     switch (name) {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -62,6 +62,7 @@ export interface TestModel extends Model {
   unknownType?: unknown;
   genericTypeObject?: Generic<{ foo: string; bar: boolean }>;
   indexed?: Partial<Indexed['foo']>;
+  record?: Record<'record-foo' | 'record-bar', { data: string }>;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
   modelsObjectIndirectNS?: TestSubModelContainerNamespace.TestSubModelContainer;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -405,6 +405,41 @@ describe('Definition generation', () => {
           indexed: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Partial_Indexed~foo~_');
           },
+          record: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/Record_record-foo~OR~record-bar._data-string__');
+            const schema = getValidatedDefinition('Record_record-foo~OR~record-bar._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
+              properties: {
+                'record-foo': {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+                'record-bar': {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: 'Construct a type with a set of properties K of type T',
+            });
+          },
           modelsObjectIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -596,6 +596,41 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           indexed: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Partial_Indexed~foo~_');
           },
+          record: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/Record_record-foo~OR~record-bar._data-string__');
+            const schema = getComponentSchema('Record_record-foo~OR~record-bar._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
+              properties: {
+                'record-foo': {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+                'record-bar': {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: 'Construct a type with a set of properties K of type T',
+            });
+          },
           modelsObjectIndirect: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/TestSubModelContainer', `for property ${propertyName}.$ref`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

Closes #653

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Some code is duplicated with jsdoc tags, but I haven't found a better way to handle this.