### PR TITLE
Add support for @Hidden() decorator on Query params

### DIFF
--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -62,15 +62,17 @@ export class MethodGenerator {
   }
 
   private buildParameters() {
-    const parameters = this.node.parameters.map(p => {
-      try {
-        return new ParameterGenerator(p, this.method, this.path, this.current).Generate();
-      } catch (e) {
-        const methodId = this.node.name as ts.Identifier;
-        const controllerId = (this.node.parent as ts.ClassDeclaration).name as ts.Identifier;
-        throw new GenerateMetadataError(`${e.message} \n in '${controllerId.text}.${methodId.text}'`);
-      }
-    });
+    const parameters = this.node.parameters
+      .map(p => {
+        try {
+          return new ParameterGenerator(p, this.method, this.path, this.current).Generate();
+        } catch (e) {
+          const methodId = this.node.name as ts.Identifier;
+          const controllerId = (this.node.parent as ts.ClassDeclaration).name as ts.Identifier;
+          throw new GenerateMetadataError(`${e.message} \n in '${controllerId.text}.${methodId.text}'`);
+        }
+      })
+      .filter((p): p is Tsoa.Parameter => p !== null);
 
     const bodyParameters = parameters.filter(p => p.in === 'body');
     const bodyProps = parameters.filter(p => p.in === 'body-prop');

--- a/tests/fixtures/controllers/hiddenMethodController.ts
+++ b/tests/fixtures/controllers/hiddenMethodController.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Hidden, Route } from '../../../src';
+import { Controller, Get, Hidden, Route, Query } from '../../../src';
 import { TestModel } from '../../fixtures/testModel';
 import { ModelService } from '../services/modelService';
 
@@ -12,6 +12,11 @@ export class HiddenMethodController extends Controller {
   @Get('hiddenGetMethod')
   @Hidden()
   public async hiddenGetMethod(): Promise<TestModel> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+
+  @Get('hiddenQueryMethod')
+  public async hiddenQueryMethod(@Query() normalParam: string, @Query() @Hidden() defaultSecret = true, @Query() @Hidden() optionalSecret?: string): Promise<TestModel> {
     return Promise.resolve(new ModelService().getModel());
   }
 }

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -637,6 +637,28 @@ describe('Metadata generation', () => {
       expect(method.path).to.equal('hiddenGetMethod');
       expect(method.isHidden).to.equal(true);
     });
+
+    it('should mark query params as hidden', () => {
+      const method = controller.methods.find(m => m.name === 'hiddenQueryMethod');
+      if (!method) {
+        throw new Error('Method hiddenQueryMethod not defined!');
+      }
+
+      const defaultSecret = method.parameters.find(p => p.name === 'defaultSecret');
+      expect(defaultSecret).to.be.undefined;
+
+      const optionalSecret = method.parameters.find(p => p.name === 'optionalSecret');
+      expect(optionalSecret).to.be.undefined;
+
+      expect(method.parameters.length).to.equal(1);
+
+      const normalParam = method.parameters[0];
+      expect(normalParam.in).to.equal('query');
+      expect(normalParam.name).to.equal('normalParam');
+      expect(normalParam.parameterName).to.equal('normalParam');
+      expect(normalParam.required).to.be.true;
+      expect(normalParam.type.dataType).to.equal('string');
+    });
   });
 
   describe('HiddenControllerGenerator', () => {

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -63,7 +63,31 @@ describe('Schema details generation', () => {
         const metadataHiddenMethod = new MetadataGenerator('./tests/fixtures/controllers/hiddenMethodController.ts').Generate();
         const specHiddenMethod = new SpecGenerator2(metadataHiddenMethod, getDefaultExtendedOptions()).GetSpec();
 
-        expect(specHiddenMethod.paths).to.have.keys(['/Controller/normalGetMethod']);
+        expect(specHiddenMethod.paths).to.have.keys(['/Controller/normalGetMethod', '/Controller/hiddenQueryMethod']);
+      });
+
+      it('should not contain hidden query params', () => {
+        const metadataHidden = new MetadataGenerator('./tests/fixtures/controllers/hiddenMethodController.ts').Generate();
+        const specHidden = new SpecGenerator2(metadataHidden, getDefaultExtendedOptions()).GetSpec();
+
+        if (!specHidden.paths) {
+          throw new Error('Paths are not defined.');
+        }
+        if (!specHidden.paths['/Controller/hiddenQueryMethod']) {
+          throw new Error('hiddenQueryMethod path not defined.');
+        }
+        if (!specHidden.paths['/Controller/hiddenQueryMethod'].get) {
+          throw new Error('hiddenQueryMethod get method not defined.');
+        }
+
+        const method = specHidden.paths['/Controller/hiddenQueryMethod'].get;
+        expect(method.parameters).to.have.lengthOf(1);
+
+        const normalParam = method.parameters![0];
+        expect(normalParam.in).to.equal('query');
+        expect(normalParam.name).to.equal('normalParam');
+        expect(normalParam.required).to.be.true;
+        expect(normalParam.type).to.equal('string');
       });
 
       it('should not contain paths for hidden controller', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -236,7 +236,31 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
         const metadataHiddenMethod = new MetadataGenerator('./tests/fixtures/controllers/hiddenMethodController.ts').Generate();
         const specHiddenMethod = new SpecGenerator3(metadataHiddenMethod, JSON.parse(JSON.stringify(defaultOptions))).GetSpec();
 
-        expect(specHiddenMethod.paths).to.have.keys(['/Controller/normalGetMethod']);
+        expect(specHiddenMethod.paths).to.have.keys(['/Controller/normalGetMethod', '/Controller/hiddenQueryMethod']);
+      });
+
+      it('should not contain hidden query params', () => {
+        const metadataHidden = new MetadataGenerator('./tests/fixtures/controllers/hiddenMethodController.ts').Generate();
+        const specHidden = new SpecGenerator3(metadataHidden, JSON.parse(JSON.stringify(defaultOptions))).GetSpec();
+
+        if (!specHidden.paths) {
+          throw new Error('Paths are not defined.');
+        }
+        if (!specHidden.paths['/Controller/hiddenQueryMethod']) {
+          throw new Error('hiddenQueryMethod path not defined.');
+        }
+        if (!specHidden.paths['/Controller/hiddenQueryMethod'].get) {
+          throw new Error('hiddenQueryMethod get method not defined.');
+        }
+
+        const method = specHidden.paths['/Controller/hiddenQueryMethod'].get;
+        expect(method.parameters).to.have.lengthOf(1);
+
+        const normalParam = method.parameters![0];
+        expect(normalParam.in).to.equal('query');
+        expect(normalParam.name).to.equal('normalParam');
+        expect(normalParam.required).to.be.true;
+        expect(normalParam.schema.type).to.equal('string');
       });
 
       it('should not contain paths for hidden controller', () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**
Closes #582
Relates to #310 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
- Why this approach? Went with `@Hidden` because it's consistent with tsoa controllers and methods, and was the agreed approach from discussion on #582 
- Alternative 1: add a `hidden` property to `@Query`. This would align with how Swagger's Java annotations work `@ApiParam(hidden = true)`, see [here](http://docs.swagger.io/swagger-core/v1.5.X/apidocs/index.html?io/swagger/annotations/ApiParam.html)
- Alternative 2: don't put this in tsoa. Instead, allow users to configure arbitrary filters that extend tsoa, similar to how Swagger .NET works, see [here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore#extend-generator-with-operation-schema--document-filters)

**Test plan**
- found all existing tests for `@Hidden` and added a query unit test to each