### PR TITLE
fix: validate additionalProperties

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -84,7 +84,7 @@ export class ValidationService {
     additionalProperties: TsoaRoute.PropertySchema | boolean | undefined,
     parent: string,
   ) {
-    if (!(value instanceof Object)) {
+    if (!(value instanceof Object) || Array.isArray(value)) {
       fieldErrors[parent + name] = {
         message: `invalid object`,
         value,
@@ -127,6 +127,16 @@ export class ValidationService {
         value[key] = validatedProp;
       }
     });
+
+    if (typeof additionalProperties === 'object' && typeof value === 'object') {
+      const keys = Object.keys(value).filter(key => typeof nestedProperties[key] === 'undefined')
+      keys.forEach(key => {
+        const validatedProp = this.ValidateParam(additionalProperties, value[key], key, fieldErrors, parent + name + '.', swaggerConfig);
+        if (validatedProp !== undefined) {
+          value[key] = validatedProp;
+        }
+      })
+    }
 
     if (Object.keys(fieldErrors).length > previousErrors) {
       return;

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -23,6 +23,11 @@ export class PostTestController {
     return model;
   }
 
+  @Post('Object')
+  public async postObject(@Body() body: { obj: { [key: string]: string } }): Promise<{ [key: string]: string }> {
+    return body.obj;
+  }
+
   @Patch()
   public async updateModel(@Body() model: TestModel): Promise<TestModel> {
     return await new ModelService().getModel();

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -60,7 +60,7 @@ describe('Express Server', () => {
     return verifyGetRequest(basePath + '/GetTest/Multi', (err, res) => {
       const models = res.body as TestModel[];
       expect(models.length).to.equal(3);
-      models.forEach(m => {
+      models.forEach((m) => {
         expect(m.id).to.equal(1);
       });
     });
@@ -124,6 +124,16 @@ describe('Express Server', () => {
       const model = res.body as TestModel;
       expect(model.optionalString).to.equal(stringValue);
     });
+  });
+
+  it('should reject invalid additionalProperties', () => {
+    const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
+
+    return Promise.all(
+      invalidValues.map((value: any) => {
+        return verifyPostRequest(basePath + '/PostTest/Object', { obj: value }, (err: any, res: any) => null, 400);
+      }),
+    );
   });
 
   it('parses buffer parameter', () => {
@@ -985,7 +995,7 @@ describe('Express Server', () => {
           expect(model.human).to.equal(true);
           expect(model.gender).to.equal('MALE');
         },
-        request => {
+        (request) => {
           return request.get(basePath + '/ParameterTest/Header').set({
             age: 45,
             firstname: 'Tony',
@@ -1091,11 +1101,11 @@ describe('Express Server', () => {
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.get(path), expectedStatus);
   }
 
   function verifyPostRequest(path: string, data: any, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.post(path).send(data), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.post(path).send(data), expectedStatus);
   }
 
   function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -139,6 +139,19 @@ describe('Express Server', () => {
     });
   });
 
+  it('should reject invalid additionalProperties', () => {
+    const invalidValues = [
+      'invalid', null, [], 1,
+      { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }
+    ];
+
+    return Promise.all(
+      invalidValues.map((value: any) => {
+        return verifyPostRequest(basePath + '/PostTest/Object', { obj: value }, (err: any, res: any) => null, 400);
+      }),
+    );
+  });
+
   it('parsed body parameters', () => {
     const data = getFakeModel();
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -48,7 +48,7 @@ describe('Hapi Server', () => {
     return verifyGetRequest(basePath + '/GetTest/Multi', (err, res) => {
       const models = res.body as TestModel[];
       expect(models.length).to.equal(3);
-      models.forEach(m => {
+      models.forEach((m) => {
         expect(m.id).to.equal(1);
       });
     });
@@ -171,6 +171,16 @@ describe('Hapi Server', () => {
         expect(res.body.dateValue).to.equal('2016-01-01T00:00:00.000Z');
       },
       200,
+    );
+  });
+
+  it('should reject invalid additionalProperties', () => {
+    const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
+
+    return Promise.all(
+      invalidValues.map((value: any) => {
+        return verifyPostRequest(basePath + '/PostTest/Object', { obj: value }, (err: any, res: any) => null, 400);
+      }),
     );
   });
 
@@ -913,7 +923,7 @@ describe('Hapi Server', () => {
           expect(model.human).to.equal(true);
           expect(model.gender).to.equal('MALE');
         },
-        request => {
+        (request) => {
           return request.get(basePath + '/ParameterTest/Header').set({
             age: 45,
             firstname: 'Tony',
@@ -1020,11 +1030,11 @@ describe('Hapi Server', () => {
   });
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.get(path), expectedStatus);
   }
 
   function verifyPostRequest(path: string, data: any, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.post(path).send(data), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.post(path).send(data), expectedStatus);
   }
 
   function verifyRequest(verifyResponse: (err: any, res: any) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -15,6 +15,16 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
     });
   });
 
+  it('should reject invalid additionalProperties', () => {
+    const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
+
+    return Promise.all(
+      invalidValues.map((value: any) => {
+        return verifyPostRequest(basePath + '/PostTest/Object', { obj: value }, (err: any, res: any) => null, 400);
+      }),
+    );
+  });
+
   it('should call out any additionalProperties', () => {
     const data = Object.assign({}, getFakeModel(), {
       someExtraProperty: 'someExtraValue',
@@ -327,7 +337,7 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       return verifyPostRequest(
         basePath + '/Validate/map',
         data,
-        err => {
+        (err) => {
           const body = JSON.parse(err.text);
 
           // Although dictionaries/records allow additionalProperties they are still subject to their own validation
@@ -437,11 +447,11 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
   it('shutdown server', () => server.close());
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.get(path), expectedStatus);
   }
 
   function verifyPostRequest(path: string, data: any, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.post(path).send(data), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.post(path).send(data), expectedStatus);
   }
 
   function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -49,7 +49,7 @@ describe('Koa Server', () => {
     return verifyGetRequest(basePath + '/GetTest/Multi', (err, res) => {
       const models = res.body as TestModel[];
       expect(models.length).to.equal(3);
-      models.forEach(m => {
+      models.forEach((m) => {
         expect(m.id).to.equal(1);
       });
     });
@@ -185,6 +185,16 @@ describe('Koa Server', () => {
         expect(err.text).to.equal('Not Found');
       },
       404,
+    );
+  });
+
+  it('should reject invalid additionalProperties', () => {
+    const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
+
+    return Promise.all(
+      invalidValues.map((value: any) => {
+        return verifyPostRequest(basePath + '/PostTest/Object', { obj: value }, (err: any, res: any) => null, 400);
+      }),
     );
   });
 
@@ -902,7 +912,7 @@ describe('Koa Server', () => {
           expect(model.human).to.equal(true);
           expect(model.gender).to.equal('MALE');
         },
-        request => {
+        (request) => {
           return request.get(basePath + '/ParameterTest/Header').set({
             age: 45,
             firstname: 'Tony',
@@ -1011,11 +1021,11 @@ describe('Koa Server', () => {
   it('shutdown server', () => server.close());
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.get(path), expectedStatus);
   }
 
   function verifyPostRequest(path: string, data: any, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
-    return verifyRequest(verifyResponse, request => request.post(path).send(data), expectedStatus);
+    return verifyRequest(verifyResponse, (request) => request.post(path).send(data), expectedStatus);
   }
 
   function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {


### PR DESCRIPTION
It seems that validation for additionalProperties was removed here https://github.com/lukeautry/tsoa/commit/e41fdafc0ad3c77188500d7fdbe662399306bd9f

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [ ] This PR is associated with an existing issue?

