### PR TITLE
Nullable unions without enum

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -430,7 +430,7 @@ export class SpecGenerator3 extends SpecGenerator {
     if (types.size === 1) {
       const type = types.values().next().value;
       const nullable = enumType.enums.includes(null) ? true : false;
-      return { type, enum: enumType.enums.map(member => String(member)), nullable };
+      return { type, enum: enumType.enums.map(member => (member === null ? null : String(member))), nullable };
     } else {
       const valuesDelimited = Array.from(types).join(',');
       throw new Error(`Enums can only have string or number values, but enum had ${valuesDelimited}`);

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -394,6 +394,29 @@ export class SpecGenerator3 extends SpecGenerator {
   }
 
   protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
+    // use nullable: true to represent simple unions with null. This converts to
+    // a better type when using code generation in a client.
+    if (type.types.length === 2 && type.types.find(typeInUnion => typeInUnion.dataType === 'enum' && typeInUnion.enums.includes(null))) {
+      const nullEnumIndex = type.types.findIndex(type => type.dataType === 'enum' && type.enums.includes(null));
+      const typeIndex = nullEnumIndex === 1 ? 0 : 1;
+      const swaggerType = this.getSwaggerType(type.types[typeIndex]);
+
+      const isRef = !!swaggerType.$ref;
+
+      // let special case of ref union with null fall through to be handled as a
+      // oneOf. Example of this case is:
+      // type Nullable<T> = T | null;
+      // type MyNullableType = Nullable<OtherType>;
+      //
+      // this is required because other members of $ref containing objects are
+      // ignored so the null would otherwise get left out:
+      // https://swagger.io/docs/specification/using-ref/#syntax
+      if (!isRef) {
+        swaggerType['nullable'] = true;
+        return swaggerType;
+      }
+    }
+
     return { oneOf: type.types.map(x => this.getSwaggerType(x)) };
   }
 

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -222,7 +222,7 @@ export namespace Swagger {
     uniqueItems?: boolean;
     maxProperties?: number;
     minProperties?: number;
-    enum?: Array<string | number>;
+    enum?: Array<string | number | null>;
     items?: BaseSchema;
   }
 

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1194,11 +1194,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 maybeString: { $ref: '#/components/schemas/Maybe_string_', description: undefined, format: undefined, example: undefined },
                 wordOrNull: { $ref: '#/components/schemas/Maybe_Word_', description: undefined, format: undefined, example: undefined },
                 numberOrNull: {
-                  oneOf: [{ type: 'number', format: 'double' }, { type: 'number', enum: ['null'], nullable: true }],
-                  description: undefined,
-                  format: undefined,
                   default: undefined,
+                  description: undefined,
                   example: undefined,
+                  format: 'double',
+                  nullable: true,
+                  type: 'number',
                 },
                 justNull: {
                   default: undefined,
@@ -1216,7 +1217,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const maybeString = getComponentSchema('Maybe_string_', currentSpec);
             expect(maybeString).to.deep.eq(
-              { oneOf: [{ type: 'string' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
+              {
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+                nullable: true,
+                type: 'string',
+              },
               `for schema linked by property ${propertyName}`,
             );
 

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1205,7 +1205,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                   description: undefined,
                   example: undefined,
-                  enum: ['null'],
+                  enum: [null],
                   format: undefined,
                   nullable: true,
                   type: 'number',
@@ -1230,7 +1230,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const maybeWord = getComponentSchema('Maybe_Word_', currentSpec);
             expect(maybeWord).to.deep.eq(
-              { oneOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: ['null'], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
+              { oneOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: [null], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
               `for schema linked by property ${propertyName}`,
             );
           },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
* [x] Have you written unit tests?
* [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
* [x] This PR is associated with an existing issue?

**Closing issues**

closes #668 

**Related Issues**

relates to #479 

### If this is a new feature submission:

* [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

One issue with this approach is that typescript when compiled with strictNullChecks, appears to not allow enums with null value.  This feels like a typescript bug to me but I haven't been able to track it down.

**Test plan**
I updated existing unit tests to cover the new behavior.  I additionally experiment with code generated with the new changes when possible.  Code generation for oneOfs is not currently working with typescript-fetch generator.