### PR TITLE
Use anyOf for TS Unions

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -163,7 +163,7 @@ export class SpecGenerator3 extends SpecGenerator {
         } else {
           schema[referenceType.refName] = {
             description: referenceType.description,
-            oneOf: [
+            anyOf: [
               {
                 type: 'number',
                 enum: referenceType.enums.filter(e => typeof e === 'number'),
@@ -404,7 +404,7 @@ export class SpecGenerator3 extends SpecGenerator {
       const isRef = !!swaggerType.$ref;
 
       // let special case of ref union with null fall through to be handled as a
-      // oneOf. Example of this case is:
+      // anyOf. Example of this case is:
       // type Nullable<T> = T | null;
       // type MyNullableType = Nullable<OtherType>;
       //
@@ -417,7 +417,7 @@ export class SpecGenerator3 extends SpecGenerator {
       }
     }
 
-    return { oneOf: type.types.map(x => this.getSwaggerType(x)) };
+    return { anyOf: type.types.map(x => this.getSwaggerType(x)) };
   }
 
   protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType) {

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -229,7 +229,7 @@ export namespace Swagger {
   export interface Schema3 extends Omit<Schema, 'type'> {
     type?: DataType;
     nullable?: boolean;
-    oneOf?: BaseSchema[];
+    anyOf?: BaseSchema[];
     allOf?: BaseSchema[];
   }
 

--- a/tests/unit/swagger/parameterDetails3.spec.ts
+++ b/tests/unit/swagger/parameterDetails3.spec.ts
@@ -48,7 +48,7 @@ describe('Parameter generation for OpenAPI 3.0.0', () => {
 
         expect(bodySpec).to.deep.eq(
           {
-            oneOf: [
+            anyOf: [
               {
                 $ref: '#/components/schemas/ParameterTestModel',
               },

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -525,7 +525,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const componentSchema = getComponentSchema('StrLiteral', currentSpec);
             expect(componentSchema).to.deep.eq({
-              oneOf: [
+              anyOf: [
                 { type: 'string', enum: [''], nullable: false },
                 { type: 'string', enum: ['Foo'], nullable: false },
                 { type: 'string', enum: ['Bar'], nullable: false },
@@ -545,7 +545,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           unionPrimetiveType: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq({
-              oneOf: [
+              anyOf: [
                 { type: 'string', enum: ['String'], nullable: false },
                 { type: 'number', enum: ['1'], nullable: false },
                 { type: 'number', enum: ['20'], nullable: false },
@@ -719,7 +719,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           or: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.include(
               {
-                oneOf: [{ $ref: '#/components/schemas/TypeAliasModel1' }, { $ref: '#/components/schemas/TypeAliasModel2' }],
+                anyOf: [{ $ref: '#/components/schemas/TypeAliasModel1' }, { $ref: '#/components/schemas/TypeAliasModel2' }],
               },
               `for property ${propertyName}.$ref`,
             );
@@ -728,7 +728,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           mixedUnion: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.include(
               {
-                oneOf: [{ type: 'string' }, { $ref: '#/components/schemas/TypeAliasModel1' }],
+                anyOf: [{ type: 'string' }, { $ref: '#/components/schemas/TypeAliasModel1' }],
               },
               `for property ${propertyName}.$ref`,
             );
@@ -775,7 +775,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const unionAliasSchema = getComponentSchema('UnionAlias', currentSpec);
             expect(unionAliasSchema).to.deep.eq({
-              oneOf: [{ $ref: '#/components/schemas/TypeAliasModelCase2' }, { $ref: '#/components/schemas/TypeAliasModel2' }],
+              anyOf: [{ $ref: '#/components/schemas/TypeAliasModelCase2' }, { $ref: '#/components/schemas/TypeAliasModel2' }],
               description: undefined,
               example: undefined,
               default: undefined,
@@ -823,7 +823,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const forwardGenericAliasBooleanAndTypeAliasModel1Schema = getComponentSchema('ForwardGenericAlias_boolean.TypeAliasModel1_', currentSpec);
             expect(forwardGenericAliasBooleanAndTypeAliasModel1Schema).to.deep.eq({
-              oneOf: [{ $ref: '#/components/schemas/GenericAlias_TypeAliasModel1_' }, { type: 'boolean' }],
+              anyOf: [{ $ref: '#/components/schemas/GenericAlias_TypeAliasModel1_' }, { type: 'boolean' }],
               description: undefined,
               example: undefined,
               default: undefined,
@@ -1070,7 +1070,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             const excludeLiteral = getComponentSchema('Exclude_keyofTestClassModel.account-or-defaultValue2-or-indexedTypeToInterface-or-indexedTypeToClass-or-indexedTypeToAlias_', currentSpec);
             expect(excludeLiteral).to.deep.eq(
               {
-                oneOf: [
+                anyOf: [
                   { type: 'string', enum: ['id'], nullable: false },
                   { type: 'string', enum: ['enumKeys'], nullable: false },
                   { type: 'string', enum: ['keyInterface'], nullable: false },
@@ -1150,7 +1150,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     description: undefined,
                     format: undefined,
                     example: undefined,
-                    oneOf: [
+                    anyOf: [
                       { enum: ['OK'], nullable: false, type: 'string' },
                       { enum: ['KO'], nullable: false, type: 'string' },
                     ],
@@ -1272,7 +1272,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const maybeWord = getComponentSchema('Maybe_Word_', currentSpec);
             expect(maybeWord).to.deep.eq(
-              { oneOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: [null], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
+              { anyOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: [null], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
               `for schema linked by property ${propertyName}`,
             );
           },
@@ -1336,7 +1336,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       // Assert
       expect(getComponentSchema(schemaName, { specName: 'specDefault', spec })).to.deep.eq({
         description: undefined,
-        oneOf: [
+        anyOf: [
           { type: 'number', enum: [1, 3] },
           { type: 'string', enum: ['two', 'four'] },
         ],


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #671 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
If anyone was relying on this, admittedly suboptimal behavior, their code may break.

**Buy Why**
Our validation already does what `anyOf` should do. Also, it's a better reflection of TS Union checking as of right now.
