### PR TITLE
fix: validateError instanceof ValidateError should be true

### DIFF
--- a/src/routeGeneration/templateHelpers.ts
+++ b/src/routeGeneration/templateHelpers.ts
@@ -766,6 +766,7 @@ export class ValidateError extends Error implements Exception {
 
   constructor(public fields: FieldErrors, public message: string) {
     super(message);
+    Object.setPrototypeOf(this, ValidateError.prototype);
   }
 }
 

--- a/tests/unit/templating/templateHelpers.spec.ts
+++ b/tests/unit/templating/templateHelpers.spec.ts
@@ -5,6 +5,13 @@ import { AdditionalProps } from '../../../src/routeGeneration/routeGenerator';
 import { ValidateError } from '../../../src/routeGeneration/templateHelpers';
 import { TypeAliasModel1, TypeAliasModel2 } from '../../fixtures/testModel';
 
+it('ValidateError should be an instanceof ValidateError', () => {
+  const validateError = new ValidateError({}, '');
+
+  expect(validateError instanceof ValidateError).to.be.true;
+  expect(validateError instanceof Error).to.be.true;
+});
+
 it('should allow additionalProperties (on a union) if noImplicitAdditionalProperties is set to silently-remove-extras', () => {
   // Arrange
   const refName = 'ExampleModel';


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?

https://github.com/lukeautry/tsoa/pull/661 introduced an issue that affects TypeScript's transpilation of extending Error https://github.com/microsoft/TypeScript/issues/13965.

We can set the prototype manually and avoid headaches.