### PR TITLE
Routes: Load ioc module after controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "express": "^4.17.1",
     "husky": "^3.0.2",
     "inversify": "^5.0.1",
+    "inversify-binding-decorators": "^4.0.0",
     "koa": "^2.8.1",
     "koa-bodyparser": "^4.2.1",
     "lint-staged": "9.2.3",

--- a/src/routeGeneration/templates/express.hbs
+++ b/src/routeGeneration/templates/express.hbs
@@ -6,15 +6,15 @@
 {{else}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
-{{#if iocModule}}
-import { iocContainer } from '{{iocModule}}';
-{{/if}}
 {{#each controllers}}
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { expressAuthentication } from '{{authenticationModule}}';
+{{/if}}
+{{#if iocModule}}
+import { iocContainer } from '{{iocModule}}';
 {{/if}}
 import * as express from 'express';
 

--- a/src/routeGeneration/templates/hapi.hbs
+++ b/src/routeGeneration/templates/hapi.hbs
@@ -6,15 +6,15 @@
 {{else}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
-{{#if iocModule}}
-import { iocContainer } from '{{iocModule}}';
-{{/if}}
 {{#each controllers}}
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { hapiAuthentication } from '{{authenticationModule}}';
+{{/if}}
+{{#if iocModule}}
+import { iocContainer } from '{{iocModule}}';
 {{/if}}
 import { boomify, Payload } from '@hapi/boom';
 

--- a/src/routeGeneration/templates/koa.hbs
+++ b/src/routeGeneration/templates/koa.hbs
@@ -6,15 +6,15 @@
 {{else}}
   import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute } from '../../../src';
 {{/if}}
-{{#if iocModule}}
-import { iocContainer } from '{{iocModule}}';
-{{/if}}
 {{#each controllers}}
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { koaAuthentication } from '{{authenticationModule}}';
+{{/if}}
+{{#if iocModule}}
+import { iocContainer } from '{{iocModule}}';
 {{/if}}
 import * as KoaRouter from '@koa/router';
 

--- a/tests/fixtures/inversify-cpg/authentication.ts
+++ b/tests/fixtures/inversify-cpg/authentication.ts
@@ -1,0 +1,9 @@
+import * as express from 'express';
+
+export function expressAuthentication(req: express.Request, name: string, scopes?: string[]): Promise<any> {
+  if (req.query && req.query.tsoa && req.query.tsoa === 'abc123456') {
+    return Promise.resolve({});
+  } else {
+    return Promise.reject({});
+  }
+}

--- a/tests/fixtures/inversify-cpg/ioc.ts
+++ b/tests/fixtures/inversify-cpg/ioc.ts
@@ -1,0 +1,8 @@
+import { Container } from 'inversify';
+import { buildProviderModule } from 'inversify-binding-decorators';
+
+const iocContainer = new Container();
+
+iocContainer.load(buildProviderModule());
+
+export { iocContainer };

--- a/tests/fixtures/inversify-cpg/managedController.ts
+++ b/tests/fixtures/inversify-cpg/managedController.ts
@@ -1,0 +1,17 @@
+import { inject } from 'inversify';
+import { Get, Route, Security } from '../../../src';
+import { TestModel } from '../testModel';
+import { ManagedService } from './managedService';
+import { provideSingleton } from './provideSingleton';
+
+@provideSingleton(ManagedController)
+@Route('ManagedTest')
+@Security('MySecurity')
+export class ManagedController {
+  constructor(@inject(ManagedService) private managedService: ManagedService) {}
+
+  @Get()
+  public async getModel(): Promise<TestModel> {
+    return this.managedService.getModel();
+  }
+}

--- a/tests/fixtures/inversify-cpg/managedService.ts
+++ b/tests/fixtures/inversify-cpg/managedService.ts
@@ -1,0 +1,39 @@
+import { provide } from 'inversify-binding-decorators';
+import { TestModel, TestSubModel } from '../testModel';
+
+@provide(ManagedService)
+export class ManagedService {
+  public getModel(): TestModel {
+    return {
+      and: { value1: 'foo', value2: 'bar' },
+      boolArray: [true, false],
+      boolValue: true,
+      id: 1,
+      modelValue: {
+        email: 'test@test.com',
+        id: 100,
+      },
+      modelsArray: new Array<TestSubModel>(),
+      numberArray: [1, 2, 3],
+      numberValue: 1,
+      objLiteral: {
+        name: 'hello',
+      },
+      object: {
+        a: 'a',
+      },
+      objectArray: [
+        {
+          a: 'a',
+        },
+      ],
+      optionalString: 'optional string',
+      or: { value1: 'foo', value2: 'bar' },
+      referenceAnd: { value1: 'foo', value2: 'bar' },
+      strLiteralArr: ['Foo', 'Bar'],
+      strLiteralVal: 'Foo',
+      stringArray: ['string one', 'string two'],
+      stringValue: 'a string',
+    };
+  }
+}

--- a/tests/fixtures/inversify-cpg/provideSingleton.ts
+++ b/tests/fixtures/inversify-cpg/provideSingleton.ts
@@ -1,0 +1,6 @@
+import { fluentProvide } from 'inversify-binding-decorators';
+import { interfaces } from 'inversify';
+
+export const provideSingleton = function <T>(identifier: interfaces.ServiceIdentifier<T>) {
+  return fluentProvide(identifier).inSingletonScope().done();
+};

--- a/tests/fixtures/inversify-cpg/server.ts
+++ b/tests/fixtures/inversify-cpg/server.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as methodOverride from 'method-override';
+
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(methodOverride());
+RegisterRoutes(app);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(err.status || 500).send(err.message || 'An error occurred during the request.');
+});
+
+app.listen(3009);

--- a/tests/integration/inversify-glob.spec.ts
+++ b/tests/integration/inversify-glob.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { app } from '../fixtures/inversify-cpg/server';
+import { TestModel } from '../fixtures/testModel';
+
+const basePath = '/v1';
+
+describe('Inversify Express Server with ControllerPathGlob', () => {
+  it('can handle get request with no path argument', () => {
+    return verifyGetRequest(basePath + '/ManagedTest?tsoa=abc123456', (_err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  it('handles request with managed controller using managed service', () => {
+    return verifyGetRequest(basePath + '/ManagedTest?tsoa=abc123456', (_err, res) => {
+      const model = res.body as TestModel;
+      // expect controller to use the same service
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error as any);
+          } catch (err) {
+            parsedError = res.error as any;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -138,5 +138,17 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         routesDir: './tests/fixtures/inversify',
       }),
     ),
+    log('Inversify(-binding-decorators) with ControllerPathGlob Route Generation', () =>
+      generateRoutes({
+        controllerPathGlobs: ['tests/fixtures/inversify-cpg/*Controller.ts'],
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        authenticationModule: './tests/fixtures/inversify-cpg/authentication.ts',
+        basePath: '/v1',
+        entryFile: '',
+        iocModule: './tests/fixtures/inversify-cpg/ioc.ts',
+        middleware: 'express',
+        routesDir: './tests/fixtures/inversify-cpg',
+      }),
+    ),
   ]);
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,6 +1699,11 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
+inversify-binding-decorators@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/inversify-binding-decorators/-/inversify-binding-decorators-4.0.0.tgz#c4d1ac50d7d6531f465ee7894e92031f7471c865"
+  integrity sha512-r8au/oH3vS7ttHj0RivAznwElySeRohLfg8lvOSzbrX6abf/8ik8ptk49XbzdShgrnalvl7CM6MjcskfM7MMqQ==
+
 inversify@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"


### PR DESCRIPTION
# All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

Closes #252

I'll update the docs/guide separately, but this adds tests based on the current API of inversify-binding-decorators 

**Description**

If you are using inversify binding decorators, controllers must be in scope in order to be injected.
In case you're using controllerPathGlobs, you usually are not bringing them into scope manually, but 
 tsoa does.
If we load the iocModule first, it'll be built before controllers discovered automatically by the glob are in scope and not able to provide the controllers.

**Test plan**

Added a new express server with inverify and inversify-binding-decorators + tests.