### PR TITLE
Add ability to define same responses for all methods in controller.

### DIFF
--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -46,7 +46,7 @@ export class ControllerGenerator {
   private buildMethods() {
     return this.node.members
       .filter(m => m.kind === ts.SyntaxKind.MethodDeclaration)
-      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.tags, this.security, this.isHidden, this.commonResponses))
+      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.commonResponses, this.tags, this.security, this.isHidden))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
   }
@@ -77,7 +77,7 @@ export class ControllerGenerator {
 
       const [name, description, examples] = getDecoratorValues(decorator, this.current.typeChecker);
       if (!name) {
-        throw new GenerateMetadataError(`Controller's responses should has explicit name.`);
+        throw new GenerateMetadataError(`Controller's responses should have an explicit name.`);
       }
 
       return {

--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -1,21 +1,24 @@
 import * as ts from 'typescript';
-import { getDecorators, getSecurites } from './../utils/decoratorUtils';
+import { getDecorators, getDecoratorValues, getSecurites } from './../utils/decoratorUtils';
 import { GenerateMetadataError } from './exceptions';
 import { MetadataGenerator } from './metadataGenerator';
 import { MethodGenerator } from './methodGenerator';
 import { Tsoa } from './tsoa';
+import { TypeResolver } from './typeResolver';
 
 export class ControllerGenerator {
   private readonly path?: string;
   private readonly tags?: string[];
   private readonly security?: Tsoa.Security[];
   private readonly isHidden?: boolean;
+  private readonly commonResponses: Tsoa.Response[];
 
   constructor(private readonly node: ts.ClassDeclaration, private readonly current: MetadataGenerator) {
     this.path = this.getPath();
     this.tags = this.getTags();
     this.security = this.getSecurity();
     this.isHidden = this.getIsHidden();
+    this.commonResponses = this.getCommonResponses();
   }
 
   public IsValid() {
@@ -43,7 +46,7 @@ export class ControllerGenerator {
   private buildMethods() {
     return this.node.members
       .filter(m => m.kind === ts.SyntaxKind.MethodDeclaration)
-      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.tags, this.security, this.isHidden))
+      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.tags, this.security, this.isHidden, this.commonResponses))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
   }
@@ -61,6 +64,29 @@ export class ControllerGenerator {
     const expression = decorator.parent as ts.CallExpression;
     const decoratorArgument = expression.arguments[0] as ts.StringLiteral;
     return decoratorArgument ? `${decoratorArgument.text}` : '';
+  }
+
+  private getCommonResponses(): Tsoa.Response[] {
+    const decorators = getDecorators(this.node, identifier => identifier.text === 'Response');
+    if (!decorators || !decorators.length) {
+      return [];
+    }
+
+    return decorators.map(decorator => {
+      const expression = decorator.parent as ts.CallExpression;
+
+      const [name, description, examples] = getDecoratorValues(decorator, this.current.typeChecker);
+      if (!name) {
+        throw new GenerateMetadataError(`Controller's responses should has explicit name.`);
+      }
+
+      return {
+        description: description || '',
+        examples,
+        name,
+        schema: expression.typeArguments && expression.typeArguments.length > 0 ? new TypeResolver(expression.typeArguments[0], this.current).resolve() : undefined,
+      } as Tsoa.Response;
+    });
   }
 
   private getTags() {

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -16,10 +16,10 @@ export class MethodGenerator {
   constructor(
     private readonly node: ts.MethodDeclaration,
     private readonly current: MetadataGenerator,
+    private readonly commonResponses: Tsoa.Response[],
     private readonly parentTags?: string[],
     private readonly parentSecurity?: Tsoa.Security[],
     private readonly isParentHidden?: boolean,
-    private readonly commonResponses?: Tsoa.Response[],
   ) {
     this.processMethodDecorators();
   }
@@ -41,7 +41,7 @@ export class MethodGenerator {
       nodeType = typeChecker.typeToTypeNode(implicitType) as ts.TypeNode;
     }
     const type = new TypeResolver(nodeType, this.current).resolve();
-    const responses = this.commonResponses ? this.commonResponses.concat(this.getMethodResponses()) : this.getMethodResponses();
+    const responses = this.commonResponses.concat(this.getMethodResponses());
     responses.push(this.getMethodSuccessResponse(type));
 
     return {

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -19,6 +19,7 @@ export class MethodGenerator {
     private readonly parentTags?: string[],
     private readonly parentSecurity?: Tsoa.Security[],
     private readonly isParentHidden?: boolean,
+    private readonly commonResponses?: Tsoa.Response[],
   ) {
     this.processMethodDecorators();
   }
@@ -40,7 +41,7 @@ export class MethodGenerator {
       nodeType = typeChecker.typeToTypeNode(implicitType) as ts.TypeNode;
     }
     const type = new TypeResolver(nodeType, this.current).resolve();
-    const responses = this.getMethodResponses();
+    const responses = this.commonResponses ? this.commonResponses.concat(this.getMethodResponses()) : this.getMethodResponses();
     responses.push(this.getMethodSuccessResponse(type));
 
     return {

--- a/tests/fixtures/controllers/controllerWithCommonResponses.ts
+++ b/tests/fixtures/controllers/controllerWithCommonResponses.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Response, Post, Route } from '../../../src';
 import { ModelService } from '../services/modelService';
-import { TestModel } from '../testModel';
+import { ErrorResponseModel, TestModel } from '../testModel';
 
 @Route('Controller')
-@Response('401', 'Unauthorized')
+@Response<ErrorResponseModel>('401', 'Unauthorized')
 export class HiddenMethodController extends Controller {
   @Get('protectedGetMethod')
   public async protectedGetMethod(): Promise<TestModel> {

--- a/tests/fixtures/controllers/controllerWithCommonResponses.ts
+++ b/tests/fixtures/controllers/controllerWithCommonResponses.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Response, Post, Route } from '../../../src';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+@Route('Controller')
+@Response('401', 'Unauthorized')
+export class HiddenMethodController extends Controller {
+  @Get('protectedGetMethod')
+  public async protectedGetMethod(): Promise<TestModel> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+  @Post('protectedPostMethod')
+  public async protectedPostMethod(): Promise<TestModel> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+}

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -145,8 +145,9 @@ export class MethodController extends Controller {
   }
 
   @Get('returnAliasedVoidType')
-  // tslint:disable-next-line:no-empty
-  public async returnAliasedVoidType(): Promise<VoidAlias1> {}
+  public async returnAliasedVoidType(): Promise<VoidAlias1> {
+    return;
+  }
 }
 
 type VoidAlias1 = VoidAlias2;

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -145,6 +145,7 @@ export class MethodController extends Controller {
   }
 
   @Get('returnAliasedVoidType')
+  // tslint:disable-next-line:no-empty
   public async returnAliasedVoidType(): Promise<VoidAlias1> {}
 }
 

--- a/tests/fixtures/inversify-cpg/provideSingleton.ts
+++ b/tests/fixtures/inversify-cpg/provideSingleton.ts
@@ -1,6 +1,6 @@
 import { fluentProvide } from 'inversify-binding-decorators';
 import { interfaces } from 'inversify';
 
-export const provideSingleton = function <T>(identifier: interfaces.ServiceIdentifier<T>) {
+export const provideSingleton = <T>(identifier: interfaces.ServiceIdentifier<T>) => {
   return fluentProvide(identifier).inSingletonScope().done();
 };

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -182,7 +182,7 @@ describe('Metadata generation', () => {
 
       const security = method.security[0];
       expect(security).to.haveOwnProperty('JWT2');
-      expect(security['JWT2']).to.deep.equal(['permission:admin', 'permission:owner']);
+      expect(security.JWT2).to.deep.equal(['permission:admin', 'permission:owner']);
 
       const objSecurity = method.security[1];
       expect(objSecurity).to.deep.equal({

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -651,6 +651,22 @@ describe('Metadata generation', () => {
     });
   });
 
+  describe('ControllerWithCommonResponsesGenerator', () => {
+    const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/controllerWithCommonResponses.ts').Generate();
+    const controller = parameterMetadata.controllers[0];
+
+    it('should add common responses to every method', () => {
+      expect(controller.methods).to.have.lengthOf(2);
+      controller.methods.forEach(method => {
+        expect(method.responses.length).to.equal(2);
+
+        const response = method.responses[0];
+        expect(response.name).to.equal('401');
+        expect(response.description).to.equal('Unauthorized');
+      });
+    });
+  });
+
   describe('DeprecatedMethodGenerator', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/deprecatedController.ts').Generate();
     const controller = parameterMetadata.controllers[0];

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -660,9 +660,13 @@ describe('Metadata generation', () => {
       controller.methods.forEach(method => {
         expect(method.responses.length).to.equal(2);
 
-        const response = method.responses[0];
+        let response = method.responses[0];
         expect(response.name).to.equal('401');
         expect(response.description).to.equal('Unauthorized');
+
+        response = method.responses[1];
+        expect(response.name).to.equal('200');
+        expect(response.description).to.equal('Ok');
       });
     });
   });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #680 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
Why this approach? Seems like sometimes need to define the same responses for all methods in controller, e.g. when they require authorization. For now it is possible only to define all responces manually. It is not handy and may proceed human error (e.g. to forgot to define responce for new method). 

Solution: Ability to define common responses in controller on route level, which common responce should has `name`, otherwise error will be created. All common responses merges with method's personal responses.
<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

I don't understand exactly where and what test, please point me what to do if i miss something.
