### PR TITLE
feature/665 - Add NoSecurity decorator

### DIFF
--- a/src/decorators/security.ts
+++ b/src/decorators/security.ts
@@ -1,4 +1,13 @@
 /**
+ * Can be used to indicate that a method requires no security.
+ */
+export function NoSecurity(): Function {
+  return () => {
+    return;
+  };
+}
+
+/**
  * @param {name} security name from securityDefinitions
  */
 export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): Function {

--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -79,7 +79,13 @@ export class ControllerGenerator {
   }
 
   private getSecurity(): Tsoa.Security[] {
+    const noSecurityDecorators = getDecorators(this.node, identifier => identifier.text === 'NoSecurity');
     const securityDecorators = getDecorators(this.node, identifier => identifier.text === 'Security');
+
+    if (noSecurityDecorators?.length) {
+      throw new GenerateMetadataError(`NoSecurity decorator is unnecessary in '${this.node.name!.text}' class.`);
+    }
+
     if (!securityDecorators || !securityDecorators.length) {
       return [];
     }

--- a/src/metadataGeneration/methodGenerator.ts
+++ b/src/metadataGeneration/methodGenerator.ts
@@ -217,7 +217,21 @@ export class MethodGenerator {
   }
 
   private getSecurity(): Tsoa.Security[] {
+    const noSecurityDecorators = this.getDecoratorsByIdentifier(this.node, 'NoSecurity');
     const securityDecorators = this.getDecoratorsByIdentifier(this.node, 'Security');
+
+    if (noSecurityDecorators?.length > 1) {
+      throw new GenerateMetadataError(`Only one NoSecurity decorator allowed in '${this.getCurrentLocation}' method.`);
+    }
+
+    if (noSecurityDecorators?.length && securityDecorators?.length) {
+      throw new GenerateMetadataError(`NoSecurity decorator cannot be used in conjunction with Security decorator in '${this.getCurrentLocation}' method.`);
+    }
+
+    if (noSecurityDecorators?.length) {
+      return [];
+    }
+
     if (!securityDecorators || !securityDecorators.length) {
       return this.parentSecurity || [];
     }

--- a/tests/fixtures/controllers/noSecurityController.ts
+++ b/tests/fixtures/controllers/noSecurityController.ts
@@ -1,0 +1,30 @@
+import { Get, Request, Response, Route, Security, NoSecurity } from '../../../src';
+import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
+
+interface RequestWithUser {
+  user?: any;
+}
+
+@Security('tsoa_auth', ['write:pets', 'read:pets'])
+@Route('NoSecurityTest')
+export class NoSecurityTestController {
+  @Response<ErrorResponseModel>('default', 'Unexpected error')
+  @Security('api_key')
+  @Get()
+  public async GetWithApi(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Get('Oauth')
+  public async GetWithImplicitSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Get('Anonymous')
+  @NoSecurity()
+  public async GetWithNoSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+}

--- a/tests/unit/swagger/pathGeneration/noSecurityRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/noSecurityRoutes.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import 'mocha';
+import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
+import { SpecGenerator2 } from '../../../../src/swagger/specGenerator2';
+import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
+import { VerifyPath } from '../../utilities/verifyPath';
+
+describe('NoSecurity route generation', () => {
+  const metadata = new MetadataGenerator('./tests/fixtures/controllers/noSecurityController.ts').Generate();
+  const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+  it('should generate a route with a named security', () => {
+    const path = verifyPath('/NoSecurityTest');
+
+    if (!path.get) {
+      throw new Error('No get operation.');
+    }
+
+    expect(path.get.security).to.deep.equal([{ api_key: [] }]);
+  });
+
+  it('should generate a route with scoped security', () => {
+    const path = verifyPath('/NoSecurityTest/Oauth');
+
+    if (!path.get) {
+      throw new Error('No get operation.');
+    }
+
+    expect(path.get.security).to.deep.equal([{ tsoa_auth: ['write:pets', 'read:pets'] }]);
+  });
+
+  it('should generate a route with no security', () => {
+    const path = verifyPath('/NoSecurityTest/Anonymous');
+
+    if (!path.get) {
+      throw new Error('No get operation.');
+    }
+
+    expect(path.get.security).to.deep.equal([]);
+  });
+
+  function verifyPath(route: string, isCollection?: boolean) {
+    return VerifyPath(spec, route, path => path.get, isCollection, false, '#/definitions/UserResponseModel');
+  }
+});


### PR DESCRIPTION
Resolves feature request #665 by adding a `NoSecurity` decorator that can be used to override the `Security` decorator on a class.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

The `noSecurityDecorators` variable name could be seen as a little ambiguous, but is not publicly visible.

**Test plan**

~~Tests will be added once the maintainers are happy with my approach in the PR (and I get to grips with these unit tests).~~ Ones I can think of are:

- [x] `MethodGenerator.getSecurity` returns empty array when `NoSecurity` decorator is used.

I can't seem to find any way of testing invalid decorator usage, but have verified that the following errors are thrown as expected.
- [ ] `ControllerGenerator.getSecurity` throws when a `NoSecurity` decorator is used.
- [ ] `MethodGenerator.getSecurity` throws when multiple `NoSecurity` decorators are used.
- [ ] `MethodGenerator.getSecurity` throws when `NoSecurity` and `Security` decorators are used.
