### PR TITLE
Feat: Support multiple @example at method comment

### DIFF
--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -193,11 +193,7 @@ export class ParameterGenerator {
       return undefined;
     } else {
       try {
-        if (examples.length === 1) {
-          return JSON.parse(examples[0]);
-        } else {
-          return examples.map(example => JSON.parse(example));
-        }
+        return examples.map(example => JSON.parse(example));
       } catch (e) {
         throw new GenerateMetadataError(`JSON format is incorrect: ${e.message}`);
       }

--- a/src/metadataGeneration/parameterGenerator.ts
+++ b/src/metadataGeneration/parameterGenerator.ts
@@ -185,16 +185,22 @@ export class ParameterGenerator {
   }
 
   private getParameterExample(node: ts.ParameterDeclaration, parameterName: string) {
-    const example = getJSDocTags(node.parent, tag => tag.tagName.text === 'example' && !!tag.comment && tag.comment.startsWith(parameterName)).map(tag => (tag.comment || '').split(' ')[1])[0];
+    const examples = getJSDocTags(node.parent, tag => (tag.tagName.text === 'example' || tag.tagName.escapedText === 'example') && !!tag.comment && tag.comment.startsWith(parameterName)).map(tag =>
+      (tag.comment || '').replace(`${parameterName} `, '').replace(/\r/g, ''),
+    );
 
-    if (example) {
-      try {
-        return JSON.parse(example);
-      } catch {
-        return undefined;
-      }
-    } else {
+    if (examples.length === 0) {
       return undefined;
+    } else {
+      try {
+        if (examples.length === 1) {
+          return JSON.parse(examples[0]);
+        } else {
+          return examples.map(example => JSON.parse(example));
+        }
+      } catch (e) {
+        throw new GenerateMetadataError(`JSON format is incorrect: ${e.message}`);
+      }
     }
   }
 

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -29,7 +29,7 @@ export namespace Tsoa {
 
   export interface Parameter {
     parameterName: string;
-    example?: unknown;
+    example?: unknown[];
     description?: string;
     in: 'query' | 'header' | 'path' | 'formData' | 'body' | 'body-prop' | 'request';
     name: string;

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -205,7 +205,7 @@ export class SpecGenerator2 extends SpecGenerator {
         properties[p.name] = this.getSwaggerType(p.type) as Swagger.Schema2;
         properties[p.name].default = p.default;
         properties[p.name].description = p.description;
-        properties[p.name].example = p.example;
+        properties[p.name].example = p.example === undefined ? undefined : p.example[0];
 
         if (p.required) {
           required.push(p.name);
@@ -235,7 +235,6 @@ export class SpecGenerator2 extends SpecGenerator {
     let parameter = {
       default: source.default,
       description: source.description,
-      example: source.example,
       in: source.in,
       name: source.name,
       required: source.required,

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -304,6 +304,16 @@ export class SpecGenerator3 extends SpecGenerator {
       },
     };
 
+    const parameterExamples = parameter.example as any[];
+    if (parameterExamples === undefined) {
+      mediaType.example = parameterExamples;
+    } else if (parameterExamples.length === 1) {
+      mediaType.example = parameterExamples[0];
+    } else {
+      mediaType.examples = {};
+      parameterExamples.forEach((example, index) => Object.assign(mediaType.examples, { [`Example ${index + 1}`]: { value: example } }));
+    }
+
     const requestBody: Swagger.RequestBody = {
       description: parameter.description,
       required: parameter.required,
@@ -318,7 +328,6 @@ export class SpecGenerator3 extends SpecGenerator {
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter {
     const parameter = {
       description: source.description,
-      example: source.example,
       in: source.in,
       name: source.name,
       required: source.required,
@@ -358,6 +367,16 @@ export class SpecGenerator3 extends SpecGenerator {
     }
 
     parameter.schema = Object.assign({}, parameter.schema, validatorObjs);
+
+    const parameterExamples = source.example as any[];
+    if (parameterExamples === undefined) {
+      parameter.example = parameterExamples;
+    } else if (parameterExamples.length === 1) {
+      parameter.example = parameterExamples[0];
+    } else {
+      parameter.examples = {};
+      parameterExamples.forEach((example, index) => Object.assign(parameter.examples, { [`Example ${index + 1}`]: { value: example } }));
+    }
 
     return parameter;
   }

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -275,7 +275,7 @@ export class SpecGenerator3 extends SpecGenerator {
       }
       if (res.examples) {
         /* tslint:disable:no-string-literal */
-        (swaggerResponses[res.name].content || {})['application/json']['examples'] = { example: { value: res.examples } };
+        (swaggerResponses[res.name].content || {})['application/json']['examples'] = { example: { value: res.examples } as Swagger.Example3 };
       }
     });
 
@@ -304,14 +304,18 @@ export class SpecGenerator3 extends SpecGenerator {
       },
     };
 
-    const parameterExamples = parameter.example as any[];
+    const parameterExamples = parameter.example;
     if (parameterExamples === undefined) {
       mediaType.example = parameterExamples;
     } else if (parameterExamples.length === 1) {
       mediaType.example = parameterExamples[0];
     } else {
       mediaType.examples = {};
-      parameterExamples.forEach((example, index) => Object.assign(mediaType.examples, { [`Example ${index + 1}`]: { value: example } }));
+      parameterExamples.forEach((example, index) =>
+        Object.assign(mediaType.examples, {
+          [`Example ${index + 1}`]: { value: example } as Swagger.Example3,
+        }),
+      );
     }
 
     const requestBody: Swagger.RequestBody = {
@@ -368,14 +372,18 @@ export class SpecGenerator3 extends SpecGenerator {
 
     parameter.schema = Object.assign({}, parameter.schema, validatorObjs);
 
-    const parameterExamples = source.example as any[];
+    const parameterExamples = source.example;
     if (parameterExamples === undefined) {
       parameter.example = parameterExamples;
     } else if (parameterExamples.length === 1) {
       parameter.example = parameterExamples[0];
     } else {
       parameter.examples = {};
-      parameterExamples.forEach((example, index) => Object.assign(parameter.examples, { [`Example ${index + 1}`]: { value: example } }));
+      parameterExamples.forEach((example, index) =>
+        Object.assign(parameter.examples, {
+          [`Example ${index + 1}`]: { value: example } as Swagger.Example3,
+        }),
+      );
     }
 
     return parameter;

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -92,6 +92,7 @@ export namespace Swagger {
     required?: boolean;
     description?: string;
     example?: unknown;
+    examples?: unknown;
     schema: Schema;
     type: DataType;
     format?: DataFormat;

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -37,7 +37,7 @@ export namespace Swagger {
 
   export interface Components {
     callbacks?: { [name: string]: any };
-    examples?: { [name: string]: any };
+    examples?: { [name: string]: Example3 | string };
     headers?: { [name: string]: any };
     links?: { [name: string]: any };
     parameters?: { [name: string]: Parameter };
@@ -83,7 +83,13 @@ export namespace Swagger {
   }
 
   export interface Example {
-    [name: string]: any;
+    [mediaType: string]: unknown;
+  }
+
+  export interface Example3 {
+    value: unknown;
+    summary?: string;
+    description?: string;
   }
 
   export interface BaseParameter extends BaseSchema {
@@ -92,7 +98,7 @@ export namespace Swagger {
     required?: boolean;
     description?: string;
     example?: unknown;
-    examples?: unknown;
+    examples?: { [name: string]: Example3 | string };
     schema: Schema;
     type: DataType;
     format?: DataFormat;
@@ -185,8 +191,8 @@ export namespace Swagger {
 
   export interface MediaType {
     schema?: Schema3;
-    example?: { [name: string]: any };
-    examples?: { [name: string]: any };
+    example?: unknown;
+    examples?: { [name: string]: Example3 | string };
     encoding?: { [name: string]: any };
   }
 
@@ -194,7 +200,7 @@ export namespace Swagger {
     description: string;
     schema?: Schema;
     headers?: { [name: string]: Header };
-    examples?: { [name: string]: Example };
+    examples?: Example;
   }
 
   export interface Response3 {

--- a/tests/fixtures/controllers/exampleController.ts
+++ b/tests/fixtures/controllers/exampleController.ts
@@ -1,0 +1,36 @@
+import { Post, Route, Body, Path } from '../../../src';
+
+/**
+ * @example {
+ *  "contry": "123",
+ *  "city": "456"
+ * }
+ */
+export interface Location {
+  contry: string;
+  city: string;
+}
+
+@Route('ExampleTest')
+export class ExampleTestController {
+  /**
+   * @example location {
+   *  "contry": "1",
+   *  "city": "1"
+   * }
+   * @example location {
+   *  "contry": "2",
+   *  "city": "2"
+   * }
+   * @example s "aa0"
+   * @example s "aa1"
+   * @example s "aa2"
+   */
+  @Post('Example/{s}')
+  public async example(@Body() location: Location, @Path() s: string): Promise<Location> {
+    return {
+      contry: '123',
+      city: '456',
+    };
+  }
+}

--- a/tests/fixtures/controllers/exampleController.ts
+++ b/tests/fixtures/controllers/exampleController.ts
@@ -1,4 +1,4 @@
-import { Post, Route, Body, Path } from '../../../src';
+import { Post, Route, Body, Path, Get, Query, Header, BodyProp } from '../../../src';
 
 /**
  * @example {
@@ -14,6 +14,61 @@ export interface Location {
 @Route('ExampleTest')
 export class ExampleTestController {
   /**
+   * @example path "an_example_path"
+   * @example path "an_example_path2"
+   */
+  @Get('/path/{path}')
+  public async path(@Path() path: string): Promise<void> {
+    return;
+  }
+
+  /**
+   * @example query "an_example_query"
+   * @example query "an_example_query2"
+   */
+  @Get('/query')
+  public async query(@Query() query: string): Promise<void> {
+    return;
+  }
+
+  /**
+   * @example header "aaaaaaLongCookie"
+   * @example header "aaaaaaLongCookie2"
+   */
+  @Get('/header')
+  public async header(@Header() header: string): Promise<void> {
+    return;
+  }
+
+  /**
+   * @example location {
+   *  "contry": "1",
+   *  "city": "1"
+   * }
+   * @example location {
+   *  "contry": "2",
+   *  "city": "2"
+   * }
+   */
+  @Post('/post_body')
+  public async post(@Body() location: Location): Promise<void> {
+    return;
+  }
+
+  /**
+   * @example prop1 "prop1_1"
+   * @example prop1 "prop1_2"
+   * @example prop1 "prop1_3"
+   * @example prop2 "prop2_1"
+   * @example prop2 "prop2_2"
+   * @example prop2 "prop2_3"
+   */
+  @Post('/post_body_prop')
+  public async postBodyProp(@BodyProp() prop1: string, @BodyProp() prop2: string): Promise<void> {
+    return;
+  }
+
+  /**
    * @example location {
    *  "contry": "1",
    *  "city": "1"
@@ -26,11 +81,36 @@ export class ExampleTestController {
    * @example s "aa1"
    * @example s "aa2"
    */
-  @Post('Example/{s}')
-  public async example(@Body() location: Location, @Path() s: string): Promise<Location> {
-    return {
-      contry: '123',
-      city: '456',
-    };
+  @Post('/two_parameter/{s}')
+  public async twoParameter(@Body() location: Location, @Path() s: string): Promise<void> {
+    return;
+  }
+
+  /**
+   *
+   * @example locations [
+   *  {
+   *    "contry": "1",
+   *    "city": "1"
+   *  },
+   *  {
+   *    "contry": "2",
+   *    "city": "2"
+   *  }
+   * ]
+   * @example locations [
+   *  {
+   *    "contry": "22",
+   *    "city": "22"
+   *  },
+   *  {
+   *    "contry": "33",
+   *    "city": "33"
+   *  }
+   * ]
+   */
+  @Post('/array_with_object')
+  public async arrayWithObject(@Body() locations: Location[]): Promise<void> {
+    return;
   }
 }

--- a/tests/fixtures/controllers/invalidExampleController.ts
+++ b/tests/fixtures/controllers/invalidExampleController.ts
@@ -1,0 +1,15 @@
+import { Route, Controller, Post, Body } from '../../../src';
+
+@Route('ExampleTest')
+export class InvalidExampleController extends Controller {
+  /**
+   * @example body {
+   *  "this": is,
+   *  a: wrong-format,
+   * }
+   */
+  @Post('WrongJSON-Format')
+  public async WrongJSONFormat(@Body() body: { name: string; index: number }): Promise<void> {
+    return;
+  }
+}

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -4,7 +4,33 @@ import { Gender, ParameterTestModel } from '../testModel';
 @Route('ParameterTest')
 export class ParameterController {
   /**
-   * Get test paramater
+   * Example test parameter
+   *
+   * @example firstname "name1"
+   * @example firstname "name2"
+   * @example lastname "lastname"
+   * @example gender {
+   *  "MALE": "MALE",
+   *  "FEMALE": "FEMALE"
+   * }
+   * @example gender {
+   *  "MALE": "MALE2",
+   *  "FEMALE": "FEMALE2"
+   * }
+   * @example nicknames [
+   * "name1", "name2"
+   * ]
+   * @example nicknames [
+   *  "name2_1", "name2_2"
+   * ]
+   */
+  @Post('Example/{firstname}')
+  public async example(@Path() firstname: string, @Query() lastname: string, @Body() gender: Gender, @Query() nicknames: string[]): Promise<void> {
+    return;
+  }
+
+  /**
+   * Query test paramater
    *
    * @param {string} firstname Firstname description
    * @param {string} lastname Lastname description
@@ -16,6 +42,9 @@ export class ParameterController {
    *
    * @isInt age
    * @isFloat weight
+   *
+   * @example lastname "name1"
+   * @example lastname "name2"
    */
   @Get('Query')
   public async getQuery(
@@ -50,6 +79,9 @@ export class ParameterController {
    *
    * @isInt age
    * @isFloat weight
+   *
+   * @example lastname "name1"
+   * @example lastname "name2"
    */
   @Get('Path/{firstname}/{last_name}/{age}/{weight}/{human}/{gender}')
   public async getPath(
@@ -113,6 +145,9 @@ export class ParameterController {
    *
    * @isInt age
    * @isFloat weight
+   *
+   * @example lastname "name1"
+   * @example lastname "name2"
    */
   @Get('Header')
   public async getHeader(
@@ -154,6 +189,17 @@ export class ParameterController {
    * Body test paramater
    *
    * @param {object} body Body description
+   *
+   * @example body {
+   *  "firstname": "first1",
+   *  "lastname": "last1",
+   *  "age": 1
+   * }
+   * @example body {
+   *  "firstname": "first2",
+   *  "lastname": "last2",
+   *  "age": 2
+   * }
    */
   @Post('Body')
   public async getBody(@Body() body: ParameterTestModel): Promise<ParameterTestModel> {
@@ -189,6 +235,9 @@ export class ParameterController {
    *
    * @isInt age
    * @isFloat weight
+   *
+   * @example firstname "name1"
+   * @example firstname "name2"
    */
   @Post('BodyProps')
   public async getBodyProps(

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -15,6 +15,7 @@ import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
+import '../controllers/exampleController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -20,6 +20,10 @@
  *   "stringArray": ["string one", "string two"],
  *   "stringValue": "a string"
  * }
+ * @example
+ * {
+ *   "stringValue": "(example2)a string"
+ * }
  */
 export interface TestModel extends Model {
   and: TypeAliasModel1 & TypeAliasModel2;
@@ -30,6 +34,7 @@ export interface TestModel extends Model {
   numberArray: number[];
   /**
    * @example "letmein"
+   * @example "letmein(example)2"
    * @format password
    */
   stringValue: string;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1088,6 +1088,32 @@ describe('Definition generation', () => {
           const definition = getValidatedDefinition('TestModel', currentSpec);
           expect(definition.description).to.equal('This is a description of a model');
         });
+
+        it('should generate single first example from jsdoc', () => {
+          const definition = getValidatedDefinition('TestModel', currentSpec);
+          if (!definition.example) {
+            throw new Error('No definition example.');
+          }
+
+          expect(definition.example).to.deep.equal({
+            boolArray: [true, false],
+            boolValue: true,
+            dateValue: '2018-06-25T15:45:00Z',
+            id: 2,
+            modelValue: {
+              id: 3,
+              email: 'test(at)example.com',
+            },
+            modelsArray: [],
+            numberArray: [1, 2, 3],
+            numberValue: 1,
+            optionalString: 'optional string',
+            strLiteralArr: ['Foo', 'Bar'],
+            strLiteralVal: 'Foo',
+            stringArray: ['string one', 'string two'],
+            stringValue: 'a string',
+          });
+        });
       });
     });
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -297,6 +297,41 @@ describe('Metadata generation', () => {
     const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/parameterController.ts').Generate();
     const controller = parameterMetadata.controllers[0];
 
+    it('should generate single and multiple examples', () => {
+      const method = controller.methods.find(m => m.name === 'example');
+      if (!method) {
+        throw new Error('Method example not defined!');
+      }
+
+      expect(method.parameters.length).to.equal(4);
+
+      const firstnameParam = method.parameters[0];
+      expect(firstnameParam.example).not.to.be.undefined;
+      expect(firstnameParam.example).to.deep.equal(['name1', 'name2']);
+      expect((firstnameParam.example as unknown[]).length).to.be.equal(2);
+
+      const lastnameParam = method.parameters[1];
+      expect(lastnameParam.example).not.to.be.undefined;
+      expect(lastnameParam.example).to.deep.equal(['lastname']);
+      expect((lastnameParam.example as unknown[]).length).to.be.equal(1);
+
+      const genderParam = method.parameters[2];
+      expect(genderParam.example).not.to.be.undefined;
+      expect(genderParam.example).to.deep.equal([
+        { MALE: 'MALE', FEMALE: 'FEMALE' },
+        { MALE: 'MALE2', FEMALE: 'FEMALE2' },
+      ]);
+      expect((genderParam.example as unknown[]).length).to.be.equal(2);
+
+      const nicknamesParam = method.parameters[3];
+      expect(nicknamesParam.example).not.to.be.undefined;
+      expect(nicknamesParam.example).to.deep.equal([
+        ['name1', 'name2'],
+        ['name2_1', 'name2_2'],
+      ]);
+      expect((nicknamesParam.example as unknown[]).length).to.be.equal(2);
+    });
+
     it('should generate a query parameter', () => {
       const method = controller.methods.find(m => m.name === 'getQuery');
       if (!method) {
@@ -312,6 +347,7 @@ describe('Metadata generation', () => {
       expect(firstnameParam.description).to.equal('Firstname description');
       expect(firstnameParam.required).to.be.true;
       expect(firstnameParam.type.dataType).to.equal('string');
+      expect(firstnameParam.example).to.be.undefined;
 
       const lastnameParam = method.parameters[1];
       expect(lastnameParam.in).to.equal('query');
@@ -320,6 +356,9 @@ describe('Metadata generation', () => {
       expect(lastnameParam.description).to.equal('Lastname description');
       expect(lastnameParam.required).to.be.true;
       expect(lastnameParam.type.dataType).to.equal('string');
+      expect(lastnameParam.example).not.to.be.undefined;
+      expect(lastnameParam.example).to.deep.equal(['name1', 'name2']);
+      expect((lastnameParam.example as unknown[]).length).to.be.equal(2);
 
       const ageParam = method.parameters[2];
       expect(ageParam.in).to.equal('query');
@@ -328,6 +367,7 @@ describe('Metadata generation', () => {
       expect(ageParam.description).to.equal('Age description');
       expect(ageParam.required).to.be.true;
       expect(ageParam.type.dataType).to.equal('integer');
+      expect(ageParam.example).to.be.undefined;
 
       const weightParam = method.parameters[3];
       expect(weightParam.in).to.equal('query');
@@ -336,6 +376,7 @@ describe('Metadata generation', () => {
       expect(weightParam.description).to.equal('Weight description');
       expect(weightParam.required).to.be.true;
       expect(weightParam.type.dataType).to.equal('float');
+      expect(weightParam.example).to.be.undefined;
 
       const humanParam = method.parameters[4];
       expect(humanParam.in).to.equal('query');
@@ -344,6 +385,7 @@ describe('Metadata generation', () => {
       expect(humanParam.description).to.equal('Human description');
       expect(humanParam.required).to.be.true;
       expect(humanParam.type.dataType).to.equal('boolean');
+      expect(humanParam.example).to.be.undefined;
 
       const genderParam = method.parameters[5];
       expect(genderParam.in).to.equal('query');
@@ -352,6 +394,7 @@ describe('Metadata generation', () => {
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
       expect(genderParam.type.dataType).to.equal('refEnum');
+      expect(genderParam.example).to.be.undefined;
 
       const nicknamesParam = method.parameters[6] as Tsoa.ArrayParameter;
       expect(nicknamesParam.in).to.equal('query');
@@ -362,6 +405,7 @@ describe('Metadata generation', () => {
       expect(nicknamesParam.type.dataType).to.equal('array');
       expect(nicknamesParam.collectionFormat).to.equal('multi');
       expect(nicknamesParam.type.elementType).to.deep.equal({ dataType: 'string' });
+      expect(nicknamesParam.example).to.be.undefined;
     });
 
     it('should generate an path parameter', () => {
@@ -387,6 +431,9 @@ describe('Metadata generation', () => {
       expect(lastnameParam.description).to.equal('Lastname description');
       expect(lastnameParam.required).to.be.true;
       expect(lastnameParam.type.dataType).to.equal('string');
+      expect(lastnameParam.example).not.to.be.undefined;
+      expect(lastnameParam.example).to.deep.equal(['name1', 'name2']);
+      expect((lastnameParam.example as unknown[]).length).to.be.equal(2);
 
       const ageParam = method.parameters[2];
       expect(ageParam.in).to.equal('path');
@@ -501,6 +548,9 @@ describe('Metadata generation', () => {
       expect(lastnameParam.description).to.equal('Lastname description');
       expect(lastnameParam.required).to.be.true;
       expect(lastnameParam.type.dataType).to.equal('string');
+      expect(lastnameParam.example).not.to.be.undefined;
+      expect(lastnameParam.example).to.deep.equal(['name1', 'name2']);
+      expect((lastnameParam.example as unknown[]).length).to.be.equal(2);
 
       const ageParam = method.parameters[2];
       expect(ageParam.in).to.equal('header');
@@ -570,6 +620,20 @@ describe('Metadata generation', () => {
       expect(parameter.name).to.equal('body');
       expect(parameter.parameterName).to.equal('body');
       expect(parameter.required).to.be.true;
+      expect(parameter.example).not.to.be.undefined;
+      expect(parameter.example).to.deep.equal([
+        {
+          firstname: 'first1',
+          lastname: 'last1',
+          age: 1,
+        },
+        {
+          firstname: 'first2',
+          lastname: 'last2',
+          age: 2,
+        },
+      ]);
+      expect((parameter.example as unknown[]).length).to.be.equal(2);
     });
 
     it('should generate an body props parameter', () => {
@@ -588,6 +652,9 @@ describe('Metadata generation', () => {
       expect(parameter.name).to.equal('firstname');
       expect(parameter.parameterName).to.equal('firstname');
       expect(parameter.required).to.be.true;
+      expect(parameter.example).not.to.be.undefined;
+      expect(parameter.example).to.deep.equal(['name1', 'name2']);
+      expect((parameter.example as unknown[]).length).to.be.equal(2);
     });
 
     it('Should inline enums for TS Enums in path, query and header when using Swagger', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
Closes #650 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

This PR contains several change at below:
- Fixes the example generating at OpenAPI2 which is not a valid format.
- Add multiple examples support in methods.
- Add GenerateMetadataError throws while user provides a wrong JSON-format example.
- Specifically defined the type of example which is Example in OA2, Example3 in OA3.

Seeking more detail usage, please reference the `exampleController` in `tests/fixtures/controllers/exampleController.ts` file.