### PR TITLE
Fix: Don't include 'content' in 204 responses

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -275,14 +275,14 @@ export class SpecGenerator3 extends SpecGenerator {
 
     method.responses.forEach((res: Tsoa.Response) => {
       swaggerResponses[res.name] = {
-        content: {
-          'application/json': {} as Swagger.Schema3,
-        },
         description: res.description,
       };
       if (res.schema && !isVoidType(res.schema)) {
-        /* tslint:disable:no-string-literal */
-        (swaggerResponses[res.name].content || {})['application/json']['schema'] = this.getSwaggerType(res.schema);
+        swaggerResponses[res.name].content = {
+          'application/json': {
+            schema: this.getSwaggerType(res.schema),
+          } as Swagger.Schema3,
+        };
       }
       if (res.examples) {
         /* tslint:disable:no-string-literal */

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -212,6 +212,11 @@ export class GetTestController extends Controller {
       result: new ModelService().getModel().stringArray,
     };
   }
+
+  @Get('Void')
+  public async getVoid(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 export interface ErrorResponse {

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -3,7 +3,6 @@ import 'mocha';
 import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
 import { Tsoa } from '../../../../src/metadataGeneration/tsoa';
 import { SpecGenerator2 } from '../../../../src/swagger/specGenerator2';
-import { SpecGenerator3 } from '../../../../src/swagger/specGenerator3';
 import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
 
 describe('Metadata generation', () => {
@@ -228,16 +227,6 @@ describe('Metadata generation', () => {
       expect(mainResponse.name).to.equal('204');
     });
 
-    it('should not generate content or description for 204 responses in v3', () => {
-      const oas3 = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
-      const operation = oas3.paths['/GetTest/Void'].get;
-      console.log(JSON.stringify(operation));
-      const voidResponse = operation?.responses[204];
-      if (!voidResponse) {
-        throw new Error('Void get operation not defined!');
-      }
-      expect(voidResponse).to.not.haveOwnProperty('content');
-    });
     it('should generate api security', () => {
       const method = controller.methods.find(m => m.name === 'apiSecurity');
       if (!method) {

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -3,6 +3,7 @@ import 'mocha';
 import { MetadataGenerator } from '../../../../src/metadataGeneration/metadataGenerator';
 import { Tsoa } from '../../../../src/metadataGeneration/tsoa';
 import { SpecGenerator2 } from '../../../../src/swagger/specGenerator2';
+import { SpecGenerator3 } from '../../../../src/swagger/specGenerator3';
 import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
 
 describe('Metadata generation', () => {
@@ -225,9 +226,18 @@ describe('Metadata generation', () => {
 
       const mainResponse = method.responses[0];
       expect(mainResponse.name).to.equal('204');
-      expect(mainResponse.description).to.equal('No content');
     });
 
+    it('should not generate content or description for 204 responses in v3', () => {
+      const oas3 = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+      const operation = oas3.paths['/GetTest/Void'].get;
+      console.log(JSON.stringify(operation));
+      const voidResponse = operation?.responses[204];
+      if (!voidResponse) {
+        throw new Error('Void get operation not defined!');
+      }
+      expect(voidResponse).to.not.haveOwnProperty('content');
+    });
     it('should generate api security', () => {
       const method = controller.methods.find(m => m.name === 'apiSecurity');
       if (!method) {

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -5,6 +5,7 @@ import { SpecGenerator2 } from '../../../../src/swagger/specGenerator2';
 import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
 import { VerifyPathableNumberParameter, VerifyPathableParameter, VerifyPathableStringParameter } from '../../utilities/verifyParameter';
 import { VerifyPath } from '../../utilities/verifyPath';
+import { SpecGenerator3 } from '../../../../src/swagger/specGenerator3';
 
 describe('GET route generation', () => {
   const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
@@ -159,6 +160,17 @@ describe('GET route generation', () => {
     }
 
     expect(successResponse.schema.type).to.equal('object');
+  });
+
+  it('should not generate content for 204 responses in v3', () => {
+    const oas3 = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+    const operation = oas3.paths['/GetTest/Void'].get;
+
+    const voidResponse = operation?.responses[204];
+    if (!voidResponse) {
+      throw new Error('Void get operation not defined!');
+    }
+    expect(voidResponse).to.not.haveOwnProperty('content');
   });
 
   it('should reject complex types as arguments', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,10 +3110,10 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
-  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+typescript@^3.9.2:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
Conforms to https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5

Closes #702 

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Only addresses v3 generator.

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
