### PR TITLE
fix: SpecGen3: Render global tag descriptions if available

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -9,7 +9,6 @@ import { Swagger } from './swagger';
 /**
  * TODO:
  * Handle formData parameters
- * Handle tags
  * Handle requestBodies of type other than json
  * Handle requestBodies as reusable objects
  * Handle headers, examples, responses, etc.
@@ -28,6 +27,7 @@ export class SpecGenerator3 extends SpecGenerator {
       openapi: '3.0.0',
       paths: this.buildPaths(),
       servers: this.buildServers(),
+      tags: this.config.tags,
     };
 
     if (this.config.spec) {

--- a/tests/fixtures/defaultOptions.ts
+++ b/tests/fixtures/defaultOptions.ts
@@ -62,6 +62,7 @@ export function getDefaultOptions(outputDirectory: string = '', entryFile: strin
         },
       },
       version: '1.0.0',
+      tags: [{ name: 'hello', description: 'Endpoints related to greeting functionality' }],
     },
   };
 }

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -56,6 +56,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
     return `for the ${chosenSpec.specName} spec`;
   }
 
+  describe('tags', () => {
+    it('should generate a valid tags array', () => {
+      expect(specDefault.spec.tags).to.deep.equal([{ name: 'hello', description: 'Endpoints related to greeting functionality' }]);
+    });
+  });
+
   describe('servers', () => {
     it('should replace the parent schemes element', () => {
       expect(specDefault.spec).to.not.have.property('schemes');


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

