### PR TITLE
feat: specMerge: Validate config and add deepmerge option

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "author": "Luke Autry <lukeautry@gmail.com> (http://www.lukeautry.com)",
   "license": "MIT",
   "dependencies": {
+    "deepmerge": "^4.2.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,6 +95,10 @@ export const validateSpecConfig = async (config: Config): Promise<ExtendedSpecCo
     throw new Error('Unsupported Spec version.');
   }
 
+  if (config.spec.spec && !['immediate', 'recursive', 'deepmerge', undefined].includes(config.spec.specMerging)) {
+    throw new Error(`Invalid specMerging config: ${config.spec.specMerging}`);
+  }
+
   const noImplicitAdditionalProperties = determineNoImplicitAdditionalSetting(config.noImplicitAdditionalProperties);
   config.spec.name = config.spec.name || (await nameDefault());
   config.spec.description = config.spec.description || (await descriptionDefault());

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,10 +125,11 @@ export interface SpecConfig {
    * Possible values:
    *  - 'immediate' is overriding top level elements only thus you can not append a new path or alter an existing value without erasing same level elements.
    *  - 'recursive' proceed to a deep merge and will concat every branches or override or create new values if needed. @see https://www.npmjs.com/package/merge
+   *  - 'deepmerge' uses `deepmerge` to merge, which will concat object branches and concat arrays as well @see https://www.npmjs.com/package/deepmerge
    * The default is set to immediate so it is not breaking previous versions.
    * @default 'immediate'
    */
-  specMerging?: 'immediate' | 'recursive';
+  specMerging?: 'immediate' | 'recursive' | 'deepmerge';
 
   /**
    * Security Definitions Object

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -5,6 +5,7 @@ import { isVoidType } from '../utils/isVoidType';
 import { convertColonPathParams, normalisePath } from './../utils/pathUtils';
 import { SpecGenerator } from './specGenerator';
 import { Swagger } from './swagger';
+import { UnspecifiedObject } from '../utils/unspecifiedObject';
 
 export class SpecGenerator2 extends SpecGenerator {
   constructor(protected readonly metadata: Tsoa.Metadata, protected readonly config: ExtendedSpecConfig) {
@@ -54,6 +55,7 @@ export class SpecGenerator2 extends SpecGenerator {
       const mergeFuncs: { [key: string]: any } = {
         immediate: Object.assign,
         recursive: require('merge').recursive,
+        deepmerge: (spec: UnspecifiedObject, merge: UnspecifiedObject): UnspecifiedObject => require('deepmerge').all([spec, merge]),
       };
 
       spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);

--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -5,6 +5,7 @@ import { isVoidType } from '../utils/isVoidType';
 import { convertColonPathParams, normalisePath } from './../utils/pathUtils';
 import { SpecGenerator } from './specGenerator';
 import { Swagger } from './swagger';
+import { UnspecifiedObject } from '../utils/unspecifiedObject';
 
 /**
  * TODO:
@@ -35,6 +36,7 @@ export class SpecGenerator3 extends SpecGenerator {
       const mergeFuncs: { [key: string]: any } = {
         immediate: Object.assign,
         recursive: require('merge').recursive,
+        deepmerge: (spec: UnspecifiedObject, merge: UnspecifiedObject): UnspecifiedObject => require('deepmerge').all([spec, merge]),
       };
 
       spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);

--- a/src/utils/unspecifiedObject.ts
+++ b/src/utils/unspecifiedObject.ts
@@ -1,0 +1,1 @@
+export type UnspecifiedObject = { [key: string]: unknown };

--- a/tests/unit/utilities/specMerge.spec.ts
+++ b/tests/unit/utilities/specMerge.spec.ts
@@ -1,0 +1,129 @@
+import 'mocha';
+import { expect } from 'chai';
+import { MetadataGenerator } from '../../../src/metadataGeneration/metadataGenerator';
+import { SpecGenerator3 } from '../../../src/swagger/specGenerator3';
+import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
+import { ExtendedSpecConfig } from '../../../src/cli';
+import { Swagger } from '../../../src/swagger/swagger';
+
+describe('specMergins', () => {
+  const metadata = new MetadataGenerator('./tests/fixtures/controllers/getController.ts').Generate();
+  const defaultOptions: ExtendedSpecConfig = getDefaultExtendedOptions();
+
+  describe('recursive', () => {
+    const addedParameter = ({
+      name: 'deepQueryParamObject',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      description: 'Accepts a deep Object as query param',
+      examples: {
+        color: {
+          description: 'Setting a rgb color',
+          value: { color: 'rgba(100, 23, 12, 1)' },
+        },
+      },
+      schema: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    } as unknown) as Swagger.QueryParameter;
+
+    const options: ExtendedSpecConfig = {
+      ...defaultOptions,
+      specMerging: 'recursive',
+      spec: {
+        paths: {
+          '/GetTest/DateParam': {
+            get: {
+              operationId: 'OverriddenId',
+              parameters: [addedParameter],
+            },
+          },
+        },
+      },
+    };
+    const mergedSpec = new SpecGenerator3(metadata, options).GetSpec();
+
+    it('does not merge arrays, but overwrites instead', () => {
+      expect(mergedSpec.paths['/GetTest/DateParam'].get?.parameters).to.deep.eq([addedParameter]);
+    });
+
+    it('merges deep object, overriding primitives', () => {
+      expect(mergedSpec.paths['/GetTest/DateParam'].get?.operationId).to.eq('OverriddenId');
+    });
+
+    it('does not affect anything else', () => {
+      const originalSpec = new SpecGenerator3(metadata, defaultOptions).GetSpec();
+
+      originalSpec.paths['/GetTest/DateParam'].get!.operationId = 'OverriddenId';
+      originalSpec.paths['/GetTest/DateParam'].get!.parameters = [addedParameter];
+
+      expect(mergedSpec).to.deep.eq(originalSpec);
+    });
+  });
+
+  describe('deepMerging', () => {
+    const addedParameter = ({
+      name: 'appearance',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      description: 'Accepts an object containing style information for the marker',
+      examples: {
+        color: {
+          description: 'Setting a rgb color',
+          value: { color: 'rgba(100, 23, 12, 1)' },
+        },
+      },
+      schema: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    } as unknown) as Swagger.QueryParameter;
+
+    const options: ExtendedSpecConfig = {
+      ...defaultOptions,
+      specMerging: 'deepmerge',
+      spec: {
+        paths: {
+          '/GetTest/DateParam': {
+            get: {
+              operationId: 'OverriddenId',
+              parameters: [addedParameter],
+            },
+          },
+        },
+      },
+    };
+    const mergedSpec = new SpecGenerator3(metadata, options).GetSpec();
+
+    it('merges arrays', () => {
+      expect(mergedSpec.paths['/GetTest/DateParam'].get?.parameters).to.deep.eq([
+        {
+          description: undefined,
+          example: undefined,
+          in: 'query',
+          name: 'date',
+          required: true,
+          schema: { format: 'date-time', type: 'string', default: undefined, items: undefined, enum: undefined },
+        },
+        addedParameter,
+      ]);
+    });
+
+    it('merges deep object, overriding primitives', () => {
+      expect(mergedSpec.paths['/GetTest/DateParam'].get?.operationId).to.eq('OverriddenId');
+    });
+
+    it('does not affect anything else', () => {
+      const originalSpec = new SpecGenerator3(metadata, defaultOptions).GetSpec();
+
+      originalSpec.paths['/GetTest/DateParam'].get!.operationId = 'OverriddenId';
+
+      originalSpec.paths['/GetTest/DateParam'].get?.parameters?.push(addedParameter);
+
+      expect(mergedSpec).to.deep.eq(originalSpec);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,6 +1104,11 @@ deep-equal@~1.0.1:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

This PR introduces a new option to handle specMerging.
The reason for this addition is to handle cases where the merging needs to happen at a level in the spec where arrays are used, i.e. parameters.
In these cases, a tsoa user may want to specify an additional parameter without overriding the parameter array generated by tsoa.

A great example is [file uploads](https://tsoa-community.github.io/docs/file-upload.html#uploading-files) where we can currently only avoid the overriding by pushing the parameter of the override spec up a level (to the `/files/uploadFile` level) where it then unfortunately also applies to all other methods (get, put, delete), just to prevent overriding the post parameters.