### PR TITLE
fix: Don't explicitly set additionalProperties for unknown/any in OpenAPI3

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -436,6 +436,16 @@ export class SpecGenerator3 extends SpecGenerator {
     return { $ref: `#/components/schemas/${referenceType.refName}` };
   }
 
+  protected getSwaggerTypeForPrimitiveType(dataType: Tsoa.PrimitiveTypeLiteral): Swagger.Schema {
+    if (dataType === 'any') {
+      // Setting additionalProperties causes issues with code generators for OpenAPI 3
+      // Therefore, we avoid setting it explicitly (since it's the implicit default already)
+      return {};
+    }
+
+    return super.getSwaggerTypeForPrimitiveType(dataType);
+  }
+
   protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
     // use nullable: true to represent simple unions with null. This converts to
     // a better type when using code generation in a client.

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -738,12 +738,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           anyType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}`);
             expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
-            expect(propertySchema.additionalProperties).to.eq(true, 'because the "any" type always allows more properties be definition');
+            expect(propertySchema.additionalProperties).to.eq(undefined, 'because the "any" type always allows more properties be definition');
           },
           unknownType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}`);
             expect(propertySchema.nullable).to.eq(undefined, `for property ${propertyName}.nullable`);
-            expect(propertySchema.additionalProperties).to.eq(true, 'because the "unknown" type always allows more properties be definition');
+            expect(propertySchema.additionalProperties).to.eq(undefined, 'because the "unknown" type always allows more properties be definition');
           },
           genericTypeObject: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Generic__foo-string--bar-boolean__');


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests? Upda
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Closing issues**

Closes #711, closes #721 

