### PR TITLE
Fix: Use anyof and nullable: true for nullable unions w/refs

### DIFF
--- a/src/swagger/specGenerator3.ts
+++ b/src/swagger/specGenerator3.ts
@@ -451,31 +451,36 @@ export class SpecGenerator3 extends SpecGenerator {
     return super.getSwaggerTypeForPrimitiveType(dataType);
   }
 
+  private isNull(type: Tsoa.Type) {
+    return type.dataType === 'enum' && type.enums.length === 1 && type.enums[0] === null;
+  }
+
   protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
-    // use nullable: true to represent simple unions with null. This converts to
-    // a better type when using code generation in a client.
-    if (type.types.length === 2 && type.types.find(typeInUnion => typeInUnion.dataType === 'enum' && typeInUnion.enums.includes(null))) {
-      const nullEnumIndex = type.types.findIndex(type => type.dataType === 'enum' && type.enums.includes(null));
-      const typeIndex = nullEnumIndex === 1 ? 0 : 1;
-      const swaggerType = this.getSwaggerType(type.types[typeIndex]);
+    const notNullSwaggerTypes = type.types.filter(x => !this.isNull(x)).map(x => this.getSwaggerType(x));
+    const nullable = type.types.length !== notNullSwaggerTypes.length;
 
-      const isRef = !!swaggerType.$ref;
+    if (nullable && notNullSwaggerTypes.length === 1) {
+      const [swaggerType] = notNullSwaggerTypes;
 
-      // let special case of ref union with null fall through to be handled as a
-      // anyOf. Example of this case is:
-      // type Nullable<T> = T | null;
-      // type MyNullableType = Nullable<OtherType>;
-      //
-      // this is required because other members of $ref containing objects are
-      // ignored so the null would otherwise get left out:
+      // let special case of ref union with null to use an allOf with a single
+      // element since you can't attach nullable directly to a ref.
       // https://swagger.io/docs/specification/using-ref/#syntax
-      if (!isRef) {
+      //
+      // Using this format has the benefit that its already supported by the
+      // openapi typescript-fetch generation.
+      if (swaggerType.$ref) {
+        return { allOf: [swaggerType], nullable: true };
+      } else {
         swaggerType['nullable'] = true;
         return swaggerType;
       }
     }
 
-    return { anyOf: type.types.map(x => this.getSwaggerType(x)) };
+    if (nullable) {
+      return { anyOf: notNullSwaggerTypes, nullable };
+    } else {
+      return { anyOf: notNullSwaggerTypes };
+    }
   }
 
   protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType) {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1450,7 +1450,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             const maybeWord = getComponentSchema('Maybe_Word_', currentSpec);
             expect(maybeWord).to.deep.eq(
-              { anyOf: [{ $ref: '#/components/schemas/Word' }, { type: 'number', enum: [null], nullable: true }], description: undefined, default: undefined, example: undefined, format: undefined },
+              { allOf: [{ $ref: '#/components/schemas/Word' }], description: undefined, default: undefined, example: undefined, format: undefined, nullable: true },
               `for schema linked by property ${propertyName}`,
             );
           },


### PR DESCRIPTION
Using the " anyOf with nullable: true" form has the benefit that the
openapi typescript-fetch generator already has support for this
construct.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

None that I'm aware

**Test plan**

I modified the existing test which was relevant to ensure the correct values were being returned