### PR TITLE
Don't strip `.ts` from within module import paths.

### DIFF
--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -43,7 +43,7 @@ export class RouteGenerator {
     return await this.GenerateRoutes(file, pathTransformer);
   }
 
-  private buildContent(middlewareTemplate: string, pathTransformer: (path: string) => string) {
+  public buildContent(middlewareTemplate: string, pathTransformer: (path: string) => string) {
     handlebars.registerHelper('json', (context: any) => {
       return JSON.stringify(context);
     });
@@ -163,7 +163,7 @@ export class RouteGenerator {
   }
 
   private getRelativeImportPath(fileLocation: string) {
-    fileLocation = fileLocation.replace('.ts', ''); // no ts extension in import
+    fileLocation = fileLocation.replace(/.ts$/, ''); // no ts extension in import
     return `./${path.relative(this.options.routesDir, fileLocation).replace(/\\/g, '/')}`;
   }
 

--- a/tests/unit/templating/routeGenerator.spec.ts
+++ b/tests/unit/templating/routeGenerator.spec.ts
@@ -67,4 +67,31 @@ describe('RouteGenerator', () => {
       });
     });
   });
+
+  describe('.buildContent', () => {
+    it('strips .ts from the end of module paths but not from the middle', () => {
+      const generator = new RouteGenerator(
+        {
+          controllers: [
+            {
+              location: 'controllerWith.tsInPath.ts',
+              methods: [],
+              name: '',
+              path: '',
+            },
+          ],
+          referenceTypeMap: {},
+        },
+        {
+          entryFile: 'mockEntryFile',
+          routesDir: '.',
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+        },
+      );
+
+      const models = generator.buildContent('{{#each controllers}}{{modulePath}}{{/each}}', s => s);
+
+      expect(models).to.equal('./controllerWith.tsInPath');
+    });
+  });
 });


### PR DESCRIPTION
e.g. if a module is named `users.tsoa.controller.ts` to distinguish it from non-tsoa controllers, the generated import is `usersoa.controller.ts`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
