### PR TITLE
Fix errors in workspaces

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -757,7 +757,7 @@ export class TypeResolver {
       }
 
       const modelTypeDeclaration = node as UsableDeclaration | ts.EnumMember;
-      return (modelTypeDeclaration.name as ts.Identifier).text === typeName;
+      return (modelTypeDeclaration.name as ts.Identifier)?.text === typeName;
     }) as Array<Exclude<UsableDeclaration | ts.EnumMember, ts.PropertySignature>>;
 
     if (!modelTypes.length) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] This PR is associated with an existing issue?

**Closing issues**

Fixes https://github.com/lukeautry/tsoa/issues/732
Fixes https://github.com/lukeautry/tsoa/issues/592

**Summary**
For some reason, `modelTypeDeclaration.name` is undefined if tsoa is used in a monorepo. Taken out of the mono repo, it works, using the exact same config. Pretty sure this doesn't fix the root cause, but it surely fixes tsoa issues in workspaces for me, and I can't imagine the change to ever do any harm.