### PR TITLE
feat: Add ability to fetch custom IoC container

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -11,6 +11,7 @@ import { expressAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
+import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
 {{/if}}
 import * as express from 'express';
 
@@ -72,14 +73,9 @@ export function RegisterRoutes(app: express.Express) {
             }
 
             {{#if ../../iocModule}}
-            function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
-            interface Container<T> { get<T>(type: any): any; }
+            const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
 
-            let container: any = iocContainer;
-            if (isFunction(iocContainer)) {
-                container = iocContainer(request);
-            }
-            const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
+            const controller: any = container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -72,7 +72,14 @@ export function RegisterRoutes(app: express.Express) {
             }
 
             {{#if ../../iocModule}}
-            const controller: any = iocContainer.get<{{../name}}>({{../name}});
+            function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
+            interface Container<T> { get<T>(type: any): any; }
+
+            let container: any = iocContainer;
+            if (isFunction(iocContainer)) {
+                container = iocContainer(request);
+            }
+            const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -11,7 +11,7 @@ import { expressAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
-import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
+import { IocContainer, IocContainerFactory } from '@tsoa/runtime';
 {{/if}}
 import * as express from 'express';
 
@@ -73,7 +73,7 @@ export function RegisterRoutes(app: express.Express) {
             }
 
             {{#if ../../iocModule}}
-            const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
+            const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
 
             const controller: any = container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -11,7 +11,7 @@ import { hapiAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
-import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
+import { IocContainer, IocContainerFactory } from '@tsoa/runtime';
 {{/if}}
 import { boomify, Payload } from '@hapi/boom';
 
@@ -86,7 +86,7 @@ export function RegisterRoutes(server: any) {
                     }
 
                     {{#if ../../iocModule}}
-                    const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
+                    const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
 
                     const controller: any = container.get<{{../name}}>({{../name}});
                     if (typeof controller['setStatus'] === 'function') {

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -11,6 +11,7 @@ import { hapiAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
+import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
 {{/if}}
 import { boomify, Payload } from '@hapi/boom';
 
@@ -85,14 +86,9 @@ export function RegisterRoutes(server: any) {
                     }
 
                     {{#if ../../iocModule}}
-                    function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
-                    interface Container<T> { get<T>(type: any): any; }
+                    const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
 
-                    let container: any = iocContainer;
-                    if (isFunction(iocContainer)) {
-                        container = iocContainer(request);
-                    }
-                    const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
+                    const controller: any = container.get<{{../name}}>({{../name}});
                     if (typeof controller['setStatus'] === 'function') {
                         controller.setStatus(undefined);
                     }

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -85,7 +85,14 @@ export function RegisterRoutes(server: any) {
                     }
 
                     {{#if ../../iocModule}}
-                    const controller: any = iocContainer.get<{{../name}}>({{../name}});
+                    function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
+                    interface Container<T> { get<T>(type: any): any; }
+
+                    let container: any = iocContainer;
+                    if (isFunction(iocContainer)) {
+                        container = iocContainer(request);
+                    }
+                    const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
                     if (typeof controller['setStatus'] === 'function') {
                         controller.setStatus(undefined);
                     }

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -15,6 +15,7 @@ import { koaAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
+import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
 {{/if}}
 import * as KoaRouter from '@koa/router';
 
@@ -75,14 +76,9 @@ export function RegisterRoutes(router: KoaRouter) {
             }
 
             {{#if ../../iocModule}}
-            function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
-            interface Container<T> { get<T>(type: any): any; }
+            const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
 
-            let container: any = iocContainer;
-            if (isFunction(iocContainer)) {
-                container = iocContainer(request);
-            }
-            const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
+            const controller: any = container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -15,7 +15,7 @@ import { koaAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
-import { TsoaIocContainer, TsoaIocContainerMethod } from '@tsoa/runtime';
+import { IocContainer, IocContainerFactory } from '@tsoa/runtime';
 {{/if}}
 import * as KoaRouter from '@koa/router';
 
@@ -76,7 +76,7 @@ export function RegisterRoutes(router: KoaRouter) {
             }
 
             {{#if ../../iocModule}}
-            const container: TsoaIocContainer = typeof iocContainer === 'function' ? (iocContainer as TsoaIocContainerMethod)(request) : iocContainer;
+            const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
 
             const controller: any = container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -75,7 +75,14 @@ export function RegisterRoutes(router: KoaRouter) {
             }
 
             {{#if ../../iocModule}}
-            const controller: any = iocContainer.get<{{../name}}>({{../name}});
+            function isFunction(obj: any): obj is Function { return typeof obj === 'function'; }
+            interface Container<T> { get<T>(type: any): any; }
+
+            let container: any = iocContainer;
+            if (isFunction(iocContainer)) {
+                container = iocContainer(request);
+            }
+            const controller: any = (container as Container<{{../name}}> ).get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,6 +9,7 @@ export * from './decorators/security';
 export * from './decorators/extension';
 export * from './interfaces/controller';
 export * from './interfaces/response';
+export * from './interfaces/iocModule';
 export * from './decorators/response';
 export * from './metadataGeneration/tsoa';
 export * from './routeGeneration/templateHelpers';

--- a/packages/runtime/src/interfaces/iocModule.ts
+++ b/packages/runtime/src/interfaces/iocModule.ts
@@ -1,5 +1,5 @@
-export interface TsoaIocContainer {
-  get<T>(controller: any): T;
+export interface IocContainer {
+  get<T>(controller: { prototype: T }): T;
 }
 
-export type TsoaIocContainerMethod = (request: any) => TsoaIocContainer;
+export type IocContainerFactory = (request: unknown) => IocContainer;

--- a/packages/runtime/src/interfaces/iocModule.ts
+++ b/packages/runtime/src/interfaces/iocModule.ts
@@ -1,0 +1,5 @@
+export interface TsoaIocContainer {
+  get<T>(controller: any): T;
+}
+
+export type TsoaIocContainerMethod = (request: any) => TsoaIocContainer;

--- a/tests/fixtures/inversify-dynamic-container/authentication.ts
+++ b/tests/fixtures/inversify-dynamic-container/authentication.ts
@@ -1,0 +1,9 @@
+import * as express from 'express';
+
+export function expressAuthentication(req: express.Request, name: string, scopes?: string[]): Promise<any> {
+  if (req.query && req.query.tsoa && req.query.tsoa === 'abc123456') {
+    return Promise.resolve({});
+  } else {
+    return Promise.reject({});
+  }
+}

--- a/tests/fixtures/inversify-dynamic-container/ioc.ts
+++ b/tests/fixtures/inversify-dynamic-container/ioc.ts
@@ -2,8 +2,9 @@ import e = require('express');
 import { Container } from 'inversify';
 import { ManagedController } from './managedController';
 import { ManagedService } from './managedService';
+import { IocContainerFactory, IocContainer } from '@tsoa/runtime';
 
-const iocContainer = function (request: e.Request): Container {
+const iocContainer: IocContainerFactory = function (request: e.Request): IocContainer {
   const container = new Container();
   container.bind<string>(Symbol.for('requestPath')).toConstantValue(request.path);
   container.bind<ManagedService>(ManagedService).to(ManagedService);

--- a/tests/fixtures/inversify-dynamic-container/ioc.ts
+++ b/tests/fixtures/inversify-dynamic-container/ioc.ts
@@ -1,0 +1,15 @@
+import { Container } from 'inversify';
+import { ManagedController } from './managedController';
+import { ManagedService } from './managedService';
+
+export let containerMethodCalled = false;
+
+const iocContainer = function (request: Express.Request): Container {
+  const container = new Container();
+  containerMethodCalled = true;
+  container.bind<ManagedService>(ManagedService).to(ManagedService).inSingletonScope();
+  container.bind<ManagedController>(ManagedController).to(ManagedController).inSingletonScope();
+  return container;
+};
+
+export { iocContainer };

--- a/tests/fixtures/inversify-dynamic-container/ioc.ts
+++ b/tests/fixtures/inversify-dynamic-container/ioc.ts
@@ -1,13 +1,12 @@
+import e = require('express');
 import { Container } from 'inversify';
 import { ManagedController } from './managedController';
 import { ManagedService } from './managedService';
 
-export let containerMethodCalled = false;
-
-const iocContainer = function (request: Express.Request): Container {
+const iocContainer = function (request: e.Request): Container {
   const container = new Container();
-  containerMethodCalled = true;
-  container.bind<ManagedService>(ManagedService).to(ManagedService).inSingletonScope();
+  container.bind<string>(Symbol.for('requestPath')).toConstantValue(request.path);
+  container.bind<ManagedService>(ManagedService).to(ManagedService);
   container.bind<ManagedController>(ManagedController).to(ManagedController).inSingletonScope();
   return container;
 };

--- a/tests/fixtures/inversify-dynamic-container/managedController.ts
+++ b/tests/fixtures/inversify-dynamic-container/managedController.ts
@@ -1,0 +1,16 @@
+import { inject, injectable } from 'inversify';
+import { Get, Route, Security } from '@tsoa/runtime';
+import { TestModel } from '../testModel';
+import { ManagedService } from './managedService';
+
+@injectable()
+@Route('ManagedTest')
+@Security('MySecurity')
+export class ManagedController {
+  constructor(@inject(ManagedService) private managedService: ManagedService) {}
+
+  @Get()
+  public async getModel(): Promise<TestModel> {
+    return this.managedService.getModel();
+  }
+}

--- a/tests/fixtures/inversify-dynamic-container/managedController.ts
+++ b/tests/fixtures/inversify-dynamic-container/managedController.ts
@@ -1,6 +1,5 @@
 import { inject, injectable } from 'inversify';
 import { Get, Route, Security } from '@tsoa/runtime';
-import { TestModel } from '../testModel';
 import { ManagedService } from './managedService';
 
 @injectable()
@@ -10,7 +9,7 @@ export class ManagedController {
   constructor(@inject(ManagedService) private managedService: ManagedService) {}
 
   @Get()
-  public async getModel(): Promise<TestModel> {
-    return this.managedService.getModel();
+  public async getModel(): Promise<string> {
+    return this.managedService.getPath();
   }
 }

--- a/tests/fixtures/inversify-dynamic-container/managedService.ts
+++ b/tests/fixtures/inversify-dynamic-container/managedService.ts
@@ -1,0 +1,39 @@
+import { injectable } from 'inversify';
+import { TestModel, TestSubModel } from '../testModel';
+
+@injectable()
+export class ManagedService {
+  public getModel(): TestModel {
+    return {
+      and: { value1: 'foo', value2: 'bar' },
+      boolArray: [true, false],
+      boolValue: true,
+      id: 1,
+      modelValue: {
+        email: 'test@test.com',
+        id: 100,
+      },
+      modelsArray: new Array<TestSubModel>(),
+      numberArray: [1, 2, 3],
+      numberValue: 1,
+      objLiteral: {
+        name: 'hello',
+      },
+      object: {
+        a: 'a',
+      },
+      objectArray: [
+        {
+          a: 'a',
+        },
+      ],
+      optionalString: 'optional string',
+      or: { value1: 'foo', value2: 'bar' },
+      referenceAnd: { value1: 'foo', value2: 'bar' },
+      strLiteralArr: ['Foo', 'Bar'],
+      strLiteralVal: 'Foo',
+      stringArray: ['string one', 'string two'],
+      stringValue: 'a string',
+    };
+  }
+}

--- a/tests/fixtures/inversify-dynamic-container/managedService.ts
+++ b/tests/fixtures/inversify-dynamic-container/managedService.ts
@@ -1,39 +1,10 @@
-import { injectable } from 'inversify';
-import { TestModel, TestSubModel } from '../testModel';
+import { inject, injectable } from 'inversify';
 
 @injectable()
 export class ManagedService {
-  public getModel(): TestModel {
-    return {
-      and: { value1: 'foo', value2: 'bar' },
-      boolArray: [true, false],
-      boolValue: true,
-      id: 1,
-      modelValue: {
-        email: 'test@test.com',
-        id: 100,
-      },
-      modelsArray: new Array<TestSubModel>(),
-      numberArray: [1, 2, 3],
-      numberValue: 1,
-      objLiteral: {
-        name: 'hello',
-      },
-      object: {
-        a: 'a',
-      },
-      objectArray: [
-        {
-          a: 'a',
-        },
-      ],
-      optionalString: 'optional string',
-      or: { value1: 'foo', value2: 'bar' },
-      referenceAnd: { value1: 'foo', value2: 'bar' },
-      strLiteralArr: ['Foo', 'Bar'],
-      strLiteralVal: 'Foo',
-      stringArray: ['string one', 'string two'],
-      stringValue: 'a string',
-    };
+  constructor(@inject(Symbol.for('requestPath')) private readonly path: string) {}
+
+  public getPath(): string {
+    return this.path;
   }
 }

--- a/tests/fixtures/inversify-dynamic-container/server.ts
+++ b/tests/fixtures/inversify-dynamic-container/server.ts
@@ -16,4 +16,4 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
   res.status(err.status || 500).send(err.message || 'An error occurred during the request.');
 });
 
-app.listen(3004);
+app.listen();

--- a/tests/fixtures/inversify-dynamic-container/server.ts
+++ b/tests/fixtures/inversify-dynamic-container/server.ts
@@ -1,0 +1,19 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as methodOverride from 'method-override';
+
+import './managedController';
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(methodOverride());
+RegisterRoutes(app);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(err.status || 500).send(err.message || 'An error occurred during the request.');
+});
+
+app.listen(3004);

--- a/tests/integration/inversify-dynamic-container.spec.ts
+++ b/tests/integration/inversify-dynamic-container.spec.ts
@@ -3,18 +3,14 @@ import 'mocha';
 import 'reflect-metadata';
 import * as request from 'supertest';
 import { app } from '../fixtures/inversify-dynamic-container/server';
-import { containerMethodCalled } from '../fixtures/inversify-dynamic-container/ioc';
-import { TestModel } from '../fixtures/testModel';
 
 const basePath = '/v1';
 
 describe('Inversify Express Server Dynamic Container', () => {
   it('can handle get request with no path argument', () => {
-    expect(containerMethodCalled).to.equal(false);
     return verifyGetRequest(basePath + '/ManagedTest?tsoa=abc123456', (err, res) => {
-      const model = res.body as TestModel;
-      expect(model.id).to.equal(1);
-      expect(containerMethodCalled).to.equal(true);
+      const model = res.body as string;
+      expect(model).to.equal(basePath + '/ManagedTest');
     });
   });
 

--- a/tests/integration/inversify-dynamic-container.spec.ts
+++ b/tests/integration/inversify-dynamic-container.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import 'mocha';
+import 'reflect-metadata';
+import * as request from 'supertest';
+import { app } from '../fixtures/inversify-dynamic-container/server';
+import { containerMethodCalled } from '../fixtures/inversify-dynamic-container/ioc';
+import { TestModel } from '../fixtures/testModel';
+
+const basePath = '/v1';
+
+describe('Inversify Express Server Dynamic Container', () => {
+  it('can handle get request with no path argument', () => {
+    expect(containerMethodCalled).to.equal(false);
+    return verifyGetRequest(basePath + '/ManagedTest?tsoa=abc123456', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+      expect(containerMethodCalled).to.equal(true);
+    });
+  });
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -150,5 +150,16 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         routesDir: './fixtures/inversify-cpg',
       }),
     ),
+    log('Inversify Route Generation using dynamic container creation', () =>
+      generateRoutes({
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        authenticationModule: './fixtures/inversify-dynamic-container/authentication.ts',
+        basePath: '/v1',
+        entryFile: './fixtures/inversify-dynamic-container/server.ts',
+        iocModule: './fixtures/inversify-dynamic-container/ioc.ts',
+        middleware: 'express',
+        routesDir: './fixtures/inversify-dynamic-container',
+      }),
+    ),
   ]);
 })();


### PR DESCRIPTION
Hey! Happy hacktoberfest 🎃! This closes #779.

This adds a check to see if `iocContainer` is a function and if it is, calls it with the request to resolve the IoC container. This means that the `iocContainer` can be created/updated/fetched per request.

The reason I've added in the check to see if it's a function is to avoid being a breaking change.

I will need to raise a PR over at [tsoa-community/docs](https://github.com/tsoa-community/docs) to document this change.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?




