### PR TITLE
express: RegisterRoutes: accept express.Router, not just express.Application

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -45,7 +45,7 @@ const validationService = new ValidationService(models);
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-export function RegisterRoutes(app: express.Express) {
+export function RegisterRoutes(app: express.Router) {
     // ###########################################################################################################
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa

--- a/tests/fixtures/express-router/authentication.ts
+++ b/tests/fixtures/express-router/authentication.ts
@@ -1,0 +1,32 @@
+import * as express from 'express';
+
+export function expressAuthentication(req: express.Request, name: string, scopes?: string[]): Promise<any> {
+  if (name === 'api_key') {
+    let token;
+    if (req.query && req.query.access_token) {
+      token = req.query.access_token;
+    } else {
+      return Promise.reject({});
+    }
+
+    if (token === 'abc123456') {
+      return Promise.resolve({
+        id: 1,
+        name: 'Ironman',
+      });
+    } else if (token === 'xyz123456') {
+      return Promise.resolve({
+        id: 2,
+        name: 'Thor',
+      });
+    } else {
+      return Promise.reject({});
+    }
+  } else {
+    if (req.query && req.query.tsoa && req.query.tsoa === 'abc123456') {
+      return Promise.resolve({});
+    } else {
+      return Promise.reject({});
+    }
+  }
+}

--- a/tests/fixtures/express-router/server.ts
+++ b/tests/fixtures/express-router/server.ts
@@ -1,0 +1,32 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as methodOverride from 'method-override';
+import '../controllers/rootController';
+
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+export const router = express.Router();
+app.use('/v1', router);
+router.use(bodyParser.urlencoded({ extended: true }));
+router.use(bodyParser.json());
+router.use(methodOverride());
+router.use((req: any, res: any, next: any) => {
+  req.stringValue = 'fancyStringForContext';
+  next();
+});
+RegisterRoutes(router);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const status = err.status || 500;
+  const body: any = {
+    fields: err.fields || undefined,
+    message: err.message || 'An error occurred during the request.',
+    name: err.name,
+    status,
+  };
+  res.status(status).json(body);
+});
+
+app.listen();

--- a/tests/integration/express-router-server.spec.ts
+++ b/tests/integration/express-router-server.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { app } from '../fixtures/express-router/server';
+import { TestModel } from '../fixtures/testModel';
+
+const basePath = '/v1';
+
+describe('Express Router Server', () => {
+  it('can handle get request to root controller`s path', () => {
+    return verifyGetRequest(basePath + '/', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  it('can handle get request to root controller`s method path', () => {
+    return verifyGetRequest(basePath + '/rootControllerMethodWithPath', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -39,6 +39,20 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         metadata,
       ),
     ),
+    log('Express Router Route Generation', () =>
+      generateRoutes(
+        {
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          authenticationModule: './fixtures/express-router/authentication.ts',
+          entryFile: './fixtures/express-router/server.ts',
+          middleware: 'express',
+          routesDir: './fixtures/express-router',
+        },
+        undefined,
+        undefined,
+        metadata,
+      ),
+    ),
     log('Express Route Generation, OpenAPI3, noImplicitAdditionalProperties', () =>
       generateRoutes(
         {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests? **Modified an existing test.**
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?  **Not applicable here?**
- [ ] This PR is associated with an existing issue?

**Test plan**

Modified the express test to use an `express.Router` instance.  Test fails without the fix.