### PR TITLE
fix: make flows optional in OauthFlow security schemas

### DIFF
--- a/packages/runtime/src/swagger/swagger.ts
+++ b/packages/runtime/src/swagger/swagger.ts
@@ -337,7 +337,7 @@ export namespace Swagger {
   }
 
   export type OAuthFlow = {
-    [flowName in OAuth2FlowTypes]: OAuth2SecurityFlow3;
+    [flowName in OAuth2FlowTypes]?: OAuth2SecurityFlow3;
   };
   export type OAuth2FlowTypes = 'authorizationCode' | 'implicit' | 'password' | 'clientCredentials';
   export type Security = BasicSecurity | BasicSecurity3 | ApiKeySecurity | OAuth2AccessCodeSecurity | OAuth2ApplicationSecurity | OAuth2ImplicitSecurity | OAuth2PasswordSecurity | OAuth2Security3;

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -141,6 +141,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
       const flow = password.flows.password;
 
+      if (!flow) {
+        throw new Error('No password flow.');
+      }
+
       expect(flow.tokenUrl).to.equal('/ats-api/auth/token');
       expect(flow.authorizationUrl).to.be.undefined;
 
@@ -164,6 +168,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(app.flows.clientCredentials).exist;
 
       const flow = app.flows.clientCredentials;
+
+      if (!flow) {
+        throw new Error('No clientCredentials flow.');
+      }
 
       expect(flow.tokenUrl).to.equal('/ats-api/auth/token');
       expect(flow.authorizationUrl).to.be.undefined;
@@ -189,6 +197,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
       const flow = authCode.flows.authorizationCode;
 
+      if (!flow) {
+        throw new Error('No authorizationCode flow.');
+      }
+
       expect(flow.tokenUrl).to.equal('/ats-api/auth/token');
       expect(flow.authorizationUrl).to.equal('/ats-api/auth/authorization');
 
@@ -212,6 +224,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(imp.flows.implicit).exist;
 
       const flow = imp.flows.implicit;
+
+      if (!flow) {
+        throw new Error('No implicit flow.');
+      }
 
       expect(flow.tokenUrl).to.be.undefined;
       expect(flow.authorizationUrl).to.equal('/ats-api/auth/authorization');


### PR DESCRIPTION

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #843 
