### PR TITLE
Use code from SuccessResponse decorator as default status.

### DIFF
--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -82,6 +82,7 @@ export class RouteGenerator {
               parameters: parameterObjs,
               path: normalisedMethodPath,
               security: method.security,
+              successStatus: method.successStatus || 'undefined',
             };
           }),
           modulePath: this.getRelativeImportPath(controller.location),

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -82,7 +82,7 @@ export class RouteGenerator {
               parameters: parameterObjs,
               path: normalisedMethodPath,
               security: method.security,
-              successStatus: method.successStatus || 'undefined',
+              successStatus: this.options.useSuccessResponseCode && method.successStatus ? method.successStatus : 'undefined',
             };
           }),
           modulePath: this.getRelativeImportPath(controller.location),

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -85,7 +85,7 @@ export function RegisterRoutes(app: express.Router) {
 
 
             const promise = controller.{{name}}.apply(controller, validatedArgs as any);
-            promiseHandler(controller, promise, response, next);
+            promiseHandler(controller, promise, response, {{successStatus}}, next);
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     {{/each}}
@@ -149,10 +149,10 @@ export function RegisterRoutes(app: express.Router) {
         return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
     }
 
-    function promiseHandler(controllerObj: any, promise: any, response: any, next: any) {
+    function promiseHandler(controllerObj: any, promise: any, response: any, successStatus: any, next: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
-                let statusCode;
+                let statusCode = successStatus;
                 let headers;
                 if (isController(controllerObj)) {
                     headers = controllerObj.getHeaders();

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -97,7 +97,7 @@ export function RegisterRoutes(server: any) {
                     {{/if}}
 
                     const promise = controller.{{name}}.apply(controller, validatedArgs as any);
-                    return promiseHandler(controller, promise, request, h);
+                    return promiseHandler(controller, promise, request, {{successStatus}}, h);
                 }
             }
         });
@@ -162,10 +162,10 @@ export function RegisterRoutes(server: any) {
         return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
     }
 
-    function promiseHandler(controllerObj: any, promise: any, request: any, h: any) {
+    function promiseHandler(controllerObj: any, promise: any, request: any, successStatus: any, h: any) {
         return Promise.resolve(promise)
             .then((data: any) => {
-                let statusCode;
+                let statusCode = successStatus;
                 let headers;
 
                 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -87,7 +87,7 @@ export function RegisterRoutes(router: KoaRouter) {
             {{/if}}
 
             const promise = controller.{{name}}.apply(controller, validatedArgs as any);
-            return promiseHandler(controller, promise, context, next);
+            return promiseHandler(controller, promise, context, {{successStatus}}, next);
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     {{/each}}
@@ -157,10 +157,10 @@ export function RegisterRoutes(router: KoaRouter) {
 
   // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-  function promiseHandler(controllerObj: any, promise: Promise<any>, context: any, next: () => Promise<any>) {
+  function promiseHandler(controllerObj: any, promise: Promise<any>, context: any, successStatus: any, next: () => Promise<any>) {
       return Promise.resolve(promise)
         .then((data: any) => {
-            let statusCode;
+            let statusCode = successStatus;
             let headers;
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -204,6 +204,8 @@ export interface RoutesConfig {
   /**
    * When enabled, the `@SuccessResponse` annotations' code is used for responses by default.
    * Otherwise, non-empty responses default to 200 and empty responses to 204.
+   *
+   * @default false
    */
   useSuccessResponseCode?: boolean;
 }

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -200,4 +200,10 @@ export interface RoutesConfig {
    * Authentication Module for express, hapi and koa
    */
   authenticationModule?: string;
+
+  /**
+   * When enabled, the `@SuccessResponse` annotations' code is used for responses by default.
+   * Otherwise, non-empty responses default to 200 and empty responses to 204.
+   */
+  useSuccessResponseCode?: boolean;
 }

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -24,6 +24,7 @@ export namespace Tsoa {
     type: Type;
     tags?: string[];
     responses: Response[];
+    successStatus?: number;
     security: Security[];
     summary?: string;
     isHidden: boolean;

--- a/tests/fixtures/controllers/noExtendsController.ts
+++ b/tests/fixtures/controllers/noExtendsController.ts
@@ -1,0 +1,26 @@
+import { Get, Route, SuccessResponse } from '@tsoa/runtime';
+
+enum TEST_ENUM_CODES {
+  ACCEPTED = 202,
+}
+
+@Route('NoExtends')
+export class NoExtendsController {
+  @Get('customSuccessResponseCode')
+  @SuccessResponse('202')
+  public async customSuccessResponseCode(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  @Get('enumSuccessResponseCode')
+  @SuccessResponse(TEST_ENUM_CODES.ACCEPTED)
+  public async enumSuccessResponseCode(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  @Get('namedSuccessResponse')
+  @SuccessResponse('Teapot')
+  public async namedSuccessResponse(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/tests/fixtures/controllers/noExtendsController.ts
+++ b/tests/fixtures/controllers/noExtendsController.ts
@@ -18,9 +18,9 @@ export class NoExtendsController {
     return Promise.resolve();
   }
 
-  @Get('namedSuccessResponse')
-  @SuccessResponse('Teapot')
-  public async namedSuccessResponse(): Promise<void> {
+  @Get('rangedSuccessResponse')
+  @SuccessResponse('2XX')
+  public async rangedSuccessResponse(): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/tests/fixtures/express-openapi3/server.ts
+++ b/tests/fixtures/express-openapi3/server.ts
@@ -15,6 +15,7 @@ import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
+import '../controllers/noExtendsController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/express-success-code/server.ts
+++ b/tests/fixtures/express-success-code/server.ts
@@ -1,0 +1,30 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as methodOverride from 'method-override';
+import '../controllers/rootController';
+
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(methodOverride());
+app.use((req: any, res: any, next: any) => {
+  req.stringValue = 'fancyStringForContext';
+  next();
+});
+RegisterRoutes(app);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const status = err.status || 500;
+  const body: any = {
+    fields: err.fields || undefined,
+    message: err.message || 'An error occurred during the request.',
+    name: err.name,
+    status,
+  };
+  res.status(status).json(body);
+});
+
+app.listen();

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -17,6 +17,7 @@ import '../controllers/testController';
 import '../controllers/validateController';
 import '../controllers/exampleController';
 import '../controllers/tagController';
+import '../controllers/noExtendsController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/hapi-success-code/server.ts
+++ b/tests/fixtures/hapi-success-code/server.ts
@@ -1,0 +1,27 @@
+import { Server } from '@hapi/hapi';
+import '../controllers/rootController';
+
+import '../controllers/deleteController';
+import '../controllers/getController';
+import '../controllers/patchController';
+import '../controllers/postController';
+import '../controllers/putController';
+
+import '../controllers/methodController';
+import '../controllers/parameterController';
+import '../controllers/securityController';
+import '../controllers/testController';
+import '../controllers/validateController';
+import '../controllers/noExtendsController';
+
+import { RegisterRoutes } from './routes';
+
+export const server = new Server({});
+
+RegisterRoutes(server);
+
+server.start().catch(err => {
+  if (err) {
+    throw err;
+  }
+});

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -12,6 +12,7 @@ import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
+import '../controllers/noExtendsController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/koa-success-code/server.ts
+++ b/tests/fixtures/koa-success-code/server.ts
@@ -1,0 +1,41 @@
+import * as Koa from 'koa';
+import * as KoaRouter from '@koa/router';
+import '../controllers/rootController';
+
+import '../controllers/deleteController';
+import '../controllers/getController';
+import '../controllers/headController';
+import '../controllers/patchController';
+import '../controllers/postController';
+import '../controllers/putController';
+
+import '../controllers/methodController';
+import '../controllers/parameterController';
+import '../controllers/securityController';
+import '../controllers/testController';
+import '../controllers/validateController';
+import '../controllers/noExtendsController';
+
+import * as bodyParser from 'koa-bodyparser';
+import { RegisterRoutes } from './routes';
+
+const app = new Koa();
+app.use(bodyParser());
+
+const router = new KoaRouter();
+
+RegisterRoutes(router);
+
+// It's important that this come after the main routes are registered
+app.use(async (context, next) => {
+  try {
+    await next();
+  } catch (err) {
+    context.status = err.status || 500;
+    context.body = err.message || 'An error occurred during the request.';
+  }
+});
+
+app.use(router.routes()).use(router.allowedMethods());
+
+export const server = app.listen();

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -14,6 +14,7 @@ import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
+import '../controllers/noExtendsController';
 
 import * as bodyParser from 'koa-bodyparser';
 import { RegisterRoutes } from './routes';

--- a/tests/fixtures/koaNoAdditional/server.ts
+++ b/tests/fixtures/koaNoAdditional/server.ts
@@ -14,6 +14,7 @@ import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
+import '../controllers/noExtendsController';
 
 import * as bodyParser from 'koa-bodyparser';
 import { RegisterRoutes } from './routes';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -377,6 +377,38 @@ describe('Express Server', () => {
     });
   });
 
+  describe('NoExtends', () => {
+    it('should apply custom code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should apply enum code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore named success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/namedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+
   describe('Validate', () => {
     it('should valid minDate and maxDate validation of date type', () => {
       const minDate = '2019-01-01';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -378,27 +378,27 @@ describe('Express Server', () => {
   });
 
   describe('NoExtends', () => {
-    it('should apply custom code from success response', () => {
+    it('should ignore SuccessResponse code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/customSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should apply enum code from success response', () => {
+    it('should ignore SuccessResponse enum code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/enumSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should ignore named success response', () => {
+    it('should ignore SuccessResponse 2XX code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -400,7 +400,7 @@ describe('Express Server', () => {
 
     it('should ignore named success response', () => {
       return verifyGetRequest(
-        basePath + `/NoExtends/namedSuccessResponse`,
+        basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {
           expect(res.status).to.equal(204);
         },

--- a/tests/integration/express-success-code.spec.ts
+++ b/tests/integration/express-success-code.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { app } from '../fixtures/express-success-code/server';
+
+describe('Express Server with useSuccessResponseCode', () => {
+  const basePath = '/v1';
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  describe('NoExtends', () => {
+    it('should apply custom code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should apply enum code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore 2XX code range from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/rangedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+});

--- a/tests/integration/express-success-code.spec.ts
+++ b/tests/integration/express-success-code.spec.ts
@@ -67,4 +67,46 @@ describe('Express Server with useSuccessResponseCode', () => {
       );
     });
   });
+
+  describe('Controller', () => {
+    it('should normal status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/normalStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should normal status code with false boolean result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/falseStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should no content status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/noContentStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+
+    it('should custom status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/customStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(205);
+        },
+        205,
+      );
+    });
+  });
 });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -300,6 +300,38 @@ describe('Hapi Server', () => {
     });
   });
 
+  describe('NoExtends', () => {
+    it('should apply custom code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should apply enum code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore named success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/namedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+
   describe('Validate', () => {
     it('should valid minDate and maxDate validation of date type', () => {
       const minDate = '2019-01-01';

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -323,7 +323,7 @@ describe('Hapi Server', () => {
 
     it('should ignore named success response', () => {
       return verifyGetRequest(
-        basePath + `/NoExtends/namedSuccessResponse`,
+        basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {
           expect(res.status).to.equal(204);
         },

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -301,27 +301,27 @@ describe('Hapi Server', () => {
   });
 
   describe('NoExtends', () => {
-    it('should apply custom code from success response', () => {
+    it('should ignore SuccessResponse code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/customSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should apply enum code from success response', () => {
+    it('should ignore SuccessResponse enum code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/enumSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should ignore named success response', () => {
+    it('should ignore SuccessResponse 2XX code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {

--- a/tests/integration/hapi-success-code.spec.ts
+++ b/tests/integration/hapi-success-code.spec.ts
@@ -67,4 +67,46 @@ describe('Hapi Server with useSuccessResponseCode', () => {
       );
     });
   });
+
+  describe('Controller', () => {
+    it('should normal status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/normalStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should normal status code with false boolean result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/falseStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should no content status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/noContentStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+
+    it('should custom status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/customStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(205);
+        },
+        205,
+      );
+    });
+  });
 });

--- a/tests/integration/hapi-success-code.spec.ts
+++ b/tests/integration/hapi-success-code.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { server } from '../fixtures/hapi-success-code/server';
+
+describe('Hapi Server with useSuccessResponseCode', () => {
+  const basePath = '/v1';
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: any) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(server.listener))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+
+  describe('NoExtends', () => {
+    it('should apply custom code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should apply enum code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore named success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/rangedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+});

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -279,27 +279,27 @@ describe('Koa Server', () => {
   });
 
   describe('NoExtends', () => {
-    it('should apply custom code from success response', () => {
+    it('should ignore SuccessResponse code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/customSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should apply enum code from success response', () => {
+    it('should ignore SuccessResponse enum code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/enumSuccessResponseCode`,
         (err, res) => {
-          expect(res.status).to.equal(202);
+          expect(res.status).to.equal(204);
         },
-        202,
+        204,
       );
     });
 
-    it('should ignore named success response', () => {
+    it('should ignore SuccessResponse 2XX code and use default code', () => {
       return verifyGetRequest(
         basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -278,6 +278,38 @@ describe('Koa Server', () => {
     });
   });
 
+  describe('NoExtends', () => {
+    it('should apply custom code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should apply enum code from success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore named success response', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/namedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+
   describe('Validate', () => {
     it('should valid minDate and maxDate validation of date type', () => {
       const minDate = '2019-01-01';

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -301,7 +301,7 @@ describe('Koa Server', () => {
 
     it('should ignore named success response', () => {
       return verifyGetRequest(
-        basePath + `/NoExtends/namedSuccessResponse`,
+        basePath + `/NoExtends/rangedSuccessResponse`,
         (err, res) => {
           expect(res.status).to.equal(204);
         },

--- a/tests/integration/koa-success-code.spec.ts
+++ b/tests/integration/koa-success-code.spec.ts
@@ -69,5 +69,47 @@ describe('Koa Server with useSuccessResponseCode', () => {
     });
   });
 
+  describe('Controller', () => {
+    it('should normal status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/normalStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should normal status code with false boolean result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/falseStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
+    it('should no content status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/noContentStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+
+    it('should custom status code', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/customStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(205);
+        },
+        205,
+      );
+    });
+  });
+
   it('shutdown server', () => server.close());
 });

--- a/tests/integration/koa-success-code.spec.ts
+++ b/tests/integration/koa-success-code.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { server } from '../fixtures/koa-success-code/server';
+
+describe('Koa Server with useSuccessResponseCode', () => {
+  const basePath = '/v1';
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(server))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+
+  describe('NoExtends', () => {
+    it('should ignore SuccessResponse code and use default code', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/customSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore SuccessResponse enum code and use default code', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/enumSuccessResponseCode`,
+        (err, res) => {
+          expect(res.status).to.equal(202);
+        },
+        202,
+      );
+    });
+
+    it('should ignore SuccessResponse 2XX code and use default code', () => {
+      return verifyGetRequest(
+        basePath + `/NoExtends/rangedSuccessResponse`,
+        (err, res) => {
+          expect(res.status).to.equal(204);
+        },
+        204,
+      );
+    });
+  });
+
+  it('shutdown server', () => server.close());
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -84,6 +84,22 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         metadata,
       ),
     ),
+    log('Express Route Generation with useSuccessResponseCode feature', () =>
+      generateRoutes(
+        {
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          authenticationModule: './fixtures/express/authentication.ts',
+          basePath: '/v1',
+          entryFile: './fixtures/express-success-code/server.ts',
+          middleware: 'express',
+          routesDir: './fixtures/express-success-code',
+          useSuccessResponseCode: true,
+        },
+        undefined,
+        undefined,
+        metadata,
+      ),
+    ),
     log('Koa Route Generation', () =>
       generateRoutes(
         {
@@ -114,6 +130,22 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         metadata,
       ),
     ),
+    log('Koa Route Generation with useSuccessResponseCode feature', () =>
+      generateRoutes(
+        {
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          authenticationModule: './fixtures/koa/authentication.ts',
+          basePath: '/v1',
+          entryFile: './fixtures/koa-success-code/server.ts',
+          middleware: 'koa',
+          routesDir: './fixtures/koa-success-code',
+          useSuccessResponseCode: true,
+        },
+        undefined,
+        undefined,
+        metadata,
+      ),
+    ),
     log('Hapi Route Generation', () =>
       generateRoutes({
         noImplicitAdditionalProperties: 'silently-remove-extras',
@@ -122,6 +154,17 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         entryFile: './fixtures/hapi/server.ts',
         middleware: 'hapi',
         routesDir: './fixtures/hapi',
+      }),
+    ),
+    log('Hapi Route Generation with useSuccessResponseCode feature', () =>
+      generateRoutes({
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        authenticationModule: './fixtures/hapi/authentication.ts',
+        basePath: '/v1',
+        entryFile: './fixtures/hapi-success-code/server.ts',
+        middleware: 'hapi',
+        routesDir: './fixtures/hapi-success-code',
+        useSuccessResponseCode: true,
       }),
     ),
     log('Custom Route Generation', () =>


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #723 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Although this seems to "fix" TSOA to have the actual response code match the spec when given through `@SuccessResponse`, it is also a breaking change, so I completely understand if a different solution would be preferred.

**Test plan**

Unit test shows the 202 value from the `@SucessResponse` on a controller that doesn't extend `Controller`. Also a test for cases where `@SucessResponse` has something other than a numeric status code.
