### PR TITLE
Validate path variables. Fixes #865

### DIFF
--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -4,7 +4,7 @@ import { ExtendedRoutesConfig } from '../cli';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '@tsoa/runtime';
 import { RouteGenerator } from '../routeGeneration/routeGenerator';
-import { convertBracketPathParams } from '../utils/pathUtils';
+import { convertBracesPathParams } from '../utils/pathUtils';
 
 export const generateRoutes = async (
   routesConfig: ExtendedRoutesConfig,
@@ -21,7 +21,7 @@ export const generateRoutes = async (
 
   const routeGenerator = new RouteGenerator(metadata, routesConfig);
 
-  let pathTransformer = convertBracketPathParams;
+  let pathTransformer = convertBracesPathParams;
   let template;
 
   switch (routesConfig.middleware) {

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -4,6 +4,7 @@ import { ExtendedRoutesConfig } from '../cli';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '@tsoa/runtime';
 import { RouteGenerator } from '../routeGeneration/routeGenerator';
+import { convertBracketPathParams } from '../utils/pathUtils';
 
 export const generateRoutes = async (
   routesConfig: ExtendedRoutesConfig,
@@ -20,9 +21,8 @@ export const generateRoutes = async (
 
   const routeGenerator = new RouteGenerator(metadata, routesConfig);
 
-  let pathTransformer;
+  let pathTransformer = convertBracketPathParams;
   let template;
-  pathTransformer = (path: string) => path.replace(/{/g, ':').replace(/}/g, '');
 
   switch (routesConfig.middleware) {
     case 'express':

--- a/packages/cli/src/utils/pathUtils.ts
+++ b/packages/cli/src/utils/pathUtils.ts
@@ -30,9 +30,5 @@ export function convertColonPathParams(path: string) {
 }
 
 export function convertBracesPathParams(path: string) {
-  const normalised = path.replace(/{([^\/]+)}/g, ':$1');
-  if (normalised.indexOf('{') >= 0 || normalised.indexOf('}') >= 0) {
-    throw new Error(`Invalid parameters found in path: ${path}`);
-  }
-  return normalised;
+  return path.replace(/{([^\/]+)}/g, ':$1');
 }

--- a/packages/cli/src/utils/pathUtils.ts
+++ b/packages/cli/src/utils/pathUtils.ts
@@ -29,7 +29,7 @@ export function convertColonPathParams(path: string) {
   return normalised;
 }
 
-export function convertBracketPathParams(path: string) {
+export function convertBracesPathParams(path: string) {
   const normalised = path.replace(/{([^\/]+)}/g, ':$1');
   if (normalised.indexOf('{') >= 0 || normalised.indexOf('}') >= 0) {
     throw new Error(`Invalid parameters found in path: ${path}`);

--- a/packages/cli/src/utils/pathUtils.ts
+++ b/packages/cli/src/utils/pathUtils.ts
@@ -28,3 +28,11 @@ export function convertColonPathParams(path: string) {
   const normalised = path.replace(/:([^\/]+)/g, '{$1}');
   return normalised;
 }
+
+export function convertBracketPathParams(path: string) {
+  const normalised = path.replace(/{([^\/]+)}/g, ':$1');
+  if (normalised.indexOf('{') >= 0 || normalised.indexOf('}') >= 0) {
+    throw new Error(`Invalid parameters found in path: ${path}`);
+  }
+  return normalised;
+}

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import 'mocha';
-import { normalisePath, convertColonPathParams } from '@tsoa/cli/utils/pathUtils';
+import { normalisePath, convertColonPathParams, convertBracketPathParams } from '@tsoa/cli/utils/pathUtils';
 
 describe('Paths normalisation', () => {
   it('should remove all redundant symbols at the beginning and at the end', () => {
@@ -86,5 +86,28 @@ describe('Colon path params conversion', () => {
     expect(convertColonPathParams('')).to.equal('');
     const emptyObject = {};
     expect(convertColonPathParams(emptyObject as any)).to.equal(emptyObject);
+  });
+});
+
+describe('Bracket path params conversion', () => {
+  it('should not modify paths without brackets', () => {
+    expect(convertBracketPathParams('path1/path2')).to.equal('path1/path2');
+    expect(convertBracketPathParams('path1/:pathParam')).to.equal('path1/:pathParam');
+  });
+
+  it('should replace "{param}" with ":param" in path', () => {
+    expect(convertBracketPathParams('{pathParam}')).to.equal(':pathParam');
+    expect(convertBracketPathParams('/path1/{pathParam}')).to.equal('/path1/:pathParam');
+    expect(convertBracketPathParams('/path1/{pathParam}/path2')).to.equal('/path1/:pathParam/path2');
+  });
+
+  it('should handle empty path', () => {
+    expect(convertBracketPathParams('')).to.equal('');
+  });
+
+  it('should throw with invalid params', () => {
+    expect(() => convertBracketPathParams('{')).to.throw();
+    expect(() => convertBracketPathParams('path}')).to.throw();
+    expect(() => convertBracketPathParams('/path/{pathParam1}/{pathParam2')).to.throw();
   });
 });

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -95,7 +95,7 @@ describe('Braces path params conversion', () => {
     expect(convertBracesPathParams('path1/:pathParam')).to.equal('path1/:pathParam');
   });
 
-  it('should replace "{param}" with ":param" in path', () => {
+  it('should replace braces params with colon params', () => {
     expect(convertBracesPathParams('{pathParam}')).to.equal(':pathParam');
     expect(convertBracesPathParams('/path1/{pathParam}')).to.equal('/path1/:pathParam');
     expect(convertBracesPathParams('/path1/{pathParam}/path2')).to.equal('/path1/:pathParam/path2');
@@ -105,9 +105,9 @@ describe('Braces path params conversion', () => {
     expect(convertBracesPathParams('')).to.equal('');
   });
 
-  it('should throw with invalid params', () => {
-    expect(() => convertBracesPathParams('{')).to.throw();
-    expect(() => convertBracesPathParams('path}')).to.throw();
-    expect(() => convertBracesPathParams('/path/{pathParam1}/{pathParam2')).to.throw();
+  it('should not replace floating braces', () => {
+    expect(() => convertBracesPathParams('{')).to.equal('{');
+    expect(() => convertBracesPathParams('path}')).to.equal('path}');
+    expect(() => convertBracesPathParams('/path/{pathParam1}/{pathParam2')).to.equal('/path/:pathParam/{pathParam2');
   });
 });

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -95,10 +95,14 @@ describe('Braces path params conversion', () => {
     expect(convertBracesPathParams('path1/:pathParam')).to.equal('path1/:pathParam');
   });
 
-  it('should replace braces params with colon params', () => {
+  it('should replace braces param with colon param', () => {
     expect(convertBracesPathParams('{pathParam}')).to.equal(':pathParam');
     expect(convertBracesPathParams('/path1/{pathParam}')).to.equal('/path1/:pathParam');
     expect(convertBracesPathParams('/path1/{pathParam}/path2')).to.equal('/path1/:pathParam/path2');
+  });
+
+  it('should replace multiple braces params with colon params', () => {
+    expect(convertBracesPathParams('/path1/{pathParam1}/path2/{pathParam2}')).to.equal('/path1/:pathParam1/path2/:pathParam2');
   });
 
   it('should handle empty path', () => {
@@ -106,8 +110,8 @@ describe('Braces path params conversion', () => {
   });
 
   it('should not replace floating braces', () => {
-    expect(() => convertBracesPathParams('{')).to.equal('{');
-    expect(() => convertBracesPathParams('path}')).to.equal('path}');
-    expect(() => convertBracesPathParams('/path/{pathParam1}/{pathParam2')).to.equal('/path/:pathParam/{pathParam2');
+    expect(convertBracesPathParams('{')).to.equal('{');
+    expect(convertBracesPathParams('path}')).to.equal('path}');
+    expect(convertBracesPathParams('/path/{pathParam1}/{pathParam2')).to.equal('/path/:pathParam1/{pathParam2');
   });
 });

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import 'mocha';
-import { normalisePath, convertColonPathParams, convertBracketPathParams } from '@tsoa/cli/utils/pathUtils';
+import { normalisePath, convertColonPathParams, convertBracesPathParams } from '@tsoa/cli/utils/pathUtils';
 
 describe('Paths normalisation', () => {
   it('should remove all redundant symbols at the beginning and at the end', () => {
@@ -89,25 +89,25 @@ describe('Colon path params conversion', () => {
   });
 });
 
-describe('Bracket path params conversion', () => {
-  it('should not modify paths without brackets', () => {
-    expect(convertBracketPathParams('path1/path2')).to.equal('path1/path2');
-    expect(convertBracketPathParams('path1/:pathParam')).to.equal('path1/:pathParam');
+describe('Braces path params conversion', () => {
+  it('should not modify paths without braces', () => {
+    expect(convertBracesPathParams('path1/path2')).to.equal('path1/path2');
+    expect(convertBracesPathParams('path1/:pathParam')).to.equal('path1/:pathParam');
   });
 
   it('should replace "{param}" with ":param" in path', () => {
-    expect(convertBracketPathParams('{pathParam}')).to.equal(':pathParam');
-    expect(convertBracketPathParams('/path1/{pathParam}')).to.equal('/path1/:pathParam');
-    expect(convertBracketPathParams('/path1/{pathParam}/path2')).to.equal('/path1/:pathParam/path2');
+    expect(convertBracesPathParams('{pathParam}')).to.equal(':pathParam');
+    expect(convertBracesPathParams('/path1/{pathParam}')).to.equal('/path1/:pathParam');
+    expect(convertBracesPathParams('/path1/{pathParam}/path2')).to.equal('/path1/:pathParam/path2');
   });
 
   it('should handle empty path', () => {
-    expect(convertBracketPathParams('')).to.equal('');
+    expect(convertBracesPathParams('')).to.equal('');
   });
 
   it('should throw with invalid params', () => {
-    expect(() => convertBracketPathParams('{')).to.throw();
-    expect(() => convertBracketPathParams('path}')).to.throw();
-    expect(() => convertBracketPathParams('/path/{pathParam1}/{pathParam2')).to.throw();
+    expect(() => convertBracesPathParams('{')).to.throw();
+    expect(() => convertBracesPathParams('path}')).to.throw();
+    expect(() => convertBracesPathParams('/path/{pathParam1}/{pathParam2')).to.throw();
   });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
Closes #865

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
- Breaking change. Would any users rely on `{` or `}` being part of their path?
<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
- Unit tests show `{param}` -> `:param` replacement still works, and that errant `{` or `}` now throw
<!-- explain why the unit tests that you added are demonstrating that the feature works -->
