### PR TITLE
Test renamed imports

### DIFF
--- a/tests/fixtures/controllers/controllerWithRenamedMethodImport.ts
+++ b/tests/fixtures/controllers/controllerWithRenamedMethodImport.ts
@@ -1,0 +1,12 @@
+import { Controller, Get as RequestGet, Route } from '@tsoa/runtime';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+@Route('RenamedMethodImport')
+export class RenamedMethodImportController extends Controller {
+
+  @RequestGet()
+  public async get(): Promise<TestModel> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+}

--- a/tests/fixtures/controllers/controllerWithRenamedModelImport.ts
+++ b/tests/fixtures/controllers/controllerWithRenamedModelImport.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Route } from '@tsoa/runtime';
+import { ModelService } from '../services/modelService';
+import { TestModel as TestModelRenamed } from '../testModel';
+
+@Route('RenamedModelImport')
+export class RenamedModelImportsController extends Controller {
+
+  @Get()
+  public async get(): Promise<TestModelRenamed> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+}

--- a/tests/unit/swagger/pathGeneration/renamedImports.spec.ts
+++ b/tests/unit/swagger/pathGeneration/renamedImports.spec.ts
@@ -1,0 +1,21 @@
+import 'mocha';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
+import { getDefaultExtendedOptions } from 'fixtures/defaultOptions';
+import { VerifyPath } from 'unit/utilities/verifyPath';
+
+describe('Renamed imports', () => {
+  describe('method', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/controllerWithRenamedMethodImport.ts').Generate();
+    const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+    const baseRoute = '/RenamedMethodImport';
+
+    it('should generate a path for a function with a renamed method decorator', () => {
+      verifyPath(baseRoute);
+    });
+
+    function verifyPath(route: string, isCollection?: boolean, isNoContent?: boolean) {
+      return VerifyPath(spec, route, path => path.get, isCollection, isNoContent);
+    }
+  });
+});

--- a/tests/unit/swagger/pathGeneration/renamedImports.spec.ts
+++ b/tests/unit/swagger/pathGeneration/renamedImports.spec.ts
@@ -18,4 +18,18 @@ describe('Renamed imports', () => {
       return VerifyPath(spec, route, path => path.get, isCollection, isNoContent);
     }
   });
+
+  describe('model', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/controllerWithRenamedModelImport.ts').Generate();
+    const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+    const baseRoute = '/RenamedModelImport';
+
+    it('should generate a path for a function with a renamed model', () => {
+      verifyPath(baseRoute);
+    });
+
+    function verifyPath(route: string, isCollection?: boolean, isNoContent?: boolean) {
+      return VerifyPath(spec, route, path => path.get, isCollection, isNoContent);
+    }
+  });
 });


### PR DESCRIPTION
`tsoa` does not support renaming of decorators in imports nor renaming of models. This is a problem in case there is a naming conflict, for example when you have a model named `Post`. 

The two new fixtures included in this PR contain examples of decorators such as `Get` being renamed and models being renamed.

Model renaming crashes the test suite outright. Method decorator renaming fails more gracefully.