### PR TITLE
Rethrow original validation error in Koa template

### DIFF
--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -72,7 +72,7 @@ export function RegisterRoutes(router: KoaRouter) {
               validatedArgs = getValidatedArgs(args, context, next);
             } catch (error) {
               context.status = error.status;
-              context.throw(error.status, JSON.stringify({ fields: error.fields }));
+              context.throw(error.status, JSON.stringify({ fields: error.fields }), error);
             }
 
             {{#if ../../iocModule}}


### PR DESCRIPTION
The Express template rethrows the original validation error, however the Koa template does not.

By throwing the original validation error object, error handling code can catch the error (e.g. "error instanceof ValidateError") and deal with the error accordingly, as per the docs.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?