### PR TITLE
Feat: allow path parameters on controllers

### DIFF
--- a/packages/cli/src/metadataGeneration/controllerGenerator.ts
+++ b/packages/cli/src/metadataGeneration/controllerGenerator.ts
@@ -46,7 +46,7 @@ export class ControllerGenerator {
   private buildMethods() {
     return this.node.members
       .filter(m => m.kind === ts.SyntaxKind.MethodDeclaration)
-      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.commonResponses, this.tags, this.security, this.isHidden))
+      .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.current, this.commonResponses, this.path, this.tags, this.security, this.isHidden))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
   }

--- a/packages/cli/src/metadataGeneration/methodGenerator.ts
+++ b/packages/cli/src/metadataGeneration/methodGenerator.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import * as path from 'path';
 import { isVoidType } from '../utils/isVoidType';
 import { getDecorators, getDecoratorValues, getSecurites } from './../utils/decoratorUtils';
 import { getJSDocComment, getJSDocDescription, isExistJSDocTag } from './../utils/jsDocUtils';
@@ -18,6 +19,7 @@ export class MethodGenerator {
     private readonly node: ts.MethodDeclaration,
     private readonly current: MetadataGenerator,
     private readonly commonResponses: Tsoa.Response[],
+    private readonly parentPath?: string,
     private readonly parentTags?: string[],
     private readonly parentSecurity?: Tsoa.Security[],
     private readonly isParentHidden?: boolean,
@@ -69,10 +71,11 @@ export class MethodGenerator {
   }
 
   private buildParameters() {
+    const fullPath = path.join(this.parentPath || '', this.path);
     const parameters = this.node.parameters
       .map(p => {
         try {
-          return new ParameterGenerator(p, this.method, this.path, this.current).Generate();
+          return new ParameterGenerator(p, this.method, fullPath, this.current).Generate();
         } catch (e) {
           const methodId = this.node.name as ts.Identifier;
           const controllerId = (this.node.parent as ts.ClassDeclaration).name as ts.Identifier;

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -63,7 +63,7 @@ export class RouteGenerator {
       basePath: normalisedBasePath,
       canImportByAlias,
       controllers: this.metadata.controllers.map(controller => {
-        const normalisedControllerPath = normalisePath(controller.path, '/');
+        const normalisedControllerPath = pathTransformer(normalisePath(controller.path, '/'));
 
         return {
           actions: controller.methods.map(method => {

--- a/tests/fixtures/controllers/subresourceController.ts
+++ b/tests/fixtures/controllers/subresourceController.ts
@@ -12,12 +12,16 @@ export class SubResourceTestController {
     return `${mainResourceId}:${subResourceId}`;
   }
 }
+
+@Route('SubResourceColonTest/:mainResourceId/SubResource')
+export class SubResourceColonTestController {
+  @Get()
+  public async getSubResource(@Path('mainResourceId') mainResourceId: string): Promise<string> {
+    return mainResourceId;
   }
 
   @Get('{subResourceId}')
-  public async getWithParameter(@Path('mainResourceId') mainResourceId: string, @Path('subResourceId') subResourceId: string): Promise<TestModel> {
-    const model = new ModelService().getModel();
-    model.stringArray = [mainResourceId, subResourceId];
-    return model;
+  public async getWithParameter(@Path('mainResourceId') mainResourceId: string, @Path('subResourceId') subResourceId: string): Promise<string> {
+    return `${mainResourceId}:${subResourceId}`;
   }
 }

--- a/tests/fixtures/controllers/subresourceController.ts
+++ b/tests/fixtures/controllers/subresourceController.ts
@@ -1,0 +1,21 @@
+import { Get, Path, Route } from '@tsoa/runtime';
+
+import { TestModel } from '../testModel';
+import { ModelService } from './../services/modelService';
+
+@Route('SubResourceTest/{mainResourceId}/SubResource')
+export class SubResourceTestController {
+  @Get()
+  public async getSubResource(@Path('mainResourceId') mainResourceId: string): Promise<TestModel> {
+    const model = new ModelService().getModel();
+    model.stringArray = [mainResourceId];
+    return model;
+  }
+
+  @Get('{subResourceId}')
+  public async getWithParameter(@Path('mainResourceId') mainResourceId: string, @Path('subResourceId') subResourceId: string): Promise<TestModel> {
+    const model = new ModelService().getModel();
+    model.stringArray = [mainResourceId, subResourceId];
+    return model;
+  }
+}

--- a/tests/fixtures/controllers/subresourceController.ts
+++ b/tests/fixtures/controllers/subresourceController.ts
@@ -1,15 +1,17 @@
 import { Get, Path, Route } from '@tsoa/runtime';
 
-import { TestModel } from '../testModel';
-import { ModelService } from './../services/modelService';
-
 @Route('SubResourceTest/{mainResourceId}/SubResource')
 export class SubResourceTestController {
   @Get()
-  public async getSubResource(@Path('mainResourceId') mainResourceId: string): Promise<TestModel> {
-    const model = new ModelService().getModel();
-    model.stringArray = [mainResourceId];
-    return model;
+  public async getSubResource(@Path('mainResourceId') mainResourceId: string): Promise<string> {
+    return mainResourceId;
+  }
+
+  @Get('{subResourceId}')
+  public async getWithParameter(@Path('mainResourceId') mainResourceId: string, @Path('subResourceId') subResourceId: string): Promise<string> {
+    return `${mainResourceId}:${subResourceId}`;
+  }
+}
   }
 
   @Get('{subResourceId}')

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -19,6 +19,7 @@ import '../controllers/validateController';
 import '../controllers/exampleController';
 import '../controllers/tagController';
 import '../controllers/noExtendsController';
+import '../controllers/subresourceController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -14,6 +14,7 @@ import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
 import '../controllers/noExtendsController';
+import '../controllers/subresourceController';
 
 import { RegisterRoutes } from './routes';
 

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -16,6 +16,7 @@ import '../controllers/securityController';
 import '../controllers/testController';
 import '../controllers/validateController';
 import '../controllers/noExtendsController';
+import '../controllers/subresourceController';
 
 import * as bodyParser from 'koa-bodyparser';
 import { RegisterRoutes } from './routes';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1246,6 +1246,27 @@ describe('Express Server', () => {
     });
   });
 
+  describe('Sub resource', () => {
+    it('parses path parameters from the controller description', () => {
+      const mainResourceId = 'main-123';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId]);
+      });
+    });
+
+    it('parses path parameters from the controller description and method description', () => {
+      const mainResourceId = 'main-123';
+      const subResourceId = 'sub-456';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+      });
+    });
+  });
+
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
     return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
   }

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1251,8 +1251,7 @@ describe('Express Server', () => {
       const mainResourceId = 'main-123';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId]);
+        expect(res.body).to.equal(mainResourceId);
       });
     });
 
@@ -1261,8 +1260,7 @@ describe('Express Server', () => {
       const subResourceId = 'sub-456';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+        expect(res.body).to.equal(`${mainResourceId}:${subResourceId}`);
       });
     });
   });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1090,8 +1090,7 @@ describe('Hapi Server', () => {
       const mainResourceId = 'main-123';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId]);
+        expect(res.text).to.equal(mainResourceId);
       });
     });
 
@@ -1100,8 +1099,7 @@ describe('Hapi Server', () => {
       const subResourceId = 'sub-456';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+        expect(res.text).to.equal(`${mainResourceId}:${subResourceId}`);
       });
     });
   });

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1085,6 +1085,27 @@ describe('Hapi Server', () => {
     });
   });
 
+  describe('Sub resource', () => {
+    it('parses path parameters from the controller description', () => {
+      const mainResourceId = 'main-123';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId]);
+      });
+    });
+
+    it('parses path parameters from the controller description and method description', () => {
+      const mainResourceId = 'main-123';
+      const subResourceId = 'sub-456';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+      });
+    });
+  });
+
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
     return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
   }

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1079,8 +1079,7 @@ describe('Koa Server', () => {
       const mainResourceId = 'main-123';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId]);
+        expect(res.text).to.equal(mainResourceId);
       });
     });
 
@@ -1089,8 +1088,7 @@ describe('Koa Server', () => {
       const subResourceId = 'sub-456';
 
       return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
-        const model = res.body as TestModel;
-        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+        expect(res.text).to.equal(`${mainResourceId}:${subResourceId}`);
       });
     });
   });

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1074,6 +1074,27 @@ describe('Koa Server', () => {
     });
   });
 
+  describe('Sub resource', () => {
+    it('parses path parameters from the controller description', () => {
+      const mainResourceId = 'main-123';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId]);
+      });
+    });
+
+    it('parses path parameters from the controller description and method description', () => {
+      const mainResourceId = 'main-123';
+      const subResourceId = 'sub-456';
+
+      return verifyGetRequest(basePath + `/SubResourceTest/${mainResourceId}/SubResource/${subResourceId}`, (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.stringArray).to.eql([mainResourceId, subResourceId]);
+      });
+    });
+  });
+
   it('shutdown server', () => server.close());
 
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {

--- a/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
@@ -1,0 +1,35 @@
+import 'mocha';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
+import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
+import { VerifyPathableParameter } from '../../utilities/verifyParameter';
+import { VerifyPath } from '../../utilities/verifyPath';
+
+describe('Sub resource route generation', () => {
+  const metadata = new MetadataGenerator('./fixtures/controllers/subResourceController.ts').Generate();
+  const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+  const baseRoute = '/SubResourceTest/{mainResourceId}';
+
+  const getValidatedParameters = (actionRoute: string) => {
+    const path = VerifyPath(spec, actionRoute, path => path.get);
+    if (!path.get) {
+      throw new Error('No get operation.');
+    }
+    if (!path.get.parameters) {
+      throw new Error('No parameters');
+    }
+
+    return path.get.parameters as any;
+  };
+
+  it('should generate a path parameter for method without path parameter', () => {
+    const parameters = getValidatedParameters(`${baseRoute}/SubResource`);
+    VerifyPathableParameter(parameters, 'mainResourceId', 'string', 'path');
+  });
+
+  it('should generate two path parameters for method with path parameter', () => {
+    const parameters = getValidatedParameters(`${baseRoute}/SubResource/{subResourceId}`);
+    VerifyPathableParameter(parameters, 'mainResourceId', 'string', 'path');
+    VerifyPathableParameter(parameters, 'subResourceId', 'string', 'path');
+  });
+});

--- a/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
@@ -4,7 +4,7 @@ import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerato
 import { Tsoa } from '@tsoa/runtime';
 
 describe('Sub resource route generation', () => {
-  const metadata = new MetadataGenerator('./fixtures/controllers/subResourceController.ts').Generate();
+  const metadata = new MetadataGenerator('./fixtures/controllers/subresourceController.ts').Generate();
 
   const variants = [
     {

--- a/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/subResourceRoutes.spec.ts
@@ -5,37 +5,51 @@ import { Tsoa } from '@tsoa/runtime';
 
 describe('Sub resource route generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/subResourceController.ts').Generate();
-  const baseRoute = 'SubResourceTest/{mainResourceId}/SubResource';
 
-  const getParameters = (methodPath: string) => {
-    const controller = metadata.controllers.find(c => c.path === baseRoute);
-    if (!controller) {
-      throw new Error(`Missing controller for ${baseRoute}`);
-    }
+  const variants = [
+    {
+      name: 'Using brackets',
+      baseRoute: 'SubResourceTest/{mainResourceId}/SubResource',
+    },
+    {
+      name: 'Using colon',
+      baseRoute: 'SubResourceColonTest/:mainResourceId/SubResource',
+    },
+  ];
 
-    const method = controller.methods.find(m => m.path === methodPath);
-    if (!method) {
-      throw new Error('Unknown method ');
-    }
+  variants.forEach(({ name, baseRoute }) => {
+    describe(name, () => {
+      const getParameters = (methodPath: string) => {
+        const controller = metadata.controllers.find(c => c.path === baseRoute);
+        if (!controller) {
+          throw new Error(`Missing controller for ${baseRoute}`);
+        }
 
-    return method.parameters;
-  };
+        const method = controller.methods.find(m => m.path === methodPath);
+        if (!method) {
+          throw new Error('Unknown method ');
+        }
 
-  const validatePathParameter = (parameters: Tsoa.Parameter[], name: string) => {
-    const parameter = parameters.find(p => p.name === name);
-    expect(parameter, `Path parameter '${name}' wasn't generated.`).to.exist;
-    expect(parameter!.in).to.equal('path');
-    expect(parameter!.type).to.eql({ dataType: 'string' });
-  };
+        return method.parameters;
+      };
 
-  it('should generate a path parameter for method without path parameter', () => {
-    const parameters = getParameters('');
-    validatePathParameter(parameters, 'mainResourceId');
-  });
+      const validatePathParameter = (parameters: Tsoa.Parameter[], name: string) => {
+        const parameter = parameters.find(p => p.name === name);
+        expect(parameter, `Path parameter '${name}' wasn't generated.`).to.exist;
+        expect(parameter!.in).to.equal('path');
+        expect(parameter!.type).to.eql({ dataType: 'string' });
+      };
 
-  it('should generate two path parameters for method with path parameter', () => {
-    const parameters = getParameters('{subResourceId}');
-    validatePathParameter(parameters, 'mainResourceId');
-    validatePathParameter(parameters, 'subResourceId');
+      it('should generate a path parameter for method without path parameter', () => {
+        const parameters = getParameters('');
+        validatePathParameter(parameters, 'mainResourceId');
+      });
+
+      it('should generate two path parameters for method with path parameter', () => {
+        const parameters = getParameters('{subResourceId}');
+        validatePathParameter(parameters, 'mainResourceId');
+        validatePathParameter(parameters, 'subResourceId');
+      });
+    });
   });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Close #261

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This is quite a simple solution. I am not sure if passing down the controller path this way is the correct way to solve it, or if it would be better to get the parent information from within the `MethodGenerator`. I created this as a starting point for discussion; I'd happily update the approach if preferred.

In the related issue #318 Luke Autry wrote

> The tricky thing would be verifying that each method within the controller properly accepts the path parameter (e.g. {companyId}).

I don't think that is implemented on method level yet either, so I did not add support for that here. Since the full path is in scope when handling the `@Path` decorator, I don't think this solution makes that validation harder, if someone would want to add that later.

**Test plan**

I verified that the correct parameters are generated and that both controller parameters and method parameters can be used in all 3 generated server frameworks.
