### PR TITLE
docs(README): fix broken link to API reference

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ OpenAPI-compliant REST APIs using TypeScript and Node
 ## Getting Started
 
 - [Documentation](https://tsoa-community.github.io/docs/index)
-- [API Reference](https://tsoa-community.github.io/reference/globals.html)
+- [API Reference](https://tsoa-community.github.io/reference)
 - [Getting started guide](https://tsoa-community.github.io/docs/getting-started)
 
 ## Examples


### PR DESCRIPTION
it was pointing to `https://tsoa-community.github.io/reference/globals.html` which does not exist

(removed the PR template as this is just a docs update, and does not need tests)