### PR TITLE
fix(cli): allow returning 0 from controllers

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -174,7 +174,7 @@ export function RegisterRoutes(app: express.Router) {
         });
         if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
             data.pipe(response);
-        } else if (data || data === false) { // === false allows boolean result
+        } else if (data !== null && data !== undefined) {
             response.status(statusCode || 200).json(data);
         } else {
             response.status(statusCode || 204).end();

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -187,7 +187,7 @@ export function RegisterRoutes(server: any) {
             return h.__isTsoaResponded;
         }
 
-        let response = (data || data === false) 
+        let response = data !== null && data !== undefined
                     ? h.response(data).code(200)
                     : h.response("").code(204);
 

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -184,7 +184,7 @@ export function RegisterRoutes(router: KoaRouter) {
         if (!context.response.__tsoaResponded) {
             context.set(headers);
 
-            if (data || data === false) { 
+            if (data !== null && data !== undefined) { 
                 context.body = data;
                 context.status = 200;
             } else {

--- a/tests/fixtures/controllers/testController.ts
+++ b/tests/fixtures/controllers/testController.ts
@@ -21,6 +21,11 @@ export class TestController extends Controller {
     return false;
   }
 
+  @Get('zeroStatusCode')
+  public async zeroStatusCode(): Promise<number> {
+    return 0;
+  }
+
   @Get('customStatusCode')
   public async customNomalStatusCode(): Promise<TestModel> {
     const service = new ModelService();

--- a/tests/fixtures/custom/custom-tsoa-template.ts.hbs
+++ b/tests/fixtures/custom/custom-tsoa-template.ts.hbs
@@ -111,7 +111,7 @@ export function RegisterRoutes(app: any) {
                     statusCode = controller.getStatus();
                 }
 
-                if (data || data === false) {
+                if (data !== null && data !== undefined) {
                     response.status(statusCode || 200).json(data);
                 } else {
                     response.status(statusCode || 204).end();

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -294,6 +294,16 @@ describe('Express Server', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -355,6 +355,16 @@ describe('Express Server', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/express-success-code.spec.ts
+++ b/tests/integration/express-success-code.spec.ts
@@ -89,6 +89,16 @@ describe('Express Server with useSuccessResponseCode', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -278,6 +278,16 @@ describe('Hapi Server', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/hapi-success-code.spec.ts
+++ b/tests/integration/hapi-success-code.spec.ts
@@ -89,6 +89,16 @@ describe('Hapi Server with useSuccessResponseCode', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -256,6 +256,16 @@ describe('Koa Server', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,

--- a/tests/integration/koa-success-code.spec.ts
+++ b/tests/integration/koa-success-code.spec.ts
@@ -90,6 +90,16 @@ describe('Koa Server with useSuccessResponseCode', () => {
       );
     });
 
+    it('should normal status code with 0 result', () => {
+      return verifyGetRequest(
+        basePath + `/Controller/zeroStatusCode`,
+        (err, res) => {
+          expect(res.status).to.equal(200);
+        },
+        200,
+      );
+    });
+
     it('should no content status code', () => {
       return verifyGetRequest(
         basePath + `/Controller/noContentStatusCode`,


### PR DESCRIPTION
Closes #889

Instead of checking for falsyness and guarding for `false` explicitly check if a controller result is `null` or `undefined`, set status code and data based on that. This allows to return `false`, `0` and `''`(empty string).