### PR TITLE
Don't modify the response after headers were sent

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -169,6 +169,9 @@ export function RegisterRoutes(app: express.Router) {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function returnHandler(response: any, statusCode?: number, data?: any, headers: any = {}) {
+        if (response.headersSent) {
+            return;
+        }
         Object.keys(headers).forEach((name: string) => {
             response.set(name, headers[name]);
         });

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -181,7 +181,7 @@ export function RegisterRoutes(router: KoaRouter) {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     function returnHandler(context: any, next: () => any, statusCode?: number, data?: any, headers: any={}) {
-        if (!context.response.__tsoaResponded) {
+        if (!context.headerSent && !context.response.__tsoaResponded) {
             context.set(headers);
 
             if (data !== null && data !== undefined) { 

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -225,6 +225,19 @@ export class GetTestController extends Controller {
   public async getRes(@Res() res: TsoaResponse<400, TestModel, { 'custom-header': string }>): Promise<void> {
     res?.(400, new ModelService().getModel(), { 'custom-header': 'hello' });
   }
+
+  /**
+   * @param res The alternate response
+   * @param res Another alternate response
+   */
+  @Get('MultipleRes')
+  public async multipleRes(@Res() res: TsoaResponse<400, TestModel, { 'custom-header': string }>, @Res() anotherRes: TsoaResponse<401, TestModel, { 'custom-header': string }>): Promise<Result> {
+    res?.(400, new ModelService().getModel(), { 'custom-header': 'hello' });
+    anotherRes?.(401, new ModelService().getModel(), { 'custom-header': 'another hello' });
+    return {
+      value: 'success',
+    };
+  }
 }
 
 export interface ErrorResponse {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -138,6 +138,18 @@ describe('Express Server', () => {
     );
   });
 
+  it('Should not modify the response after headers sent', () => {
+    return verifyGetRequest(
+      basePath + '/GetTest/MultipleRes',
+      (err, res) => {
+        const model = res.body as TestModel;
+        expect(model.id).to.equal(1);
+        expect(res.get('custom-header')).to.eq('hello');
+      },
+      400,
+    );
+  });
+
   it('parses buffer parameter', () => {
     return verifyGetRequest(`${basePath}/GetTest/HandleBufferType?buffer=${base64image}`, (err, res) => {
       return;

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1093,6 +1093,18 @@ describe('Hapi Server', () => {
         400,
       );
     });
+
+    it('Should not modify the response after headers sent', () => {
+      return verifyGetRequest(
+        basePath + '/GetTest/MultipleRes',
+        (err, res) => {
+          const model = res.body as TestModel;
+          expect(model.id).to.equal(1);
+          expect(res.get('custom-header')).to.eq('hello');
+        },
+        400,
+      );
+    });
   });
 
   describe('Sub resource', () => {

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1082,6 +1082,18 @@ describe('Koa Server', () => {
         400,
       );
     });
+
+    it('Should not modify the response after headers sent', () => {
+      return verifyGetRequest(
+        basePath + '/GetTest/MultipleRes',
+        (err, res) => {
+          const model = res.body as TestModel;
+          expect(model.id).to.equal(1);
+          expect(res.get('custom-header')).to.eq('hello');
+        },
+        400,
+      );
+    });
   });
 
   describe('Sub resource', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #904  #859 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

enhancement discussed in #907 #859

**Potential Problems With The Approach**

1. Couldn't find anything similar to `headersSent` for the hapi and wasn't sure how to add same check for this framework. Maybe it's because of the request lifecycle specific for the hapi? Would need someone familiar with hapi to comment.
2. Issues with testing (see below)

**Test plan**

I have added integration test with multiple `@Res`, but it's not really correct in its current state.
- for hapi and koa, the test already succeeds because of the `__isTsoaResponded` checks
- for express I can see the exception ```Error [ERR_HTTP_HEADERS_SENT]``` in the test logs (if the check is not there), but this exception does not cause the test to break (since the client receives proper response). How do I catch that exception in the test and cause it to fail?


