### PR TITLE
Fix @tsoa/runtime's package.json for pnpm by moving avoiding mention of ts.CompilerOptions in Config

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -74,8 +74,8 @@ const getConfig = async (configPath = 'tsoa.json'): Promise<Config> => {
   return config;
 };
 
-const validateCompilerOptions = (config?: ts.CompilerOptions): ts.CompilerOptions => {
-  return config || {};
+const validateCompilerOptions = (config?: Record<string, unknown>): ts.CompilerOptions => {
+  return (config || {}) as ts.CompilerOptions;
 };
 
 export interface ExtendedSpecConfig extends SpecConfig {

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -1,4 +1,3 @@
-import * as ts from 'typescript';
 import { Swagger } from './swagger/swagger';
 
 export interface Config {
@@ -35,10 +34,10 @@ export interface Config {
   /**
    * Typescript CompilerOptions to be used during generation
    *
-   * @type {ts.CompilerOptions}
+   * @type {Record<string, unknown>}
    * @memberof RoutesConfig
    */
-  compilerOptions?: ts.CompilerOptions;
+  compilerOptions?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
  - Related: #730 and #690
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?
  - Sort of (#730), but that issue was closed and it was also made before tsoa was split into separate packages

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

*Edit: Changed approach to avoid referencing typescript-provided types at all.*

Original approach below:

> Sounds like the explicit goal of #690 was to exclude `typescript` as a prod dependency for the runtime.
>
> But if you use pnpm and TypeScript together, it becomes apparent that the runtime *does* in fact depend on `typescript` for its public interface, so it won't compile without the change in this PR.
>
> npm users sneak past this issue because it doesn't isolate dependencies the way pnpm does, so they're able to leverage their dev dependencies even while doing prod builds, and since this is just some config thing tucked away somewhere instead of a deep dependency on calling a function in `typescript`, probably nobody has seen any runtime errors from this issue.

Relevant code from `@tsoa/runtime`:

```ts
// @tsoa/runtime/dist/config.d.ts
import * as ts from 'typescript';
...
export interface Config {
    ...
    compilerOptions?: ts.CompilerOptions;
}
```

Example project demonstrating the error: https://github.com/kibiz0r/tsoa-typescript-dep-bug-example

The example uses regular npm, to prove it's not just pnpm being weird, but that meant I had to reference `@tsoa/runtime` instead of `tsoa` in order to trigger the behavior that pnpm triggers simply by referencing `tsoa`.

```
yarn run v1.22.4
$ tsc
node_modules/@tsoa/runtime/dist/config.d.ts:1:21 - error TS2307: Cannot find module 'typescript' or its corresponding type declarations.

1 import * as ts from 'typescript';
                      ~~~~~~~~~~~~
```

So two options here are:
1. Accept the prod dependency
2. Avoid the reference to typescript in the public API

I assume the authors prefer option 2, so they can indeed omit `typescript` from `@tsoa/runtime` actual (not declared) dependencies.

~~But that's a design change, where this PR is just a change to make the declared dependencies match the actual dependencies, thus making strict package managers like pnpm work with tsoa as it is designed today.~~

Edit: Going with option 2.