### PR TITLE
Add @Inject decorator for ignoring injected parameters

### DIFF
--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -30,6 +30,8 @@ export class ParameterGenerator {
         return this.getPathParameter(this.parameter);
       case 'Res':
         return this.getResParameter(this.parameter);
+      case 'Inject':
+        return null;
       default:
         return this.getPathParameter(this.parameter);
     }
@@ -262,7 +264,7 @@ export class ParameterGenerator {
   }
 
   private supportParameterDecorator(decoratorName: string) {
-    return ['header', 'query', 'path', 'body', 'bodyprop', 'request', 'res'].some(d => d === decoratorName.toLocaleLowerCase());
+    return ['header', 'query', 'path', 'body', 'bodyprop', 'request', 'res', 'inject'].some(d => d === decoratorName.toLocaleLowerCase());
   }
 
   private supportPathDataType(parameterType: Tsoa.Type) {

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -60,3 +60,12 @@ export function Header(name?: string): Function {
     return;
   };
 }
+
+/**
+ * Mark parameter as manually injected, which will not be generated
+ */
+export function Inject(): Function {
+  return () => {
+    return;
+  };
+}

--- a/tests/fixtures/controllers/injectParameterController.ts
+++ b/tests/fixtures/controllers/injectParameterController.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, Query, Inject, Route } from '@tsoa/runtime';
+import { TestModel } from '../../fixtures/testModel';
+import { ModelService } from '../services/modelService';
+
+@Route('Controller')
+export class InjectParameterController extends Controller {
+  @Get('injectParameterMethod')
+  public async injectParameterMethod(@Query() normalParam: string, @Inject() injectedParam: string): Promise<TestModel> {
+    return Promise.resolve(new ModelService().getModel());
+  }
+}

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -173,6 +173,30 @@ describe('Schema details generation', () => {
         expect(normalParam.type).to.equal('string');
       });
 
+      it('should not contain injected params', () => {
+        const metadataHidden = new MetadataGenerator('./fixtures/controllers/injectParameterController.ts').Generate();
+        const specHidden = new SpecGenerator2(metadataHidden, getDefaultExtendedOptions()).GetSpec();
+
+        if (!specHidden.paths) {
+          throw new Error('Paths are not defined.');
+        }
+        if (!specHidden.paths['/Controller/injectParameterMethod']) {
+          throw new Error('injectParameterMethod path not defined.');
+        }
+        if (!specHidden.paths['/Controller/injectParameterMethod'].get) {
+          throw new Error('injectParameterMethod get method not defined.');
+        }
+
+        const method = specHidden.paths['/Controller/injectParameterMethod'].get;
+        expect(method.parameters).to.have.lengthOf(1);
+
+        const normalParam = method.parameters![0];
+        expect(normalParam.in).to.equal('query');
+        expect(normalParam.name).to.equal('normalParam');
+        expect(normalParam.required).to.be.true;
+        expect(normalParam.type).to.equal('string');
+      });
+
       it('should not contain paths for hidden controller', () => {
         const metadataHiddenController = new MetadataGenerator('./fixtures/controllers/hiddenController.ts').Generate();
         const specHiddenController = new SpecGenerator2(metadataHiddenController, getDefaultExtendedOptions()).GetSpec();


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Closing issues**

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

I'm not sure if this counts as a new feature, because the doc is already [mentioning this decorator](https://tsoa-community.github.io/docs/decorators.html#request):

> Note that the parameter request does not appear in your OAS file. Likewise you can use the decorator @Inject to mark a parameter as being injected manually and should be omitted in Spec generation. In this case you should write your own custom template where you inject the needed objects/values in the method-call.

The reason I made this PR is because I couldn't find the `@Inject` decorator. I'm currently trying to use `tsoa` for a project where the controllers have injected parameters that shouldn't appear in the spec (e.g. authenticated user object).

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

The unit test is very similar to how `@Hidden` decorator is tested. It creates a controller with a method with 2 parameters, and one on them is decorated with `@Inject`. The parameter marked as injected should not appear in the generated spec.
