### PR TITLE
Make @tsoaModel decorator work for enums

### DIFF
--- a/tests/fixtures/duplicateTestModel.ts
+++ b/tests/fixtures/duplicateTestModel.ts
@@ -1,1 +1,10 @@
 export class TestModel {}
+/**
+ * This enum deliberately deviates from
+ * the original to make sure the test would fail
+ * if this enum is chosen over the other
+ */
+export enum EnumStringNumberValue {
+  VALUE_X,
+  VALUE_Y,
+}

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -264,6 +264,7 @@ export enum EnumNumberValue {
 
 /**
  * EnumStringNumberValue.
+ * @tsoaModel
  */
 export enum EnumStringNumberValue {
   VALUE_0 = '0',


### PR DESCRIPTION
Create private method which returns designated nodes
Make 'getEnumerateType' and 'getModelTypeDeclaration' use this method

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #842


**Test plan**

I added another `EnumStringNumberValue` in `duplicateTestModel.ts` which would trigger the `Multiple matching models found`-error.

But since the original `EnumStringNumberValue` declared in `testModel.ts` now has `@tsoaModel` it won't.
Before it would have triggered the `Multiple matching enum found`-error. But with this fix it doesn't.
