### PR TITLE
allow arrays in @Extension decorator values

### DIFF
--- a/packages/runtime/src/decorators/extension.ts
+++ b/packages/runtime/src/decorators/extension.ts
@@ -4,4 +4,4 @@ export function Extension(_name: string, _value: ExtensionType | ExtensionType[]
   };
 }
 
-export type ExtensionType = string | { [name: string]: ExtensionType };
+export type ExtensionType = string | { [name: string]: ExtensionType | ExtensionType[] };

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -159,6 +159,7 @@ export class MethodController extends Controller {
   @Extension('x-attKey1', { test: 'testVal' })
   @Extension('x-attKey2', ['y0', 'y1'])
   @Extension('x-attKey3', [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }])
+  @Extension('x-attKey4', { test: ['testVal'] })
   @Get('Extension')
   public async extension(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -298,6 +298,7 @@ describe('Metadata generation', () => {
         { key: 'x-attKey1', value: { test: 'testVal' } },
         { key: 'x-attKey2', value: ['y0', 'y1'] },
         { key: 'x-attKey3', value: [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }] },
+        { key: 'x-attKey4', value: { test: ['testVal'] } },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -510,11 +510,13 @@ describe('Schema details generation', () => {
     expect(extensionPath).to.have.property('x-attKey1');
     expect(extensionPath).to.have.property('x-attKey2');
     expect(extensionPath).to.have.property('x-attKey3');
+    expect(extensionPath).to.have.property('x-attKey4');
 
     // Verify that extensions have correct values
     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
     expect(extensionPath['x-attKey1']).to.deep.equal({ test: 'testVal' });
     expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
     expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
+    expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
   });
 });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2038,12 +2038,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
     expect(extensionPath).to.have.property('x-attKey1');
     expect(extensionPath).to.have.property('x-attKey2');
     expect(extensionPath).to.have.property('x-attKey3');
+    expect(extensionPath).to.have.property('x-attKey4');
 
     // Verify that extensions have correct values
     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
     expect(extensionPath['x-attKey1']).to.deep.equal({ test: 'testVal' });
     expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
     expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
+    expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
   });
 
   describe('module declarations with namespaces', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #951

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

Added new assertions for arrays inside objects to the existing @Extension tests.
