### PR TITLE
fix: Hapi errors when passing error to h.response

### DIFF
--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -13,7 +13,7 @@ import { hapiAuthentication } from '{{authenticationModule}}';
 import { iocContainer } from '{{iocModule}}';
 import { IocContainer, IocContainerFactory } from '@tsoa/runtime';
 {{/if}}
-import { boomify, Payload } from '@hapi/boom';
+import { boomify, isBoom, Payload } from '@hapi/boom';
 import { Request } from '@hapi/hapi';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -100,13 +100,17 @@ export function RegisterRoutes(server: any) {
                     let validatedArgs: any[] = [];
                     try {
                         validatedArgs = getValidatedArgs(args, request, h);
-                    } catch (err) {
-                        const boomErr = boomify(err);
-                        boomErr.output.statusCode = err.status || 500;
+                    } catch (error) {
+                        if (isBoom(error)) {
+                            throw error;
+                        }
+
+                        const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
+                        boomErr.output.statusCode = error.status || 500;
                         boomErr.output.payload = {
-                            name: err.name,
-                            fields: err.fields,
-                            message: err.message,
+                            name: error.name,
+                            fields: error.fields,
+                            message: error.message,
                         } as unknown as Payload;
                         throw boomErr;
                     }
@@ -151,7 +155,17 @@ export function RegisterRoutes(server: any) {
             const fail = function(error: any) {
                 responded++;
                 if (responded == security.length && !success) {
-                    h.response(error).code(error.status || 401);
+                    if (isBoom(error)) {
+                        throw error;
+                    }
+
+                    const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
+                    boomErr.output.statusCode = error.status || 401;
+                    boomErr.output.payload = {
+                        name: error.name,
+                        message: error.message,
+                    } as unknown as Payload;
+                    throw boomErr;
                 }
                 return error;
             };
@@ -249,7 +263,19 @@ export function RegisterRoutes(server: any) {
                 }
                 return returnHandler(h, statusCode, data, headers);;
             })
-            .catch((error: any) => h.response(error).code(error.status || 500));
+            .catch((error: any) => {
+                if (isBoom(error)) {
+                    throw error;
+                }
+
+                const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
+                boomErr.output.statusCode = error.status || 500;
+                boomErr.output.payload = {
+                    name: error.name,
+                    message: error.message,
+                } as unknown as Payload;
+                throw boomErr;
+            });
     }
 
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa


### PR DESCRIPTION
This either re-throws the error if it's already a Boom error, or wraps it in a Boom error and throws it. This is a fix for #921 based off a fix from a private company repo.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.