### PR TITLE
Feat: allow multiple http status codes in res

### DIFF
--- a/packages/cli/src/metadataGeneration/methodGenerator.ts
+++ b/packages/cli/src/metadataGeneration/methodGenerator.ts
@@ -83,7 +83,7 @@ export class MethodGenerator {
           throw new GenerateMetadataError(`${String(e.message)} \n in '${controllerId.text}.${methodId.text}'`);
         }
       })
-      .filter((p): p is Tsoa.Parameter => p !== null);
+      .reduce((flattened, params) => [...flattened, ...params], []);
 
     const bodyParameters = parameters.filter(p => p.in === 'body');
     const bodyProps = parameters.filter(p => p.in === 'body-prop');

--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -12,34 +12,34 @@ import { getHeaderType } from '../utils/headerTypeHelpers';
 export class ParameterGenerator {
   constructor(private readonly parameter: ts.ParameterDeclaration, private readonly method: string, private readonly path: string, private readonly current: MetadataGenerator) {}
 
-  public Generate(): Tsoa.Parameter | null {
+  public Generate(): Tsoa.Parameter[] {
     const decoratorName = getNodeFirstDecoratorName(this.parameter, identifier => this.supportParameterDecorator(identifier.text));
 
     switch (decoratorName) {
       case 'Request':
-        return this.getRequestParameter(this.parameter);
+        return [this.getRequestParameter(this.parameter)];
       case 'Body':
-        return this.getBodyParameter(this.parameter);
+        return [this.getBodyParameter(this.parameter)];
       case 'BodyProp':
-        return this.getBodyPropParameter(this.parameter);
+        return [this.getBodyPropParameter(this.parameter)];
       case 'FormField':
-        return this.getFormFieldParameter(this.parameter);
+        return [this.getFormFieldParameter(this.parameter)];
       case 'Header':
-        return this.getHeaderParameter(this.parameter);
+        return [this.getHeaderParameter(this.parameter)];
       case 'Query':
-        return this.getQueryParameter(this.parameter);
+        return this.getQueryParameters(this.parameter);
       case 'Path':
-        return this.getPathParameter(this.parameter);
+        return [this.getPathParameter(this.parameter)];
       case 'Res':
-        return this.getResParameter(this.parameter);
+        return [this.getResParameter(this.parameter)];
       case 'Inject':
-        return null;
+        return [];
       case 'UploadedFile':
-        return this.getUploadedFileParameter(this.parameter);
+        return [this.getUploadedFileParameter(this.parameter)];
       case 'UploadedFiles':
-        return this.getUploadedFileParameter(this.parameter, true);
+        return [this.getUploadedFileParameter(this.parameter, true)];
       default:
-        return this.getPathParameter(this.parameter);
+        return [this.getPathParameter(this.parameter)];
     }
   }
 
@@ -215,7 +215,7 @@ export class ParameterGenerator {
     };
   }
 
-  private getQueryParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter | null {
+  private getQueryParameters(parameter: ts.ParameterDeclaration): Tsoa.Parameter[] {
     const parameterName = (parameter.name as ts.Identifier).text;
     const type = this.getValidatedType(parameter);
 
@@ -234,7 +234,7 @@ export class ParameterGenerator {
       if (commonProperties.required) {
         throw new GenerateMetadataError(`@Query('${parameterName}') Can't support @Hidden because it is required (does not allow undefined and does not have a default value).`);
       }
-      return null;
+      return [];
     }
 
     if (type.dataType === 'array') {
@@ -242,21 +242,21 @@ export class ParameterGenerator {
       if (!this.supportPathDataType(arrayType.elementType)) {
         throw new GenerateMetadataError(`@Query('${parameterName}') Can't support array '${arrayType.elementType.dataType}' type.`);
       }
-      return {
+      return [{
         ...commonProperties,
         collectionFormat: 'multi',
         type: arrayType,
-      } as Tsoa.ArrayParameter;
+      } as Tsoa.ArrayParameter];
     }
 
     if (!this.supportPathDataType(type)) {
       throw new GenerateMetadataError(`@Query('${parameterName}') Can't support '${type.dataType}' type.`);
     }
 
-    return {
+    return [{
       ...commonProperties,
       type,
-    };
+    }];
   }
 
   private getPathParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter {

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -238,6 +238,14 @@ export class GetTestController extends Controller {
       value: 'success',
     };
   }
+
+  /**
+   * @param res The alternate response
+   */
+   @Get('MultipleStatusCodeRes')
+   public async multipleStatusCodeRes(@Res() res: TsoaResponse<400 | 500, TestModel, { 'custom-header': string }>, @Query('statusCode') statusCode: 400 | 500): Promise<void> {
+     res?.(statusCode, new ModelService().getModel(), { 'custom-header': 'hello' });
+   }
 }
 
 export interface ErrorResponse {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -141,6 +141,20 @@ describe('Express Server', () => {
     );
   });
 
+  [400, 500].forEach(statusCode =>
+    it('Should support multiple status codes with the same @Res structure', () => {
+      return verifyGetRequest(
+        basePath + `/GetTest/MultipleStatusCodeRes?statusCode=${statusCode}`,
+        (err, res) => {
+          const model = res.body as TestModel;
+          expect(model.id).to.equal(1);
+          expect(res.get('custom-header')).to.eq('hello');
+        },
+        statusCode,
+      );
+    })
+  );
+
   it('Should not modify the response after headers sent', () => {
     return verifyGetRequest(
       basePath + '/GetTest/MultipleRes',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1097,6 +1097,20 @@ describe('Hapi Server', () => {
       );
     });
 
+    [400, 500].forEach(statusCode =>
+      it('Should support multiple status codes with the same @Res structure', () => {
+        return verifyGetRequest(
+          basePath + `/GetTest/MultipleStatusCodeRes?statusCode=${statusCode}`,
+          (err, res) => {
+            const model = res.body as TestModel;
+            expect(model.id).to.equal(1);
+            expect(res.get('custom-header')).to.eq('hello');
+          },
+          statusCode,
+        );
+      })
+    );
+
     it('Should not modify the response after headers sent', () => {
       return verifyGetRequest(
         basePath + '/GetTest/MultipleRes',

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1086,6 +1086,20 @@ describe('Koa Server', () => {
       );
     });
 
+    [400, 500].forEach(statusCode =>
+      it('Should support multiple status codes with the same @Res structure', () => {
+        return verifyGetRequest(
+          basePath + `/GetTest/MultipleStatusCodeRes?statusCode=${statusCode}`,
+          (err, res) => {
+            const model = res.body as TestModel;
+            expect(model.id).to.equal(1);
+            expect(res.get('custom-header')).to.eq('hello');
+          },
+          statusCode,
+        );
+      })
+    );
+
     it('Should not modify the response after headers sent', () => {
       return verifyGetRequest(
         basePath + '/GetTest/MultipleRes',

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
 import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
-import { Tsoa } from '@tsoa/runtime';
+import { Swagger, Tsoa } from '@tsoa/runtime';
 import { ExtendedSpecConfig } from '@tsoa/cli/cli';
 
 describe('Schema details generation', () => {
@@ -518,5 +518,39 @@ describe('Schema details generation', () => {
     expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
     expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
     expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
+  });
+
+  describe('@Res responses', () => {
+    const expectTestModelSchema = (response?: Swagger.Response) => {
+      expect(response?.schema).to.deep.equal({
+        $ref: '#/definitions/TestModel',
+      });
+    };
+
+    it('creates a single error response for a single res parameter', () => {
+      const responses = spec.paths['/GetTest/Res']?.get?.responses;
+
+      expect(responses).to.have.all.keys('204', '400');
+
+      expectTestModelSchema(responses?.['400']);
+    });
+
+    it('creates multiple error responses for separate res parameters', () => {
+      const responses = spec.paths['/GetTest/MultipleRes']?.get?.responses;
+
+      expect(responses).to.have.all.keys('200', '400', '401');
+
+      expectTestModelSchema(responses?.['400']);
+      expectTestModelSchema(responses?.['401']);
+    });
+
+    it('creates multiple error responses for a combined res parameter', () => {
+      const responses = spec.paths['/GetTest/MultipleStatusCodeRes']?.get?.responses;
+
+      expect(responses).to.have.all.keys('204', '400', '500');
+
+      expectTestModelSchema(responses?.['400']);
+      expectTestModelSchema(responses?.['500']);
+    });
   });
 });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2104,4 +2104,42 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       });
     });
   });
+
+  describe('@Res responses', () => {
+    const expectTestModelContent = (response?: Swagger.Response3) => {
+      expect(response?.content).to.deep.equal({
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/TestModel',
+          },
+        },
+      });
+    };
+
+    it('creates a single error response for a single res parameter', () => {
+      const responses = specDefault.spec.paths['/GetTest/Res']?.get?.responses;
+
+      expect(responses).to.have.all.keys('204', '400');
+
+      expectTestModelContent(responses?.['400']);
+    });
+
+    it('creates multiple error responses for separate res parameters', () => {
+      const responses = specDefault.spec.paths['/GetTest/MultipleRes']?.get?.responses;
+
+      expect(responses).to.have.all.keys('200', '400', '401');
+
+      expectTestModelContent(responses?.['400']);
+      expectTestModelContent(responses?.['401']);
+    });
+
+    it('creates multiple error responses for a combined res parameter', () => {
+      const responses = specDefault.spec.paths['/GetTest/MultipleStatusCodeRes']?.get?.responses;
+
+      expect(responses).to.have.all.keys('204', '400', '500');
+
+      expectTestModelContent(responses?.['400']);
+      expectTestModelContent(responses?.['500']);
+    });
+  });
 });


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Closing issues**

Closes #919 

### If this is a new feature submission:

- [X] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This is a pretty straightforward solution. Instead of only allowing that the status code is a number, it also allows a union of numbers now, iterates over them, and creates a res parameter for each. I don't see any issues there.

**Test plan**

I added integration tests to ensure that:
- it is now possible to add a union of status codes
- each of those status codes can indeed be returned

I checked the repository but there seemed to be no unit tests yet to verify that `@Res()` decorator can only be used with numbers, not with other types. I didn't add such tests in this PR either.
