### PR TITLE
974 koa hapi multi authentication

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -8,6 +8,8 @@ import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { expressAuthentication } from '{{authenticationModule}}';
+// @ts-ignore - no great way to install types from subpackage
+const promiseAny = require('promise.any');
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -104,51 +106,63 @@ export function RegisterRoutes(app: express.Router) {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
     {{#if useSecurity}}
+
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
     function authenticateMiddleware(security: TsoaRoute.Security[] = []) {
-        return function runAuthenticationMiddleware(request: any, _response: any, next: any) {
-            let responded = 0;
-            let success = false;
-
-            const succeed = function(user: any) {
-                if (!success) {
-                    success = true;
-                    responded++;
-                    request['user'] = user;
-                    next();
-                }
-            }
+        return async function runAuthenticationMiddleware(request: any, _response: any, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-            const fail = function(error: any) {
-                responded++;
-                if (responded == security.length && !success) {
-                    error.status = error.status || 401;
-                    next(error)
-                }
-            }
+            // keep track of failed auth attempts so we can hand back the most
+            // recent one.  This behavior was previously existing so preserving it
+            // here
+            const failedAttempts: any[] = [];
+            const pushAndRethrow = (error: any) => {
+                failedAttempts.push(error);
+                throw error;
+            };
 
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
+            const secMethodOrPromises: Promise<any>[] = [];
             for (const secMethod of security) {
                 if (Object.keys(secMethod).length > 1) {
-                    let promises: Promise<any>[] = [];
+                    const secMethodAndPromises: Promise<any>[] = [];
 
                     for (const name in secMethod) {
-                        promises.push(expressAuthentication(request, name, secMethod[name]));
+                        secMethodAndPromises.push(
+                            expressAuthentication(request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
                     }
 
-                    Promise.all(promises)
-                        .then((users) => { succeed(users[0]); })
-                        .catch(fail);
+                    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+                    secMethodOrPromises.push(Promise.all(secMethodAndPromises)
+                        .then(users => { return users[0]; }));
                 } else {
                     for (const name in secMethod) {
-                        expressAuthentication(request, name, secMethod[name])
-                            .then(succeed)
-                            .catch(fail);
+                        secMethodOrPromises.push(
+                            expressAuthentication(request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
                     }
                 }
             }
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            try {
+                request['user'] = await promiseAny(secMethodOrPromises);
+                next();
+            }
+            catch(err) {
+                // Show most recent error as response
+                const error = failedAttempts.pop();
+                error.status = error.status || 401;
+                next(error);
+            }
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         }
     }
     {{/if}}

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -8,6 +8,8 @@ import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { hapiAuthentication } from '{{authenticationModule}}';
+// @ts-ignore - no great way to install types from subpackage
+const promiseAny = require('promise.any');
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -60,8 +62,7 @@ export function RegisterRoutes(server: any) {
                 pre: [
                     {{#if security.length}}
                     {
-                      method: authenticateMiddleware({{json security}}),
-                      assign: "user"
+                      method: authenticateMiddleware({{json security}})
                     },
                     {{/if}}
                     {{#if uploadFile}}
@@ -136,62 +137,73 @@ export function RegisterRoutes(server: any) {
     {{/each}}
 
     {{#if useSecurity}}
+
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
     function authenticateMiddleware(security: TsoaRoute.Security[] = []) {
-        return function runAuthenticationMiddleware(request: any, h: any) {
-            let responded = 0;
-            let success = false;
-
-            const succeed = function(user: any) {
-                if (!success) {
-                    success = true;
-                    responded++;
-                    request['user'] = user;
-                }
-                return user;
-            };
+        return async function runAuthenticationMiddleware(request: any, h: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-            const fail = function(error: any) {
-                responded++;
-                if (responded == security.length && !success) {
-                    if (isBoom(error)) {
-                        throw error;
-                    }
-
-                    const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
-                    boomErr.output.statusCode = error.status || 401;
-                    boomErr.output.payload = {
-                        name: error.name,
-                        message: error.message,
-                    } as unknown as Payload;
-                    throw boomErr;
-                }
-                return error;
+            // keep track of failed auth attempts so we can hand back the most
+            // recent one.  This behavior was previously existing so preserving it
+            // here
+            const failedAttempts: any[] = [];
+            const pushAndRethrow = (error: any) => {
+                failedAttempts.push(error);
+                throw error;
             };
 
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
+            const secMethodOrPromises: Promise<any>[] = [];
             for (const secMethod of security) {
                 if (Object.keys(secMethod).length > 1) {
-                    let promises: Promise<any>[] = [];
+                    const secMethodAndPromises: Promise<any>[] = [];
 
                     for (const name in secMethod) {
-                        promises.push(hapiAuthentication(request, name, secMethod[name]));
+                        secMethodAndPromises.push(
+                            hapiAuthentication(request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
                     }
 
-                    return Promise.all(promises)
-                        .then((users) => { succeed(users[0]); })
-                        .catch(fail);
+                    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+                    secMethodOrPromises.push(Promise.all(secMethodAndPromises)
+                        .then(users => { return users[0]; }));
                 } else {
                     for (const name in secMethod) {
-                        return hapiAuthentication(request, name, secMethod[name])
-                            .then(succeed)
-                            .catch(fail);
+                        secMethodOrPromises.push(
+                            hapiAuthentication(request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
                     }
                 }
             }
-            return null;
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            try {
+                request['user'] = await promiseAny(secMethodOrPromises);
+                return request['user'];
+            }
+            catch(err) {
+                // Show most recent error as response
+                const error = failedAttempts.pop();
+                if (isBoom(error)) {
+                    throw error;
+                }
+
+                const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
+                boomErr.output.statusCode = error.status || 401;
+                boomErr.output.payload = {
+                    name: error.name,
+                    message: error.message,
+                } as unknown as Payload;
+
+                throw boomErr;
+            }
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         }
     }
     {{/if}}

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -12,6 +12,8 @@ import { {{name}} } from '{{modulePath}}';
 {{/each}}
 {{#if authenticationModule}}
 import { koaAuthentication } from '{{authenticationModule}}';
+// @ts-ignore - no great way to install types from subpackage
+const promiseAny = require('promise.any');
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
@@ -103,61 +105,71 @@ export function RegisterRoutes(router: KoaRouter) {
     {{/each}}
     {{/each}}
 
-  {{#if useSecurity}}
-  function authenticateMiddleware(security: TsoaRoute.Security[] = []) {
-      return async function runAuthenticationMiddleware(context: any, next: any) {
-          let responded = 0;
-          let success = false;
+    {{#if useSecurity}}
 
-          const succeed = async (user: any) => {
-              if (!success) {
-                  success = true;
-                  responded++;
-                  context.request['user'] = user;
-                  await next();
-              }
-          };
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-          // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    function authenticateMiddleware(security: TsoaRoute.Security[] = []) {
+        return async function runAuthenticationMiddleware(context: any, next: any) {
 
-          const fail = async (error: any) => {
-              responded++;
-              if (responded == security.length && !success) {
-                  // this is an authentication error
-                  context.status = error.status || 401;
-                  context.throw(context.status, error.message, error);
-              } else if (success) {
-                  // the authentication was a success but arriving here means the controller
-                  // probably threw an error that we caught as well
-                  // so just pass it on
-                  throw error;
-              }
-          };
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-          // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+            // keep track of failed auth attempts so we can hand back the most
+            // recent one.  This behavior was previously existing so preserving it
+            // here
+            const failedAttempts: any[] = [];
+            const pushAndRethrow = (error: any) => {
+                failedAttempts.push(error);
+                throw error;
+            };
 
-          for (const secMethod of security) {
-              if (Object.keys(secMethod).length > 1) {
-                  let promises: Promise<any>[] = [];
+            const secMethodOrPromises: Promise<any>[] = [];
+            for (const secMethod of security) {
+                if (Object.keys(secMethod).length > 1) {
+                    const secMethodAndPromises: Promise<any>[] = [];
 
-                  for (const name in secMethod) {
-                      promises.push(koaAuthentication(context.request, name, secMethod[name]));
-                  }
+                    for (const name in secMethod) {
+                        secMethodAndPromises.push(
+                            koaAuthentication(context.request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
+                    }
 
-                  return Promise.all(promises)
-                      .then((users) => succeed(users[0]))
-                      .catch(fail);
-              } else {
-                  for (const name in secMethod) {
-                      return koaAuthentication(context.request, name, secMethod[name])
-                          .then(succeed)
-                          .catch(fail);
-                  }
-              }
-          }
-      }
-  }
-  {{/if}}
+                    secMethodOrPromises.push(Promise.all(secMethodAndPromises)
+                        .then(users => { return users[0]; }));
+                } else {
+                    for (const name in secMethod) {
+                        secMethodOrPromises.push(
+                            koaAuthentication(context.request, name, secMethod[name])
+                                .catch(pushAndRethrow)
+                        );
+                    }
+                }
+            }
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let success;
+            try {
+                const user = await promiseAny(secMethodOrPromises);
+                success = true;
+                context.request['user'] = user;
+            }
+            catch(err) {
+                // Show most recent error as response
+                const error = failedAttempts.pop();
+                context.status = error.status || 401;
+                context.throw(context.status, error.message, error);
+            }
+
+            if (success) {
+                await next();
+            }
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        }
+    }
+    {{/if}}
 
   // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,6 +25,7 @@
   "author": "Luke Autry <lukeautry@gmail.com> (http://www.lukeautry.com)",
   "license": "MIT",
   "dependencies": {
+    "promise.any": "^2.0.2",
     "validator": "^13.6.0"
   },
   "devDependencies": {

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -114,7 +114,7 @@ export class MethodController extends Controller {
 
   @Security('tsoa_auth', ['write:pets', 'read:pets'])
   @Security('api_key')
-  @Get('OauthOrAPIkeySecurity')
+  @Get('OauthOrApiKeySecurity')
   public async oauthOrAPIkeySecurity(): Promise<TestModel> {
     return new ModelService().getModel();
   }
@@ -123,7 +123,7 @@ export class MethodController extends Controller {
     api_key: [],
     tsoa_auth: ['write:pets', 'read:pets'],
   })
-  @Get('OauthAndAPIkeySecurity')
+  @Get('OauthAndApiKeySecurity')
   public async oauthAndAPIkeySecurity(): Promise<TestModel> {
     return new ModelService().getModel();
   }

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -35,6 +35,14 @@ export class SecurityTestController {
     return Promise.resolve(request.user);
   }
 
+  @Response<ErrorResponseModel>('default', 'Unexpected error')
+  @Security('api_key')
+  @Security('slow_auth')
+  @Get('ApiKeyOrTimesOut')
+  public async GetWithTimedOutSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
   @Response<ErrorResponseModel>('404', 'Not Found')
   @Security('tsoa_auth', ['write:pets', 'read:pets'])
   @Security('api_key')
@@ -57,6 +65,24 @@ export class SecurityTestController {
   @Security('api_key')
   @Get('ServerError')
   public async GetServerError(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.reject(new Error('Unexpected'));
+  }
+
+  @Response<ErrorResponseModel>('default', 'Unexpected error')
+  @Security('api_key', [])
+  @Security('tsoa_auth', ['write:pets', 'read:pets'])
+  @Get('ServerErrorOauthOrApiKey')
+  public async GetServerErrorOrAuth(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.reject(new Error('Unexpected'));
+  }
+
+  @Response<ErrorResponseModel>('default', 'Unexpected error')
+  @Security({
+    api_key: [],
+    tsoa_auth: ['write:pets', 'read:pets'],
+  })
+  @Get('ServerErrorOauthAndApiKey')
+  public async GetServerErrorAndAuth(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.reject(new Error('Unexpected'));
   }
 }

--- a/tests/fixtures/controllers/securityController.ts
+++ b/tests/fixtures/controllers/securityController.ts
@@ -38,7 +38,7 @@ export class SecurityTestController {
   @Response<ErrorResponseModel>('404', 'Not Found')
   @Security('tsoa_auth', ['write:pets', 'read:pets'])
   @Security('api_key')
-  @Get('OauthOrAPIkey')
+  @Get('OauthOrApiKey')
   public async GetWithOrSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }
@@ -48,7 +48,7 @@ export class SecurityTestController {
     api_key: [],
     tsoa_auth: ['write:pets', 'read:pets'],
   })
-  @Get('OauthAndAPIkey')
+  @Get('OauthAndApiKey')
   public async GetWithAndSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }

--- a/tests/fixtures/express/authentication.ts
+++ b/tests/fixtures/express/authentication.ts
@@ -6,7 +6,7 @@ export function expressAuthentication(req: express.Request, name: string, scopes
     if (req.query && req.query.access_token) {
       token = req.query.access_token;
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'api_key' });
     }
 
     if (token === 'abc123456') {
@@ -20,13 +20,13 @@ export function expressAuthentication(req: express.Request, name: string, scopes
         name: 'Thor',
       });
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'api_key' });
     }
   } else {
     if (req.query && req.query.tsoa && req.query.tsoa === 'abc123456') {
       return Promise.resolve({});
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'other' });
     }
   }
 }

--- a/tests/fixtures/hapi/authentication.ts
+++ b/tests/fixtures/hapi/authentication.ts
@@ -4,7 +4,7 @@ export function hapiAuthentication(request: any, name: string, scopes?: string[]
     if (request.query && request.query.access_token) {
       token = request.query.access_token;
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'api_key' });
     }
 
     if (token === 'abc123456') {
@@ -18,13 +18,15 @@ export function hapiAuthentication(request: any, name: string, scopes?: string[]
         name: 'Thor',
       });
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'api_key' });
     }
+  } else if (name === 'slow_auth') {
+    return new Promise((_, reject) => setTimeout(() => reject({ message: 'slow_auth' }), 10000));
   } else {
     if (request.query && request.query.tsoa && request.query.tsoa === 'abc123456') {
       return Promise.resolve({});
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'other' });
     }
   }
 }

--- a/tests/fixtures/koa/authentication.ts
+++ b/tests/fixtures/koa/authentication.ts
@@ -18,13 +18,15 @@ export function koaAuthentication(request: Request, name: string, scopes?: strin
         name: 'Thor',
       });
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'api_key' });
     }
+  } else if (name === 'slow_auth') {
+    return new Promise((_, reject) => setTimeout(() => reject({ message: 'slow_auth' }), 10000));
   } else {
     if (request.query && request.query.tsoa && request.query.tsoa === 'abc123456') {
       return Promise.resolve({});
     } else {
-      return Promise.reject({});
+      return Promise.reject({ message: 'other' });
     }
   }
 }

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -936,34 +936,34 @@ describe('Express Server', () => {
 
     describe('API key or tsoa auth', () => {
       it('returns 200 if the API key is correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=abc123456&tsoa=invalid';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=abc123456&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 200 if tsoa auth is correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=invalid&tsoa=abc123456';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 401 if neither API key nor tsoa auth are correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=invalid&tsoa=invalid';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
     });
 
     describe('API key and tsoa auth', () => {
       it('returns 200 if API and tsoa auth are correct', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=abc123456&tsoa=abc123456';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 401 if API key is incorrect', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=abc123456&tsoa=invalid';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
 
       it('returns 401 if tsoa auth is incorrect', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=invalid&tsoa=abc123456';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=invalid&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
     });

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1058,34 +1058,34 @@ describe('Express Server', () => {
 
     describe('API key or tsoa auth', () => {
       it('returns 200 if the API key is correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=abc123456&tsoa=invalid';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=abc123456&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 200 if tsoa auth is correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=invalid&tsoa=abc123456';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 401 if neither API key nor tsoa auth are correct', () => {
-        const path = '/SecurityTest/OauthOrAPIkey?access_token=invalid&tsoa=invalid';
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
     });
 
     describe('API key and tsoa auth', () => {
       it('returns 200 if API and tsoa auth are correct', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=abc123456&tsoa=abc123456';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
       it('returns 401 if API key is incorrect', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=abc123456&tsoa=invalid';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=invalid';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
 
       it('returns 401 if tsoa auth is incorrect', () => {
-        const path = '/SecurityTest/OauthAndAPIkey?access_token=invalid&tsoa=abc123456';
+        const path = '/SecurityTest/OauthAndApiKey?access_token=invalid&tsoa=abc123456';
         return verifyGetRequest(basePath + path, emptyHandler, 401);
       });
     });

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1067,9 +1067,15 @@ describe('Express Server', () => {
         return verifyGetRequest(basePath + path, emptyHandler, 200);
       });
 
-      it('returns 401 if neither API key nor tsoa auth are correct', () => {
+      it('returns 401 if neither API key nor tsoa auth are correct, last error to resolve is returned', () => {
         const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=invalid';
-        return verifyGetRequest(basePath + path, emptyHandler, 401);
+        return verifyGetRequest(
+          basePath + path,
+          err => {
+            expect(JSON.parse(err.text).message).to.equal('api_key');
+          },
+          401,
+        );
       });
     });
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -928,6 +928,10 @@ describe('Hapi Server', () => {
   });
 
   describe('Security', () => {
+    const emptyHandler = (err, res) => {
+      // This is an empty handler
+    };
+
     it('can handle get request with access_token user id == 1', () => {
       return verifyGetRequest(basePath + '/SecurityTest/Hapi?access_token=abc123456', (err, res) => {
         const model = res.body as Model;
@@ -939,6 +943,97 @@ describe('Hapi Server', () => {
       return verifyGetRequest(basePath + '/SecurityTest/Hapi?access_token=xyz123456', (err, res) => {
         const model = res.body as Model;
         expect(model.id).to.equal(2);
+      });
+    });
+
+    it('resolves right away after first success', () => {
+      const path = '/SecurityTest/ApiKeyOrTimesOut?access_token=abc123456';
+      return verifyGetRequest(
+        basePath + path,
+        (err, res) => {
+          const model = res.body as Model;
+          expect(model.id).to.equal(1);
+        },
+        200,
+      );
+    });
+
+    describe('API key or tsoa auth', () => {
+      it('returns 200 if the API key is correct', () => {
+        const path = '/SecurityTest/OauthOrApiKey?access_token=abc123456&tsoa=invalid';
+        return verifyGetRequest(
+          basePath + path,
+          (err, res) => {
+            const model = res.body as Model;
+            expect(model.id).to.equal(1);
+          },
+          200,
+        );
+      });
+
+      it('returns 200 if tsoa auth is correct', () => {
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=abc123456';
+        return verifyGetRequest(basePath + path, emptyHandler, 200);
+      });
+
+      it('returns 200 if multiple auth handlers are correct', () => {
+        const path = '/SecurityTest/OauthOrApiKey?access_token=abc123456&tsoa=abc123456';
+        return verifyGetRequest(basePath + path, emptyHandler, 200);
+      });
+
+      it('returns 401 if neither API key nor tsoa auth are correct, last error to resolve is returned', () => {
+        const path = '/SecurityTest/OauthOrApiKey?access_token=invalid&tsoa=invalid';
+        return verifyGetRequest(
+          basePath + path,
+          err => {
+            expect(JSON.parse(err.text).message).to.equal('api_key');
+          },
+          401,
+        );
+      });
+
+      it('should pass through error if controller method crashes', () => {
+        return verifyGetRequest(
+          basePath + `/SecurityTest/ServerErrorOauthOrApiKey?access_token=abc123456`,
+          (err, res) => {
+            expect(res.status).to.equal(500);
+          },
+          500,
+        );
+      });
+    });
+
+    describe('API key and tsoa auth', () => {
+      it('returns 200 if API and tsoa auth are correct, resolved with user from first key in object', () => {
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=abc123456';
+        return verifyGetRequest(
+          basePath + path,
+          (err, res) => {
+            const model = res.body as Model;
+            expect(model.id).to.equal(1);
+          },
+          200,
+        );
+      });
+
+      it('returns 401 if API key is incorrect', () => {
+        const path = '/SecurityTest/OauthAndApiKey?access_token=abc123456&tsoa=invalid';
+        return verifyGetRequest(basePath + path, emptyHandler, 401);
+      });
+
+      it('returns 401 if tsoa auth is incorrect', () => {
+        const path = '/SecurityTest/OauthAndApiKey?access_token=invalid&tsoa=abc123456';
+        return verifyGetRequest(basePath + path, emptyHandler, 401);
+      });
+
+      it('should pass through error if controller method crashes', () => {
+        return verifyGetRequest(
+          basePath + `/SecurityTest/ServerErrorOauthAndApiKey?access_token=abc123456&tsoa=abc123456`,
+          (err, res) => {
+            expect(res.status).to.equal(500);
+          },
+          500,
+        );
       });
     });
   });

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -263,7 +263,7 @@ describe('Metadata generation', () => {
     it('should generate oauth2 or api key security', () => {
       const method = controller.methods.find(m => m.name === 'oauthOrAPIkeySecurity');
       if (!method) {
-        throw new Error('Method OauthOrAPIkeySecurity not defined!');
+        throw new Error('Method OauthOrApiKeySecurity not defined!');
       }
       if (!method.security) {
         throw new Error('Security decorator not defined!');
@@ -275,7 +275,7 @@ describe('Metadata generation', () => {
     it('should generate oauth2 and api key security', () => {
       const method = controller.methods.find(m => m.name === 'oauthAndAPIkeySecurity');
       if (!method) {
-        throw new Error('Method OauthAndAPIkeySecurity not defined!');
+        throw new Error('Method OauthAndApiKeySecurity not defined!');
       }
       if (!method.security) {
         throw new Error('Security decorator not defined!');

--- a/tests/unit/swagger/pathGeneration/securityRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/securityRoutes.spec.ts
@@ -30,7 +30,7 @@ describe('Security route generation', () => {
   });
 
   it('should generate a route with security A OR security B', () => {
-    const path = verifyPath('/SecurityTest/OauthOrAPIkey');
+    const path = verifyPath('/SecurityTest/OauthOrApiKey');
 
     if (!path.get) {
       throw new Error('No get operation.');
@@ -40,7 +40,7 @@ describe('Security route generation', () => {
   });
 
   it('should generate a route with security A AND security B', () => {
-    const path = verifyPath('/SecurityTest/OauthAndAPIkey');
+    const path = verifyPath('/SecurityTest/OauthAndApiKey');
 
     if (!path.get) {
       throw new Error('No get operation.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,17 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+array.prototype.map@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.3.tgz#1609623618d3d84134a37d4a220030c2bd18420b"
+  integrity sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.5"
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -2137,6 +2148,14 @@ call-bind@^1.0.0:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.0"
+
+call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -3014,6 +3033,28 @@ error-inject@^1.0.0:
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
   integrity sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
 
+es-abstract@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
+  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.2"
+    is-string "^1.0.5"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.0"
+
 es-abstract@^1.18.0-next.1:
   version "1.18.0-next.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
@@ -3031,6 +3072,37 @@ es-abstract@^1.18.0-next.1:
     object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
+
+es-aggregate-error@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz#6dfeeb5bf5fd95773ac01f56ec95a57ffeb313f9"
+  integrity sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    function-bind "^1.1.1"
+    functions-have-names "^1.2.1"
+    get-intrinsic "^1.0.1"
+    globalthis "^1.0.1"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-get-iterator@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
+  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.0"
+    has-symbols "^1.0.1"
+    is-arguments "^1.1.0"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.5"
+    isarray "^2.0.5"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -3601,6 +3673,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+functions-have-names@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
+  integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3634,6 +3711,15 @@ get-intrinsic@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
   integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -3796,6 +3882,13 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globalthis@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.2.tgz#2a235d34f4d8036219f7e34929b5de9e18166b8b"
+  integrity sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
@@ -3862,6 +3955,11 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3876,6 +3974,11 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
+has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
@@ -4207,10 +4310,22 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arguments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-bigint@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
+  integrity sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -4218,6 +4333,13 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-boolean-object@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.1.tgz#3c0878f035cb821228d350d2e1e36719716a3de8"
+  integrity sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -4233,6 +4355,11 @@ is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
   integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+
+is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -4348,10 +4475,25 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
 is-negative-zero@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
   integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.5.tgz#6edfaeed7950cff19afedce9fbfca9ee6dd289eb"
+  integrity sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -4399,10 +4541,23 @@ is-regex@^1.1.1:
   dependencies:
     has-symbols "^1.0.1"
 
+is-regex@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
+  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
+  dependencies:
+    call-bind "^1.0.2"
+    has-symbols "^1.0.2"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
 is-ssh@^1.3.0:
   version "1.3.2"
@@ -4421,12 +4576,24 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-string@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
+  integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
+
 is-symbol@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
     has-symbols "^1.0.1"
+
+is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
 
 is-text-path@^1.0.1:
   version "1.0.1"
@@ -4460,6 +4627,11 @@ isarray@1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -4481,6 +4653,19 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+iterate-iterator@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
+  integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
+
+iterate-value@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
+  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
+  dependencies:
+    es-get-iterator "^1.0.2"
+    iterate-iterator "^1.0.1"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -5537,6 +5722,11 @@ object-inspect@^1.8.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
+object-inspect@^1.9.0:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
+  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -5559,7 +5749,7 @@ object.assign@4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.assign@^4.1.1:
+object.assign@^4.1.1, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -6025,6 +6215,19 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
+
+promise.any@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/promise.any/-/promise.any-2.0.2.tgz#ed08299df51c2079ecb6688111316879f5c8aa75"
+  integrity sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==
+  dependencies:
+    array.prototype.map "^1.0.2"
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0"
+    es-aggregate-error "^1.0.3"
+    get-intrinsic "^1.1.1"
+    iterate-value "^1.0.2"
 
 promzard@^0.3.0:
   version "0.3.0"
@@ -6925,12 +7128,28 @@ string.prototype.trimend@^1.0.1:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string.prototype.trimstart@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
   integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   dependencies:
     call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
@@ -7390,6 +7609,16 @@ umask@^1.1.0:
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
+unbox-primitive@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -7552,6 +7781,17 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?
- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

1. This solution is waiting for all authentication promises to resolve before proceeding.  A better solution would utilize Promise.any to all the code to proceed after the first success. The current build does not provide a polyfill for this method.  I'd  appreciate any thoughts on this.
2. I have limited knowledge of the Hapi server although this PR does make changes there.  It seems to me that setting the user via the assign block is redundant now and it seems to simplify the code to set it using one method only.  Let me know if I'm mistaken here.

**Test plan**

I've ported the AND / OR Security method tests from the express tests to Hapi / Koa.  Everything seems to be working from what I can tell.  I've also tested locally with my Koa server to verify the intitial issue I saw is fixed.
