### PR TITLE
feat(): Distrubute property validators over unions

### DIFF
--- a/packages/runtime/src/routeGeneration/templateHelpers.ts
+++ b/packages/runtime/src/routeGeneration/templateHelpers.ts
@@ -59,7 +59,7 @@ export class ValidationService {
       case 'buffer':
         return this.validateBuffer(name, value);
       case 'union':
-        return this.validateUnion(name, value, fieldErrors, minimalSwaggerConfig, property.subSchemas, parent);
+        return this.validateUnion(name, value, fieldErrors, minimalSwaggerConfig, property, parent);
       case 'intersection':
         return this.validateIntersection(name, value, fieldErrors, minimalSwaggerConfig, property.subSchemas, parent);
       case 'any':
@@ -458,8 +458,8 @@ export class ValidationService {
     return Buffer.from(value);
   }
 
-  public validateUnion(name: string, value: any, fieldErrors: FieldErrors, swaggerConfig: AdditionalProps, subSchemas: TsoaRoute.PropertySchema[] | undefined, parent = ''): any {
-    if (!subSchemas) {
+  public validateUnion(name: string, value: any, fieldErrors: FieldErrors, swaggerConfig: AdditionalProps, property: TsoaRoute.PropertySchema, parent = ''): any {
+    if (!property.subSchemas) {
       throw new Error(
         'internal tsoa error: ' +
           'the metadata that was generated should have had sub schemas since it’s for a union, however it did not. ' +
@@ -469,9 +469,16 @@ export class ValidationService {
 
     const subFieldErrors: FieldErrors[] = [];
 
-    for (const subSchema of subSchemas) {
+    for (const subSchema of property.subSchemas) {
       const subFieldError: FieldErrors = {};
-      const cleanValue = this.ValidateParam(subSchema, JSON.parse(JSON.stringify(value)), name, subFieldError, parent, swaggerConfig);
+      const cleanValue = this.ValidateParam(
+        { ...subSchema, validators: { ...property.validators, ...subSchema.validators } },
+        JSON.parse(JSON.stringify(value)),
+        name,
+        subFieldError,
+        parent,
+        swaggerConfig,
+      );
       subFieldErrors.push(subFieldError);
 
       if (Object.keys(subFieldError).length === 0) {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -173,6 +173,10 @@ export interface TestModel extends Model {
    * }
    */
   nullableTypes?: {
+    /**
+     * @isInt
+     * @minimum 5
+     */
     numberOrNull: number | null;
     wordOrNull: Maybe<Word>;
     maybeString: Maybe<string>;
@@ -525,6 +529,10 @@ export class ValidateModel {
   };
 
   public nullableTypes: {
+    /**
+     * @isInt
+     * @minimum 5
+     */
     numberOrNull: number | null;
     wordOrNull: Maybe<Word>;
     maybeString: Maybe<string>;

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -709,7 +709,7 @@ describe('Express Server', () => {
       } as any;
 
       bodyModel.nullableTypes = {
-        // numberOrNull
+        numberOrNull: 4,
         wordOrNull: '',
         maybeString: 1,
         justNull: undefined,
@@ -817,7 +817,9 @@ describe('Express Server', () => {
           expect(body.fields['body.typeAliases.genericAlias'].message).to.equal('invalid string value');
           expect(body.fields['body.typeAliases.genericAlias2.id'].message).to.equal("'id' is required");
           expect(body.fields['body.typeAliases.forwardGenericAlias'].message).to.contain('Could not match the union against any of the items.');
-          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal("'numberOrNull' is required");
+          expect(body.fields['body.nullableTypes.numberOrNull'].message).to.equal(
+            'Could not match the union against any of the items. Issues: [{"body.nullableTypes.numberOrNull":{"message":"min 5","value":4}},{"body.nullableTypes.numberOrNull":{"message":"should be one of the following; [null]","value":4}}]',
+          );
           expect(body.fields['body.nullableTypes.maybeString'].message).to.equal(
             `Could not match the union against any of the items. Issues: [{"body.nullableTypes.maybeString":{"message":"invalid string value","value":1}},{"body.nullableTypes.maybeString":{"message":"should be one of the following; [null]","value":1}}]`,
           );

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1166,7 +1166,7 @@ describe('Definition generation', () => {
               properties: {
                 maybeString: { $ref: '#/definitions/Maybe_string_', description: undefined, format: undefined, example: undefined },
                 wordOrNull: { $ref: '#/definitions/Maybe_Word_', description: undefined, format: undefined, example: undefined },
-                numberOrNull: { type: 'number', format: 'double', description: undefined, default: undefined, ['x-nullable']: true, example: undefined },
+                numberOrNull: { type: 'integer', format: 'int32', minimum: 5, description: undefined, default: undefined, ['x-nullable']: true, example: undefined },
                 justNull: {
                   default: undefined,
                   description: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1831,9 +1831,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                   description: undefined,
                   example: undefined,
-                  format: 'double',
+                  type: 'integer',
+                  format: 'int32',
+                  minimum: 5,
                   nullable: true,
-                  type: 'number',
                 },
                 justNull: {
                   default: undefined,

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -898,11 +898,29 @@ describe('ValidationService', () => {
       const minimalSwaggerConfig: AdditionalProps = {
         noImplicitAdditionalProperties: 'silently-remove-extras',
       };
-      const subSchemas = [{ ref: 'TypeA' }, { ref: 'TypeB' }];
-      const resultA = v.validateUnion(name, { type: 'A', a: 100 }, error, minimalSwaggerConfig, subSchemas);
-      const resultB = v.validateUnion(name, { type: 'B', b: 20 }, error, minimalSwaggerConfig, subSchemas);
+      const schema: TsoaRoute.PropertySchema = { subSchemas: [{ ref: 'TypeA' }, { ref: 'TypeB' }] };
+      const resultA = v.validateUnion(name, { type: 'A', a: 100 }, error, minimalSwaggerConfig, schema);
+      const resultB = v.validateUnion(name, { type: 'B', b: 20 }, error, minimalSwaggerConfig, schema);
       expect(resultA).to.deep.equal({ type: 'A', a: 100 });
       expect(resultB).to.deep.equal({ type: 'B', b: 20 });
+    });
+
+    it('validates parent validators', () => {
+      const v = new ValidationService({});
+      const errors = {};
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+      };
+      const schema: TsoaRoute.PropertySchema = { dataType: 'union', subSchemas: [{ dataType: 'integer' }, { dataType: 'string' }], required: true, validators: { minimum: { value: 5 } } };
+
+      const result = v.validateUnion('union', 2, errors, minimalSwaggerConfig, schema);
+      expect(errors).to.deep.equal({
+        union: {
+          message: 'Could not match the union against any of the items. Issues: [{"union":{"message":"min 5","value":2}},{"union":{"message":"invalid string value","value":2}}]',
+          value: 2,
+        },
+      });
+      expect(result).to.be.undefined;
     });
   });
 

--- a/tests/unit/templating/templateHelpers.spec.ts
+++ b/tests/unit/templating/templateHelpers.spec.ts
@@ -13,16 +13,16 @@ it('ValidateError should be an instanceof ValidateError', () => {
 it('should allow additionalProperties (on a union) if noImplicitAdditionalProperties is set to silently-remove-extras', () => {
   // Arrange
   const refName = 'ExampleModel';
-  const subSchemas: TsoaRoute.PropertySchema[] = [{ ref: 'TypeAliasModel1' }, { ref: 'TypeAliasModel2' }];
+  const unionProperty: TsoaRoute.PropertySchema = {
+    dataType: 'union',
+    subSchemas: [{ ref: 'TypeAliasModel1' }, { ref: 'TypeAliasModel2' }],
+    required: true,
+  };
   const models: TsoaRoute.Models = {
     [refName]: {
       dataType: 'refObject',
       properties: {
-        or: {
-          dataType: 'union',
-          subSchemas,
-          required: true,
-        },
+        or: unionProperty,
       },
     },
     TypeAliasModel1: {
@@ -53,7 +53,7 @@ it('should allow additionalProperties (on a union) if noImplicitAdditionalProper
 
   // Act
   const name = 'dataToValidate';
-  const result = v.validateUnion('or', dataToValidate, errorDictionary, minimalSwaggerConfig, subSchemas, name + '.');
+  const result = v.validateUnion('or', dataToValidate, errorDictionary, minimalSwaggerConfig, unionProperty, name + '.');
 
   // Assert
   expect(errorDictionary).to.deep.eq({});
@@ -66,16 +66,16 @@ it('should allow additionalProperties (on a union) if noImplicitAdditionalProper
 it('should throw if the data has additionalProperties (on a union) if noImplicitAdditionalProperties is set to throw-on-extras', () => {
   // Arrange
   const refName = 'ExampleModel';
-  const subSchemas: TsoaRoute.PropertySchema[] = [{ ref: 'TypeAliasModel1' }, { ref: 'TypeAliasModel2' }];
+  const unionPropertySchema: TsoaRoute.PropertySchema = {
+    dataType: 'union',
+    subSchemas: [{ ref: 'TypeAliasModel1' }, { ref: 'TypeAliasModel2' }],
+    required: true,
+  };
   const models: TsoaRoute.Models = {
     [refName]: {
       dataType: 'refObject',
       properties: {
-        or: {
-          dataType: 'union',
-          subSchemas,
-          required: true,
-        },
+        or: unionPropertySchema,
       },
     },
     TypeAliasModel1: {
@@ -106,7 +106,7 @@ it('should throw if the data has additionalProperties (on a union) if noImplicit
 
   // Act
   const name = 'dataToValidate';
-  v.validateUnion('or', dataToValidate, errorDictionary, minimalSwaggerConfig, subSchemas, name + '.');
+  v.validateUnion('or', dataToValidate, errorDictionary, minimalSwaggerConfig, unionPropertySchema, name + '.');
 
   // Assert
   const errorKeys = Object.keys(errorDictionary);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #973 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This should be considered a breaking change as it may invalidate requests that would've been considered fine previously

**Test plan**

- Ensure validators on unions are passed to the partial validators
- Ensure they are picked up and checked
