### PR TITLE
closes #1012 - allow string[] to be used in an @Extension

### DIFF
--- a/packages/runtime/src/decorators/extension.ts
+++ b/packages/runtime/src/decorators/extension.ts
@@ -4,4 +4,4 @@ export function Extension(_name: string, _value: ExtensionType | ExtensionType[]
   };
 }
 
-export type ExtensionType = string | { [name: string]: ExtensionType | ExtensionType[] };
+export type ExtensionType = string | string[] | { [name: string]: ExtensionType | ExtensionType[] };

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -160,6 +160,7 @@ export class MethodController extends Controller {
   @Extension('x-attKey2', ['y0', 'y1'])
   @Extension('x-attKey3', [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }])
   @Extension('x-attKey4', { test: ['testVal'] })
+  @Extension('x-attKey5', { test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } })
   @Get('Extension')
   public async extension(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -299,6 +299,7 @@ describe('Metadata generation', () => {
         { key: 'x-attKey2', value: ['y0', 'y1'] },
         { key: 'x-attKey3', value: [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }] },
         { key: 'x-attKey4', value: { test: ['testVal'] } },
+        { key: 'x-attKey5', value: { test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } } },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -506,12 +506,13 @@ describe('Schema details generation', () => {
       throw new Error('extension method was not rendered');
     }
 
-    // Verify that extensions are appeneded to the path
+    // Verify that extensions are appended to the path
     expect(extensionPath).to.have.property('x-attKey');
     expect(extensionPath).to.have.property('x-attKey1');
     expect(extensionPath).to.have.property('x-attKey2');
     expect(extensionPath).to.have.property('x-attKey3');
     expect(extensionPath).to.have.property('x-attKey4');
+    expect(extensionPath).to.have.property('x-attKey5');
 
     // Verify that extensions have correct values
     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
@@ -519,6 +520,7 @@ describe('Schema details generation', () => {
     expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
     expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
     expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
+    expect(extensionPath['x-attKey5']).to.deep.equal({ test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } });
   });
 
   describe('@Res responses', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2155,12 +2155,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       throw new Error('extension method was not rendered');
     }
 
-    // Verify that extensions are appeneded to the path
+    // Verify that extensions are appended to the path
     expect(extensionPath).to.have.property('x-attKey');
     expect(extensionPath).to.have.property('x-attKey1');
     expect(extensionPath).to.have.property('x-attKey2');
     expect(extensionPath).to.have.property('x-attKey3');
     expect(extensionPath).to.have.property('x-attKey4');
+    expect(extensionPath).to.have.property('x-attKey5');
 
     // Verify that extensions have correct values
     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
@@ -2168,6 +2169,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
     expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
     expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
     expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
+    expect(extensionPath['x-attKey5']).to.deep.equal({ test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } });
   });
 
   describe('module declarations with namespaces', () => {


### PR DESCRIPTION
### All Submissions:

- [✔️] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [✔️] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [✔️] Have you written unit tests?
- [❌] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? (Already existed as `InvalidExtensionControllerGenerator` test suite)
- [✔️] This PR is associated with an existing issue?

**Closing issues**

Closes #1012.

**Test plan**

The added test suite `ValidExtensionControllerGenerator` makes sure that `@Extension` declarations, similar to those we need to feed into Amazon API Gateway, do work. It's somewhat a double-check because without allowing `string[]` in `@ExtensionType`, TypeScript would not compile at all.