### PR TITLE
Allow null and primitive values in an Extension

### DIFF
--- a/packages/cli/src/metadataGeneration/initializer-value.ts
+++ b/packages/cli/src/metadataGeneration/initializer-value.ts
@@ -39,6 +39,8 @@ export const getInitializerValue = (initializer?: ts.Expression, typeChecker?: t
         return dateString;
       }
       return;
+    case ts.SyntaxKind.NullKeyword:
+      return null;
     case ts.SyntaxKind.ObjectLiteralExpression:
       const objectLiteral = initializer as ts.ObjectLiteralExpression;
       const nestedObject: any = {};

--- a/packages/runtime/src/decorators/extension.ts
+++ b/packages/runtime/src/decorators/extension.ts
@@ -4,4 +4,4 @@ export function Extension(_name: string, _value: ExtensionType | ExtensionType[]
   };
 }
 
-export type ExtensionType = string | string[] | { [name: string]: ExtensionType | ExtensionType[] };
+export type ExtensionType = string | number | boolean | null | ExtensionType[] | { [name: string]: ExtensionType | ExtensionType[] };

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -156,11 +156,15 @@ export class MethodController extends Controller {
   }
 
   @Extension('x-attKey', 'attValue')
-  @Extension('x-attKey1', { test: 'testVal' })
-  @Extension('x-attKey2', ['y0', 'y1'])
-  @Extension('x-attKey3', [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }])
-  @Extension('x-attKey4', { test: ['testVal'] })
-  @Extension('x-attKey5', { test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } })
+  @Extension('x-attKey1', 123)
+  @Extension('x-attKey2', true)
+  @Extension('x-attKey3', null)
+  @Extension('x-attKey4', { test: 'testVal' })
+  @Extension('x-attKey5', ['y0', 'y1', 123, true, null])
+  @Extension('x-attKey6', [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }])
+  @Extension('x-attKey7', { test: ['testVal', 123, true, null] })
+  @Extension('x-attKey8', { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } })
+
   @Get('Extension')
   public async extension(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -164,7 +164,6 @@ export class MethodController extends Controller {
   @Extension('x-attKey6', [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }])
   @Extension('x-attKey7', { test: ['testVal', 123, true, null] })
   @Extension('x-attKey8', { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } })
-
   @Get('Extension')
   public async extension(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -292,7 +292,7 @@ describe('Metadata generation', () => {
       if (!method.extensions || method.extensions.length <= 0) {
         throw new Error('No extension decorators defined!');
       }
-      
+
       const expectedExtensions = [
         { key: 'x-attKey', value: 'attValue' },
         { key: 'x-attKey1', value: 123 },

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -292,14 +292,17 @@ describe('Metadata generation', () => {
       if (!method.extensions || method.extensions.length <= 0) {
         throw new Error('No extension decorators defined!');
       }
-
+      
       const expectedExtensions = [
         { key: 'x-attKey', value: 'attValue' },
-        { key: 'x-attKey1', value: { test: 'testVal' } },
-        { key: 'x-attKey2', value: ['y0', 'y1'] },
-        { key: 'x-attKey3', value: [{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }] },
-        { key: 'x-attKey4', value: { test: ['testVal'] } },
-        { key: 'x-attKey5', value: { test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } } },
+        { key: 'x-attKey1', value: 123 },
+        { key: 'x-attKey2', value: true },
+        { key: 'x-attKey3', value: null },
+        { key: 'x-attKey4', value: { test: 'testVal' } },
+        { key: 'x-attKey5', value: ['y0', 'y1', 123, true, null] },
+        { key: 'x-attKey6', value: [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }] },
+        { key: 'x-attKey7', value: { test: ['testVal', 123, true, null] } },
+        { key: 'x-attKey8', value: { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } } },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -526,14 +526,20 @@ describe('Schema details generation', () => {
     expect(extensionPath).to.have.property('x-attKey3');
     expect(extensionPath).to.have.property('x-attKey4');
     expect(extensionPath).to.have.property('x-attKey5');
+    expect(extensionPath).to.have.property('x-attKey6');
+    expect(extensionPath).to.have.property('x-attKey7');
+    expect(extensionPath).to.have.property('x-attKey8');
 
     // Verify that extensions have correct values
     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
-    expect(extensionPath['x-attKey1']).to.deep.equal({ test: 'testVal' });
-    expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
-    expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
-    expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
-    expect(extensionPath['x-attKey5']).to.deep.equal({ test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } });
+    expect(extensionPath['x-attKey1']).to.deep.equal(123);
+    expect(extensionPath['x-attKey2']).to.deep.equal(true);
+    expect(extensionPath['x-attKey3']).to.deep.equal(null);
+    expect(extensionPath['x-attKey4']).to.deep.equal({ test: 'testVal' });
+    expect(extensionPath['x-attKey5']).to.deep.equal(['y0', 'y1', 123, true, null]);
+    expect(extensionPath['x-attKey6']).to.deep.equal([{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }]);
+    expect(extensionPath['x-attKey7']).to.deep.equal({ test: ['testVal', 123, true, null] });
+    expect(extensionPath['x-attKey8']).to.deep.equal({ test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } });
   });
 
   describe('@Res responses', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2180,21 +2180,27 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       throw new Error('extension method was not rendered');
     }
 
-    // Verify that extensions are appended to the path
-    expect(extensionPath).to.have.property('x-attKey');
-    expect(extensionPath).to.have.property('x-attKey1');
-    expect(extensionPath).to.have.property('x-attKey2');
-    expect(extensionPath).to.have.property('x-attKey3');
-    expect(extensionPath).to.have.property('x-attKey4');
-    expect(extensionPath).to.have.property('x-attKey5');
-
-    // Verify that extensions have correct values
-    expect(extensionPath['x-attKey']).to.deep.equal('attValue');
-    expect(extensionPath['x-attKey1']).to.deep.equal({ test: 'testVal' });
-    expect(extensionPath['x-attKey2']).to.deep.equal(['y0', 'y1']);
-    expect(extensionPath['x-attKey3']).to.deep.equal([{ y0: 'yt0', y1: 'yt1' }, { y2: 'yt2' }]);
-    expect(extensionPath['x-attKey4']).to.deep.equal({ test: ['testVal'] });
-    expect(extensionPath['x-attKey5']).to.deep.equal({ test: { testArray: ['testVal1', ['testVal2', 'testVal3']] } });
+     // Verify that extensions are appended to the path
+     expect(extensionPath).to.have.property('x-attKey');
+     expect(extensionPath).to.have.property('x-attKey1');
+     expect(extensionPath).to.have.property('x-attKey2');
+     expect(extensionPath).to.have.property('x-attKey3');
+     expect(extensionPath).to.have.property('x-attKey4');
+     expect(extensionPath).to.have.property('x-attKey5');
+     expect(extensionPath).to.have.property('x-attKey6');
+     expect(extensionPath).to.have.property('x-attKey7');
+     expect(extensionPath).to.have.property('x-attKey8');
+ 
+     // Verify that extensions have correct values
+     expect(extensionPath['x-attKey']).to.deep.equal('attValue');
+     expect(extensionPath['x-attKey1']).to.deep.equal(123);
+     expect(extensionPath['x-attKey2']).to.deep.equal(true);
+     expect(extensionPath['x-attKey3']).to.deep.equal(null);
+     expect(extensionPath['x-attKey4']).to.deep.equal({ test: 'testVal' });
+     expect(extensionPath['x-attKey5']).to.deep.equal(['y0', 'y1', 123, true, null]);
+     expect(extensionPath['x-attKey6']).to.deep.equal([{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }]);
+     expect(extensionPath['x-attKey7']).to.deep.equal({ test: ['testVal', 123, true, null] });
+     expect(extensionPath['x-attKey8']).to.deep.equal({ test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } });
   });
 
   describe('module declarations with namespaces', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? (Already existed as InvalidExtensionControllerGenerator test suite)
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #958.

**Test plan**

Updated the Extension data being used in `methodController.ts` and updated the tests in `metadata.spec.ts`, `schemaDetails.spec.ts` and `schemaDetails3.spec.ts`. These tests now include null, primitive values, and their usage in objects and arrays.