### PR TITLE
feat: supports async IoC container

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -68,7 +68,8 @@ export function RegisterRoutes(app: express.Router) {
             {{#if uploadFiles}}
             upload.array('{{uploadFilesName}}'),
             {{/if}}
-            function {{../name}}_{{name}}(request: any, response: any, next: any) {
+
+            {{#if ../../iocModule}}async {{/if}}function {{../name}}_{{name}}(request: any, response: any, next: any) {
             const args = {
                 {{#each parameters}}
                     {{@key}}: {{{json this}}},
@@ -87,7 +88,7 @@ export function RegisterRoutes(app: express.Router) {
             {{#if ../../iocModule}}
             const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
 
-            const controller: any = container.get<{{../name}}>({{../name}});
+            const controller: any = await container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -91,7 +91,7 @@ export function RegisterRoutes(server: any) {
                   allow: 'multipart/form-data'
                 },
                 {{/if}}
-                handler: function {{../name}}_{{name}}(request: any, h: any) {
+                handler: {{#if ../../iocModule}}async {{/if}}function {{../name}}_{{name}}(request: any, h: any) {
                     const args = {
                         {{#each parameters}}
                             {{@key}}: {{{json this}}},
@@ -119,7 +119,7 @@ export function RegisterRoutes(server: any) {
                     {{#if ../../iocModule}}
                     const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
 
-                    const controller: any = container.get<{{../name}}>({{../name}});
+                    const controller: any = await container.get<{{../name}}>({{../name}});
                     if (typeof controller['setStatus'] === 'function') {
                         controller.setStatus(undefined);
                     }

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -90,7 +90,7 @@ export function RegisterRoutes(router: KoaRouter) {
             {{#if ../../iocModule}}
             const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(context.request) : iocContainer;
 
-            const controller: any = container.get<{{../name}}>({{../name}});
+            const controller: any = await container.get<{{../name}}>({{../name}});
             if (typeof controller['setStatus'] === 'function') {
                 controller.setStatus(undefined);
             }

--- a/packages/runtime/src/interfaces/iocModule.ts
+++ b/packages/runtime/src/interfaces/iocModule.ts
@@ -1,5 +1,7 @@
 export interface IocContainer {
   get<T>(controller: { prototype: T }): T;
+
+  get<T>(controller: { prototype: T }): Promise<T>;
 }
 
 export type IocContainerFactory = (request: unknown) => IocContainer;

--- a/tests/fixtures/inversify-async/asyncController.ts
+++ b/tests/fixtures/inversify-async/asyncController.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from 'inversify';
+import { Get, Route } from '@tsoa/runtime';
+import { TestModel } from '../testModel';
+import { AsyncService } from './asyncService';
+
+@injectable()
+@Route('AsyncIocTest')
+export class AsyncController {
+  constructor(@inject(AsyncService) private managedService: AsyncService) {}
+
+  @Get()
+  public async getModel(): Promise<TestModel> {
+    return this.managedService.getModel();
+  }
+}

--- a/tests/fixtures/inversify-async/asyncService.ts
+++ b/tests/fixtures/inversify-async/asyncService.ts
@@ -1,0 +1,39 @@
+import { injectable } from 'inversify';
+import { TestModel, TestSubModel } from '../testModel';
+
+@injectable()
+export class AsyncService {
+  public getModel(): TestModel {
+    return {
+      and: { value1: 'foo', value2: 'bar' },
+      boolArray: [true, false],
+      boolValue: true,
+      id: 1,
+      modelValue: {
+        email: 'test@test.com',
+        id: 100,
+      },
+      modelsArray: new Array<TestSubModel>(),
+      numberArray: [1, 2, 3],
+      numberValue: 1,
+      objLiteral: {
+        name: 'hello',
+      },
+      object: {
+        a: 'a',
+      },
+      objectArray: [
+        {
+          a: 'a',
+        },
+      ],
+      optionalString: 'optional string',
+      or: { value1: 'foo', value2: 'bar' },
+      referenceAnd: { value1: 'foo', value2: 'bar' },
+      strLiteralArr: ['Foo', 'Bar'],
+      strLiteralVal: 'Foo',
+      stringArray: ['string one', 'string two'],
+      stringValue: 'a string',
+    };
+  }
+}

--- a/tests/fixtures/inversify-async/ioc.ts
+++ b/tests/fixtures/inversify-async/ioc.ts
@@ -1,0 +1,13 @@
+import { Container } from 'inversify';
+import { AsyncController } from './asyncController';
+import { AsyncService } from './asyncService';
+
+const container = new Container();
+container.bind<AsyncService>(AsyncService).to(AsyncService).inSingletonScope();
+container.bind<AsyncController>(AsyncController).to(AsyncController).inSingletonScope();
+const iocContainer = {
+  async get<T>(controller: { prototype: T }): Promise<T> {
+    return container.get(controller);
+  },
+};
+export { iocContainer };

--- a/tests/fixtures/inversify-async/server.ts
+++ b/tests/fixtures/inversify-async/server.ts
@@ -1,0 +1,19 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as methodOverride from 'method-override';
+
+import './asyncController';
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(methodOverride());
+RegisterRoutes(app);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(err.status || 500).send(err.message || 'An error occurred during the request.');
+});
+
+app.listen();

--- a/tests/integration/inversify-async-server.spec.ts
+++ b/tests/integration/inversify-async-server.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import 'mocha';
+import 'reflect-metadata';
+import * as request from 'supertest';
+import { app } from '../fixtures/inversify-async/server';
+import { TestModel } from '../fixtures/testModel';
+
+const basePath = '/v1';
+
+describe('Inversify async IoC Express Server', () => {
+  it('can handle get request with no path argument', () => {
+    return verifyGetRequest(basePath + '/AsyncIocTest?tsoa=abc123456', (err, res) => {
+      const model = res.body as TestModel;
+      expect(model.id).to.equal(1);
+    });
+  });
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -218,5 +218,15 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         routesDir: './fixtures/inversify-dynamic-container',
       }),
     ),
+    log('Inversify Async IoC Route Generation', () =>
+      generateRoutes({
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        basePath: '/v1',
+        entryFile: './fixtures/inversify-async/server.ts',
+        iocModule: './fixtures/inversify-async/ioc.ts',
+        middleware: 'express',
+        routesDir: './fixtures/inversify-async',
+      }),
+    ),
   ]);
 })();


### PR DESCRIPTION
While working with async dependencies I found that ensuring that all dependencies are ready is quite verbose. Async IoC solves it and adding support to tsoa is quite easy. I hope this can be useful for others too.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?


### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Test plan**
I have added an integration test that uses async wrapper of Inversify.
