### PR TITLE
feat: Allow to use variables and enums as Path #1060

### DIFF
--- a/packages/cli/src/metadataGeneration/methodGenerator.ts
+++ b/packages/cli/src/metadataGeneration/methodGenerator.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import * as path from 'path';
 import { isVoidType } from '../utils/isVoidType';
-import { getDecorators, getDecoratorValues, getSecurites } from './../utils/decoratorUtils';
+import { getDecorators, getDecoratorValues, getPath, getSecurites } from './../utils/decoratorUtils';
 import { getJSDocComment, getJSDocDescription, isExistJSDocTag } from './../utils/jsDocUtils';
 import { getExtensions } from './extension';
 import { GenerateMetadataError } from './exceptions';
@@ -128,14 +128,12 @@ export class MethodGenerator {
     }
 
     const decorator = pathDecorators[0];
-    const expression = decorator.parent as ts.CallExpression;
-    const decoratorArgument = expression.arguments[0] as ts.StringLiteral;
 
     this.method = decorator.text.toLowerCase() as any;
     // if you don't pass in a path to the method decorator, we'll just use the base route
     // todo: what if someone has multiple no argument methods of the same type in a single controller?
     // we need to throw an error there
-    this.path = decoratorArgument ? `${decoratorArgument.text}` : '';
+    this.path = getPath(decorator, this.current.typeChecker);
   }
 
   private getMethodResponses(): Tsoa.Response[] {

--- a/packages/cli/src/utils/decoratorUtils.ts
+++ b/packages/cli/src/utils/decoratorUtils.ts
@@ -64,3 +64,13 @@ export function isDecorator(node: ts.Node, isMatching: (identifier: ts.Identifie
 function isObject(v: any) {
   return typeof v === 'object' && v !== null;
 }
+
+export function getPath(decorator: ts.Identifier, typeChecker: ts.TypeChecker): string {
+  const [path] = getDecoratorValues(decorator, typeChecker);
+
+  if (path === undefined) {
+    return '';
+  }
+
+  return path;
+}

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -6,6 +6,11 @@ import { GenericModel, GetterClass, GetterInterface, GetterInterfaceHerited, Tes
 import { ModelService } from './../services/modelService';
 import TsoaTest from 'tsoaTest';
 
+export const PathFromConstant = 'PathFromConstantValue';
+export enum EnumPaths {
+  PathFromEnum = 'PathFromEnumValue',
+}
+
 @Route('GetTest')
 export class GetTestController extends Controller {
   /**
@@ -245,6 +250,16 @@ export class GetTestController extends Controller {
   @Get('MultipleStatusCodeRes')
   public async multipleStatusCodeRes(@Res() res: TsoaResponse<400 | 500, TestModel, { 'custom-header': string }>, @Query('statusCode') statusCode: 400 | 500): Promise<void> {
     res?.(statusCode, new ModelService().getModel(), { 'custom-header': 'hello' });
+  }
+
+  @Get(PathFromConstant)
+  public async getPathFromConstantValue(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Get(EnumPaths.PathFromEnum)
+  public async getPathFromEnumValue(): Promise<TestModel> {
+    return new ModelService().getModel();
   }
 }
 

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -83,6 +83,16 @@ describe('GET route generation', () => {
     verifyPath(actionRoute);
   });
 
+  it('should generate a path for a GET route with const argument', () => {
+    const actionRoute = `${baseRoute}/PathFromConstantValue`;
+    verifyPath(actionRoute);
+  });
+
+  it('should generate a path for a GET route with Enum argument', () => {
+    const actionRoute = `${baseRoute}/PathFromEnumValue`;
+    verifyPath(actionRoute);
+  });
+
   it('should generate a parameter for path parameters', () => {
     const actionRoute = `${baseRoute}/{numberPathParam}/{booleanPathParam}/{stringPathParam}`;
     const parameters = getValidatedParameters(actionRoute);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1060

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This covers just variables/enums. It doesn't cover string templates (that would be another feature).

**Test plan**

Test cover usage of viariable (string) and enum passed to @Get() decorator, and that the path generated is same as value and not the "name" of a variable or enum.
