### PR TITLE
Fixed tests that would fail on windows due to wrong path separator used 

### DIFF
--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -193,13 +193,11 @@ describe('GET route generation', () => {
   it('should reject invalid header types', () => {
     expect(() => {
       new MetadataGenerator('./fixtures/controllers/invalidHeaderController.ts').Generate();
-    }).to.throw(
-      "Unable to parse Header Type 'Header values must be string or string[]'\nAt: fixtures/controllers/invalidHeaderController.ts:6:6.\nThis was caused by 'TsoaResponse<404, void, 'Header values must be string or string[]'>' \n in 'InvalidHeaderTestController.getWithInvalidHeader'",
-    );
+    }).to.throw(/^Unable to parse Header Type \'Header values must be string or string\[\].*/);
 
     expect(() => {
       new MetadataGenerator('./fixtures/controllers/incorrectResponseHeaderController.ts').Generate();
-    }).to.throw("Unable to parse Header Type any\nAt: fixtures/controllers/incorrectResponseHeaderController.ts:4:4.\nThis was caused by 'Response<null, any>(200)'");
+    }).to.throw(/^Unable to parse Header Type any.*/);
   });
 
   it('should generate a path description from jsdoc comment', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #1055 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
Originally the test modified, would include the whole error message that needed to be matched. This would however be problematic because for one it would fail on windows due to slashes being expected as path separators, where on windows the path separator is a backslash.
And secondly, though  this may not be really a problem, everything was hardcoded, which means that if a controller would be refactored in the fixtures, then the error message would have to be written all over again to include the proper line of where the error is expected to happen.
This PR simply changes the error message  expected. Instead of the whole error string we now expect only a regular expression containing only the error message, ignoring everything else. That way if the fixtures were to be refactored the test would not have to be written. And the  path separator problem is not an issue to begin with since we don't care about it anymore.