### PR TITLE
feat(): response description from jsdoc

### DIFF
--- a/packages/cli/src/metadataGeneration/methodGenerator.ts
+++ b/packages/cli/src/metadataGeneration/methodGenerator.ts
@@ -161,9 +161,10 @@ export class MethodGenerator {
     const decorators = this.getDecoratorsByIdentifier(this.node, 'SuccessResponse');
 
     if (!decorators || !decorators.length) {
+      const description = getJSDocComment(this.node, 'returns') || 'Ok';
       return {
         response: {
-          description: isVoidType(type) ? 'No content' : 'Ok',
+          description: isVoidType(type) ? 'No content' : description,
           examples: this.getMethodSuccessExamples(),
           name: isVoidType(type) ? '204' : '200',
           schema: type,

--- a/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
+++ b/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Route, SuccessResponse } from '@tsoa/runtime';
-import { TestModel } from 'fixtures/duplicateTestModel';
+import { TestModel } from '../testModel';
 import { ModelService } from 'fixtures/services/modelService';
 
 @Route('Controller')

--- a/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
+++ b/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Route, SuccessResponse } from '@tsoa/runtime';
+import { TestModel } from 'fixtures/duplicateTestModel';
+import { ModelService } from 'fixtures/services/modelService';
+
+@Route('Controller')
+export class CustomResponseDescController extends Controller {
+  @Get('descriptionWithSuccessResponse')
+  @SuccessResponse(200, 'SuccessResponse description')
+  public async descriptionWithSuccessResponse(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Get('descriptionWithJsDocAnnotation')
+  /**
+   * @returns custom description with jsdoc annotation
+   */
+  public async descriptionWithJsDocAnnotation(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+
+  @Get('successResponseAndJsDocAnnotation')
+  /**
+   * @returns custom description from jsdoc annotation
+   */
+  @SuccessResponse(200, 'Success Response description')
+  public async successResponseAndJsDocAnnotation(): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}

--- a/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
+++ b/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
@@ -10,10 +10,8 @@ export class CustomResponseDescController extends Controller {
     return new ModelService().getModel();
   }
 
+  /** @returns custom description with jsdoc annotation */
   @Get('descriptionWithJsDocAnnotation')
-  /**
-   * @returns custom description with jsdoc annotation
-   */
   public async descriptionWithJsDocAnnotation(): Promise<TestModel> {
     return new ModelService().getModel();
   }

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -946,4 +946,29 @@ describe('Metadata generation', () => {
       ]);
     });
   });
+
+  describe('controllerWithJsDocResponseDescriptionGeneration', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/controllerWithJsDocResponseDescription.ts').Generate();
+    const controller = metadata.controllers[0];
+
+    it('has success response description', () => {
+      const description = 'SuccessResponse description';
+      const method = controller.methods[0]; // descriptionWithSuccessResponse
+      expect(method.responses[0].name).to.equal(200);
+      expect(method.responses[0].description).to.equal(description);
+    });
+
+    it('has a custom description when @returns is used on response 200', () => {
+      const description = 'custom description with jsdoc annotation';
+      const method = controller.methods[1]; // descriptionWithJsDocAnnotation
+      expect(method.responses[0].name).to.equal('200');
+      expect(method.responses[0].description).to.equal(description);
+    });
+    it("should not override @SuccessResponse's description even if @returns is present", () => {
+      const description = 'Success Response description';
+      const method = controller.methods[2]; // successResponseAndJsDocAnnotation
+      expect(method.responses[0].name).to.equal(200);
+      expect(method.responses[0].description).to.equal(description);
+    });
+  });
 });

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -953,20 +953,29 @@ describe('Metadata generation', () => {
 
     it('has success response description', () => {
       const description = 'SuccessResponse description';
-      const method = controller.methods[0]; // descriptionWithSuccessResponse
+      const method = controller.methods.find(m => m.name === 'descriptionWithSuccessResponse');
+      if (!method) {
+        throw new Error('method descriptionWithSuccessResponse not defined');
+      }
       expect(method.responses[0].name).to.equal(200);
       expect(method.responses[0].description).to.equal(description);
     });
 
     it('has a custom description when @returns is used on response 200', () => {
       const description = 'custom description with jsdoc annotation';
-      const method = controller.methods[1]; // descriptionWithJsDocAnnotation
+      const method = controller.methods.find(m => m.name === 'descriptionWithJsDocAnnotation');
+      if (!method) {
+        throw new Error('method descriptionWithJsDocAnnotation not defined');
+      }
       expect(method.responses[0].name).to.equal('200');
       expect(method.responses[0].description).to.equal(description);
     });
     it("should not override @SuccessResponse's description even if @returns is present", () => {
       const description = 'Success Response description';
-      const method = controller.methods[2]; // successResponseAndJsDocAnnotation
+      const method = controller.methods.find(m => m.name === 'successResponseAndJsDocAnnotation');
+      if (!method) {
+        throw new Error('method successResponseAndJsDocAnnotation not defined');
+      }
       expect(method.responses[0].name).to.equal(200);
       expect(method.responses[0].description).to.equal(description);
     });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #1029 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
The tests that have been added check the following scenarios:
* The first, tests if the description we get from SuccessResponse is 'Ok' the one we expect.
* The second one, keeps the default response, but the description will be overwritten by the returns jsdoc comment
* the third and last one simply checks if the description set by returns does not overwrite the description we'd get  from SuccessResponse, which is the behaviour we want.

It is now possible to do  something like the following:

```ts

@Route('test')
export class TestController {
  /** @returns custom description */
  @Get('test')
  public async test(): Promise<number> {
    return 1;
  }
}
```

And the description we'd get in the swagger spec would be in this  case custom description.