### PR TITLE
fix: simplify and improve declaration lookup

### DIFF
--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -8,7 +8,7 @@ import { TypeResolver } from './typeResolver';
 import { getDecorators } from '../utils/decoratorUtils';
 
 export class MetadataGenerator {
-  public readonly controllerNodes = new Array<ts.Node>();
+  public readonly controllerNodes = new Array<ts.ClassDeclaration>();
   public readonly typeChecker: ts.TypeChecker;
   private readonly program: ts.Program;
   private referenceTypeMap: Tsoa.ReferenceTypeMap = {};
@@ -59,7 +59,7 @@ export class MetadataGenerator {
       }
 
       ts.forEachChild(sf, node => {
-        if (node.kind === ts.SyntaxKind.ClassDeclaration && this.IsExportedNode(node as ts.ClassDeclaration) && getDecorators(node, identifier => identifier.text === 'Route').length) {
+        if (ts.isClassDeclaration(node) && getDecorators(node, identifier => identifier.text === 'Route').length) {
           this.controllerNodes.push(node);
         }
       });
@@ -225,7 +225,7 @@ export class MetadataGenerator {
 
   private buildControllers() {
     return this.controllerNodes
-      .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration, this))
+      .map(classDeclaration => new ControllerGenerator(classDeclaration, this))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
   }

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -14,10 +14,6 @@ export class MetadataGenerator {
   private referenceTypeMap: Tsoa.ReferenceTypeMap = {};
   private circularDependencyResolvers = new Array<(referenceTypes: Tsoa.ReferenceTypeMap) => void>();
 
-  public IsExportedNode(_node: ts.Node) {
-    return true;
-  }
-
   constructor(entryFile: string, private readonly compilerOptions?: ts.CompilerOptions, private readonly ignorePaths?: string[], controllers?: string[]) {
     TypeResolver.clearCache();
     this.program = !!controllers ? this.setProgramToDynamicControllersFiles(controllers) : ts.createProgram([entryFile], compilerOptions || {});

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -49,10 +49,10 @@ export class TypeResolver {
       return enumType;
     }
 
-    if (this.typeNode.kind === ts.SyntaxKind.ArrayType) {
+    if (ts.isArrayTypeNode(this.typeNode)) {
       const arrayMetaType: Tsoa.ArrayType = {
         dataType: 'array',
-        elementType: new TypeResolver((this.typeNode as ts.ArrayTypeNode).elementType, this.current, this.parentNode, this.context).resolve(),
+        elementType: new TypeResolver(this.typeNode.elementType, this.current, this.parentNode, this.context).resolve(),
       };
       return arrayMetaType;
     }
@@ -293,7 +293,7 @@ export class TypeResolver {
       }
     }
 
-    if (this.typeNode.kind === ts.SyntaxKind.TemplateLiteralType) {
+    if (ts.isTemplateLiteralTypeNode(this.typeNode)) {
       const type = this.current.typeChecker.getTypeFromTypeNode(this.referencer || this.typeNode);
       if (type.isUnion() && type.types.every(unionElementType => unionElementType.isStringLiteral())) {
         const stringLiteralEnum: Tsoa.EnumType = {
@@ -495,7 +495,7 @@ export class TypeResolver {
         return false;
       }
 
-      return node.kind === ts.SyntaxKind.EnumDeclaration && node.name?.text === enumName;
+      return ts.isEnumDeclaration(node) && node.name?.text === enumName;
     }) as ts.EnumDeclaration[];
 
     if (!enumNodes.length) {

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -496,7 +496,6 @@ export class TypeResolver {
     }
 
     let enumNodes = declarations.filter((node): node is ts.EnumDeclaration => {
-      // console.log('node.name.getText()', ts.isEnumDeclaration(node) &&  node.name.getText(), enumName)
       return ts.isEnumDeclaration(node) && node.name.getText() === enumName;
     });
 
@@ -797,7 +796,6 @@ export class TypeResolver {
     }
 
     let modelTypes = declarations.filter((node): node is UsableDeclarationWithoutPropertySignature => {
-      // console.log('node.name?.getText()',this.nodeIsUsable(node) && node.name?.getText());
       return this.nodeIsUsable(node) && node.name?.getText() === typeName;
     });
 


### PR DESCRIPTION
uses getSymbolAtLocation instead of manual lookup code.
This improves a lot of use cases, even though https://github.com/lukeautry/tsoa/blob/master/docs/ExternalInterfacesExplanation.MD is still true, technically it is not true now anymore. It resolves the nodes like the IDE does with "Jump to declaration" now.

This implements the idea of @WoH stated here: 
https://github.com/lukeautry/tsoa/issues/333#issuecomment-625258178
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] This PR is associated with an existing issue?

**Closing issues**
there is no exact ticket for this, sorry about this, I can create one or if anything is to discuess regarding this approach, we can discucess it here?

closes https://github.com/lukeautry/tsoa/issues/868

related https://github.com/lukeautry/tsoa/issues/333

also fixes "inaccurate" lookups like:
https://github.com/lukeautry/tsoa/issues/860
https://github.com/lukeautry/tsoa/issues/698

possbile also fixes
https://github.com/lukeautry/tsoa/issues/1033
https://github.com/lukeautry/tsoa/issues/681

**Test plan**

current tests are still working, tested it with 5 tsoa projects on our side. Everything still working like before.

