### PR TITLE
fixes request timeout in express when there is exception during container creation

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -81,24 +81,24 @@ export function RegisterRoutes(app: express.Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = getValidatedArgs(args, request, response);
+
+              {{#if ../../iocModule}}
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<{{../name}}>({{../name}});
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+              {{else}}
+                const controller = new {{../name}}();
+              {{/if}}
+
+
+              const promise = controller.{{name}}.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, {{successStatus}}, next);
             } catch (err) {
                 return next(err);
             }
-
-            {{#if ../../iocModule}}
-            const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-            const controller: any = await container.get<{{../name}}>({{../name}});
-            if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-            }
-            {{else}}
-            const controller = new {{../name}}();
-            {{/if}}
-
-
-            const promise = controller.{{name}}.apply(controller, validatedArgs as any);
-            promiseHandler(controller, promise, response, {{successStatus}}, next);
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     {{/each}}

--- a/tests/fixtures/inversify-async/asyncErrorController.ts
+++ b/tests/fixtures/inversify-async/asyncErrorController.ts
@@ -1,0 +1,13 @@
+import { inject, injectable } from 'inversify';
+import { Get, Route } from '@tsoa/runtime';
+
+@injectable()
+@Route('AsyncIocErrorTest')
+export class AsyncErrorController {
+  constructor(@inject('error') private error: string) {}
+
+  @Get()
+  public async getError(): Promise<string> {
+    return this.error;
+  }
+}

--- a/tests/fixtures/inversify-async/ioc.ts
+++ b/tests/fixtures/inversify-async/ioc.ts
@@ -1,10 +1,19 @@
 import { Container } from 'inversify';
 import { AsyncController } from './asyncController';
 import { AsyncService } from './asyncService';
+import { AsyncErrorController } from './asyncErrorController';
 
 const container = new Container();
 container.bind<AsyncService>(AsyncService).to(AsyncService).inSingletonScope();
 container.bind<AsyncController>(AsyncController).to(AsyncController).inSingletonScope();
+container.bind('error').toFactory(() => {
+  throw new Error('DI Error');
+  return () => {
+    return '';
+  };
+});
+container.bind<AsyncErrorController>(AsyncErrorController).to(AsyncErrorController).inSingletonScope();
+
 const iocContainer = {
   async get<T>(controller: { prototype: T }): Promise<T> {
     return container.get(controller);

--- a/tests/fixtures/inversify-async/server.ts
+++ b/tests/fixtures/inversify-async/server.ts
@@ -3,6 +3,7 @@ import * as express from 'express';
 import * as methodOverride from 'method-override';
 
 import './asyncController';
+import './asyncErrorController';
 import { RegisterRoutes } from './routes';
 
 export const app: express.Express = express();

--- a/tests/integration/inversify-async-server.spec.ts
+++ b/tests/integration/inversify-async-server.spec.ts
@@ -15,6 +15,16 @@ describe('Inversify async IoC Express Server', () => {
     });
   });
 
+  it('can handle errors in DI', () => {
+    return verifyGetRequest(
+      basePath + '/AsyncIocErrorTest',
+      err => {
+        expect(err.text).to.equal('DI Error');
+      },
+      500,
+    );
+  });
+
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
     return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
   }


### PR DESCRIPTION
Express isn't handling rejected promises therefore request just hangs if there is an error in DI resolution.
Controller resolution and execution were moved into try therefore all exceptions will be passed to an exception handler.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?