### PR TITLE
Support for undefined type alone and in union

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -52,6 +52,13 @@ export class TypeResolver {
       return enumType;
     }
 
+    if (this.typeNode.kind === ts.SyntaxKind.UndefinedKeyword) {
+      const undefinedType: Tsoa.UndefinedType = {
+        dataType: 'undefined',
+      };
+      return undefinedType;
+    }
+
     if (ts.isArrayTypeNode(this.typeNode)) {
       const arrayMetaType: Tsoa.ArrayType = {
         dataType: 'array',
@@ -478,6 +485,10 @@ export class TypeResolver {
       return {
         dataType: 'void',
       };
+    } else if (resolution.resolvedType === 'undefined') {
+      return {
+        dataType: 'undefined',
+      };
     } else {
       return assertNever(resolution.resolvedType);
     }
@@ -755,6 +766,11 @@ export class TypeResolver {
         foundMatch: true,
         resolvedType: 'void',
       };
+    } else if (syntaxKind === ts.SyntaxKind.UndefinedKeyword) {
+      return {
+        foundMatch: true,
+        resolvedType: 'undefined',
+      };
     } else {
       return {
         foundMatch: false,
@@ -876,8 +892,7 @@ export class TypeResolver {
 
   private getModelProperties(node: ts.InterfaceDeclaration | ts.ClassDeclaration, overrideToken?: OverrideToken): Tsoa.Property[] {
     const isIgnored = (e: ts.TypeElement | ts.ClassElement) => {
-      const ignore = isExistJSDocTag(e, tag => tag.tagName.text === 'ignore');
-      return ignore;
+      return isExistJSDocTag(e, tag => tag.tagName.text === 'ignore');
     };
 
     // Interface model
@@ -1161,7 +1176,7 @@ export class TypeResolver {
 
 interface ResolvesToPrimitive {
   foundMatch: true;
-  resolvedType: 'number' | 'string' | 'boolean' | 'void';
+  resolvedType: 'number' | 'string' | 'boolean' | 'void' | 'undefined';
 }
 interface DoesNotResolveToPrimitive {
   foundMatch: false;

--- a/packages/cli/src/utils/internalTypeGuards.ts
+++ b/packages/cli/src/utils/internalTypeGuards.ts
@@ -52,6 +52,8 @@ export function isRefType(metaType: Tsoa.Type): metaType is Tsoa.ReferenceType {
       return false;
     case 'void':
       return false;
+    case 'undefined':
+      return false;
     default: {
       return assertNever(metaType);
     }

--- a/packages/cli/src/utils/isVoidType.ts
+++ b/packages/cli/src/utils/isVoidType.ts
@@ -1,7 +1,7 @@
 import { Tsoa } from '@tsoa/runtime';
 
 export const isVoidType = (type: Tsoa.Type): boolean => {
-  if (type.dataType === 'void') {
+  if (type.dataType === 'void' || type.dataType === 'undefined') {
     return true;
   } else if (type.dataType === 'refAlias') {
     return isVoidType(type.type);

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -117,17 +117,18 @@ export namespace Tsoa {
     | 'refAlias'
     | 'nestedObjectLiteral'
     | 'union'
-    | 'intersection';
+    | 'intersection'
+    | 'undefined';
 
   export type RefTypeLiteral = 'refObject' | 'refEnum' | 'refAlias';
 
-  export type PrimitiveTypeLiteral = Exclude<TypeStringLiteral, RefTypeLiteral | 'enum' | 'array' | 'void' | 'nestedObjectLiteral' | 'union' | 'intersection'>;
+  export type PrimitiveTypeLiteral = Exclude<TypeStringLiteral, RefTypeLiteral | 'enum' | 'array' | 'void' | 'undefined' | 'nestedObjectLiteral' | 'union' | 'intersection'>;
 
   export interface TypeBase {
     dataType: TypeStringLiteral;
   }
 
-  export type PrimitiveType = StringType | BooleanType | DoubleType | FloatType | IntegerType | LongType | VoidType;
+  export type PrimitiveType = StringType | BooleanType | DoubleType | FloatType | IntegerType | LongType | VoidType | UndefinedType;
 
   /**
    * This is one of the possible objects that tsoa creates that helps the code store information about the type it found in the code.
@@ -222,6 +223,10 @@ export namespace Tsoa {
 
   export interface VoidType extends TypeBase {
     dataType: 'void';
+  }
+
+  export interface UndefinedType extends TypeBase {
+    dataType: 'undefined';
   }
 
   export interface AnyType extends TypeBase {

--- a/packages/runtime/src/swagger/swagger.ts
+++ b/packages/runtime/src/swagger/swagger.ts
@@ -1,5 +1,5 @@
 export namespace Swagger {
-  export type DataType = 'integer' | 'number' | 'boolean' | 'string' | 'array' | 'object' | 'file';
+  export type DataType = 'integer' | 'number' | 'boolean' | 'string' | 'array' | 'object' | 'file' | 'undefined';
 
   export type DataFormat = 'int32' | 'int64' | 'float' | 'double' | 'byte' | 'binary' | 'date' | 'date-time' | 'password';
 

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -30,6 +30,7 @@ export class GetTestController extends Controller {
    */
   @Get()
   @SuccessResponse('200', 'Returns TestModel')
+  // Have to give also values that are not part of the Swagger schema to get example to caller.
   @Example<TestModel>({
     and: { value1: 'foo', value2: 'bar' },
     boolArray: [true, false],
@@ -62,6 +63,8 @@ export class GetTestController extends Controller {
     strLiteralVal: 'Foo',
     stringArray: ['string one', 'string two'],
     stringValue: 'a string',
+    undefineableUnionPrimitiveType: undefined,
+    undefinedValue: undefined,
   })
   public async getModel(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/fixtures/inversify-async/asyncService.ts
+++ b/tests/fixtures/inversify-async/asyncService.ts
@@ -4,7 +4,9 @@ import { TestModel, TestSubModel } from '../testModel';
 @injectable()
 export class AsyncService {
   public getModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,
@@ -36,5 +38,6 @@ export class AsyncService {
       stringArray: ['string one', 'string two'],
       stringValue: 'a string',
     };
+    return testModel as TestModel;
   }
 }

--- a/tests/fixtures/inversify-cpg/managedService.ts
+++ b/tests/fixtures/inversify-cpg/managedService.ts
@@ -4,7 +4,9 @@ import { TestModel, TestSubModel } from '../testModel';
 @provide(ManagedService)
 export class ManagedService {
   public getModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,
@@ -36,5 +38,6 @@ export class ManagedService {
       stringArray: ['string one', 'string two'],
       stringValue: 'a string',
     };
+    return testModel as TestModel;
   }
 }

--- a/tests/fixtures/inversify/managedService.ts
+++ b/tests/fixtures/inversify/managedService.ts
@@ -4,7 +4,9 @@ import { TestModel, TestSubModel } from '../testModel';
 @injectable()
 export class ManagedService {
   public getModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,
@@ -36,5 +38,6 @@ export class ManagedService {
       stringArray: ['string one', 'string two'],
       stringValue: 'a string',
     };
+    return testModel as TestModel;
   }
 }

--- a/tests/fixtures/services/modelService.ts
+++ b/tests/fixtures/services/modelService.ts
@@ -2,7 +2,7 @@ import { TestClassModel, TestModel, TestSubModel } from '../testModel';
 
 export class ModelService {
   public getModel(): TestModel {
-    return {
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: true,
@@ -34,6 +34,7 @@ export class ModelService {
       stringArray: ['string one', 'string two'],
       stringValue: 'a string',
     };
+    return testModel as TestModel;
   }
 
   public getModelPromise(): Promise<TestModel> {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -50,6 +50,7 @@ export interface TestModel extends Model {
   boolArray: boolean[];
   object: object;
   objectArray: object[];
+  undefinedValue: undefined;
   enumValue?: EnumIndexValue;
   enumArray?: EnumIndexValue[];
   enumNumberValue?: EnumNumberValue;
@@ -65,6 +66,7 @@ export interface TestModel extends Model {
   strLiteralArr: StrLiteral[];
   unionPrimitiveType?: 'String' | 1 | 20.0 | true | false;
   nullableUnionPrimitiveType?: 'String' | 1 | 20.0 | true | false | null;
+  undefineableUnionPrimitiveType: 'String' | 1 | 20.0 | true | false | undefined;
   singleFloatLiteralType?: 3.1415;
   dateValue?: Date;
   optionalString?: string;

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -1148,7 +1148,9 @@ describe('Express Server', () => {
   }
 
   function getFakeModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,
@@ -1178,6 +1180,7 @@ describe('Express Server', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234',
     };
+    return testModel as TestModel;
   }
 
   function getFakeClassModel() {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1475,7 +1475,9 @@ describe('Express Server', () => {
   }
 
   function getFakeModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,
@@ -1505,6 +1507,7 @@ describe('Express Server', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234',
     };
+    return testModel as TestModel;
   }
 
   function getFakeClassModel() {

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1374,7 +1374,9 @@ describe('Hapi Server', () => {
   }
 
   function getFakeModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,
@@ -1404,6 +1406,7 @@ describe('Hapi Server', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234',
     };
+    return testModel as TestModel;
   }
 
   function getFakeClassModel() {

--- a/tests/integration/inversify-server.spec.ts
+++ b/tests/integration/inversify-server.spec.ts
@@ -22,7 +22,9 @@ describe('Inversify Express Server', () => {
     const oldGetModel = managedService.getModel.bind(managedService);
     // hook in a new getModel method returning id = 2
     managedService.getModel = () => {
-      return {
+      // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+      // (typed either as undefined or union with undefined typed member)
+      const testModel: Partial<TestModel> = {
         and: { value1: 'foo', value2: 'bar' },
         boolArray: [true, false],
         boolValue: true,
@@ -61,6 +63,7 @@ describe('Inversify Express Server', () => {
         stringArray: ['string one', 'string two'],
         stringValue: 'a string',
       };
+      return testModel as TestModel;
     };
     return verifyGetRequest(basePath + '/ManagedTest?tsoa=abc123456', (err, res) => {
       const model = res.body as TestModel;

--- a/tests/integration/koa-server-no-additional-allowed.spec.ts
+++ b/tests/integration/koa-server-no-additional-allowed.spec.ts
@@ -493,7 +493,9 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
   }
 
   function getFakeModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,
@@ -516,5 +518,6 @@ describe('Koa Server (with noImplicitAdditionalProperties turned on)', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234',
     };
+    return testModel as TestModel;
   }
 });

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1356,7 +1356,9 @@ describe('Koa Server', () => {
   }
 
   function getFakeModel(): TestModel {
-    return {
+    // Defining as Partial to help writing and allowing to leave out values that should be dropped or made optional in generation
+    // (typed either as undefined or union with undefined typed member)
+    const testModel: Partial<TestModel> = {
       and: { value1: 'foo', value2: 'bar' },
       boolArray: [true, false],
       boolValue: false,
@@ -1379,6 +1381,7 @@ describe('Koa Server', () => {
       stringArray: ['test', 'testtwo'],
       stringValue: 'test1234',
     };
+    return testModel as TestModel;
   }
 
   function getFakeClassModel() {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -259,6 +259,9 @@ describe('Definition generation', () => {
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
+          undefinedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
+          },
           object: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('object', `for property ${propertyName}`);
             if (currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras') {
@@ -434,6 +437,18 @@ describe('Definition generation', () => {
             expect(propertySchema.enum).to.include('true', `for property ${propertyName}.enum`);
             expect(propertySchema.enum).to.include('false', `for property ${propertyName}.enum`);
             expect(propertySchema.enum).to.include(null, `for property ${propertyName}.enum`);
+          },
+          undefineableUnionPrimitiveType: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq('string', `for property ${propertyName}.type`);
+            if (!propertySchema.enum) {
+              throw new Error(`There was no 'enum' property on ${propertyName}.`);
+            }
+            expect(propertySchema.enum).to.have.length(5, `for property ${propertyName}.enum`);
+            expect(propertySchema.enum).to.include('String', `for property ${propertyName}.enum`);
+            expect(propertySchema.enum).to.include('1', `for property ${propertyName}.enum`);
+            expect(propertySchema.enum).to.include('20', `for property ${propertyName}.enum`);
+            expect(propertySchema.enum).to.include('true', `for property ${propertyName}.enum`);
+            expect(propertySchema.enum).to.include('false', `for property ${propertyName}.enum`);
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('number', `for property ${propertyName}.type`);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -950,6 +950,9 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
+          undefinedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.type).to.eq(undefined, `for property ${propertyName}.type`);
+          },
           objLiteral: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.include({
               properties: {
@@ -1202,6 +1205,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               example: undefined,
               format: undefined,
               nullable: true,
+            });
+          },
+          undefineableUnionPrimitiveType: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq({
+              anyOf: [
+                { type: 'string', enum: ['String'] },
+                { type: 'number', enum: [1, 20] },
+                { type: 'boolean', enum: [true, false] },
+              ],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
             });
           },
           singleFloatLiteralType: (propertyName, propertySchema) => {

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -1207,4 +1207,80 @@ describe('ValidationService', () => {
       });
     });
   });
+
+  describe('undefined validate', () => {
+    const replacer = (key, value) => (typeof value === 'undefined' ? null : value);
+
+    it('returns undefined when not optional', () => {
+      const value = undefined;
+      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'undefined', required: true, validators: {} };
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'ignore',
+      };
+      const fieldErrors: FieldErrors = {};
+      const result = new ValidationService({}).ValidateParam(propertySchema, value, 'defaultProp', fieldErrors, undefined, minimalSwaggerConfig);
+      expect(Object.keys(fieldErrors)).to.be.empty;
+      expect(result).to.be.undefined;
+    });
+
+    it('fail if value required and not undefined', () => {
+      const value = 'undefined';
+      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'undefined', required: true, validators: {} };
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'ignore',
+      };
+      const fieldErrors: FieldErrors = {};
+      const result = new ValidationService({}).ValidateParam(propertySchema, value, 'defaultProp', fieldErrors, undefined, minimalSwaggerConfig);
+      expect(Object.keys(fieldErrors)).to.not.be.empty;
+      expect(result).to.be.undefined;
+    });
+
+    it('should not return undefined when optional inside object', () => {
+      const modelDefinition: TsoaRoute.ModelSchema = {
+        dataType: 'refObject',
+        properties: {
+          a: { dataType: 'undefined' },
+        },
+      };
+      const v = new ValidationService({});
+      const error = {};
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'ignore',
+      };
+      const result = v.validateModel({ name: '', value: {}, modelDefinition, fieldErrors: error, minimalSwaggerConfig });
+      expect(Object.keys(error)).to.be.empty;
+      // use JSON strngify to allow comparison of undefined values
+      expect(JSON.stringify(result, replacer)).to.equal(JSON.stringify(result));
+    });
+
+    it('should return undefined when required in object', () => {
+      const modelDefinition: TsoaRoute.ModelSchema = {
+        dataType: 'refObject',
+        properties: {
+          a: { dataType: 'undefined', required: true },
+        },
+      };
+      const v = new ValidationService({});
+      const error = {};
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'ignore',
+      };
+      const result = v.validateModel({ name: '', value: {}, modelDefinition, fieldErrors: error, minimalSwaggerConfig });
+      expect(Object.keys(error)).to.be.empty;
+      // use JSON strngify to allow comparison of undefined values
+      expect(JSON.stringify(result, replacer)).to.equal(JSON.stringify({ a: undefined }, replacer));
+    });
+
+    it('fail if value optional and not undefined', () => {
+      const value = 'undefined';
+      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'undefined', required: false, validators: {} };
+      const minimalSwaggerConfig: AdditionalProps = {
+        noImplicitAdditionalProperties: 'ignore',
+      };
+      const fieldErrors: FieldErrors = {};
+      const result = new ValidationService({}).ValidateParam(propertySchema, value, 'defaultProp', fieldErrors, undefined, minimalSwaggerConfig);
+      expect(Object.keys(fieldErrors)).to.not.be.empty;
+      expect(result).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1031 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
Might have some corner cases that are not thought, sharing code as I'm currently a bit puzzled why GET tests are failing (all others are passing).
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

Added new element validation added to model, and changed counts to realize that model has one more field than generated spec (because of `undefined` typed value is dropped).

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
