### PR TITLE
feat(spec): allow defining custom media type of responses + fix(koa): dont overwrite content-type of response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 routes.ts
 customRoutes.ts
 .idea/
+*.swp
 yarn-error.log
 tsconfig.tsbuildinfo

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -204,8 +204,6 @@ export function RegisterRoutes(router: KoaRouter) {
 
     function returnHandler(context: any, next: () => any, statusCode?: number, data?: any, headers: any={}) {
         if (!context.headerSent && !context.response.__tsoaResponded) {
-            context.set(headers);
-
             if (data !== null && data !== undefined) {
                 context.body = data;
                 context.status = 200;
@@ -217,6 +215,7 @@ export function RegisterRoutes(router: KoaRouter) {
                 context.status = statusCode;
             }
 
+            context.set(headers);
             context.response.__tsoaResponded = true;
             return next();
         }

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -222,7 +222,7 @@ export class SpecGenerator2 extends SpecGenerator {
       }
     });
 
-    produces = Array.from(new Set(produces.filter(p => p)));
+    produces = Array.from(new Set(produces.filter(p => p !== undefined)));
     if (produces.length === 0) {
       produces = [defaultProduces || DEFAULT_RESPONSE_MEDIA_TYPE];
     }

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -2,7 +2,7 @@ import { ExtendedSpecConfig } from '../cli';
 import { Tsoa, assertNever, Swagger } from '@tsoa/runtime';
 import { isVoidType } from '../utils/isVoidType';
 import { convertColonPathParams, normalisePath } from './../utils/pathUtils';
-import { getValue } from './../utils/swaggerUtils';
+import { DEFAULT_REQUEST_MEDIA_TYPE, DEFAULT_RESPONSE_MEDIA_TYPE, getValue } from './../utils/swaggerUtils';
 import { SpecGenerator } from './specGenerator';
 import { UnspecifiedObject } from '../utils/unspecifiedObject';
 
@@ -239,15 +239,15 @@ export class SpecGenerator3 extends SpecGenerator {
           let path = normalisePath(`${normalisedControllerPath}${normalisedMethodPath}`, '/', '', false);
           path = convertColonPathParams(path);
           paths[path] = paths[path] || {};
-          this.buildMethod(controller.name, method, paths[path]);
+          this.buildMethod(controller.name, method, paths[path], controller.produces);
         });
     });
 
     return paths;
   }
 
-  private buildMethod(controllerName: string, method: Tsoa.Method, pathObject: any) {
-    const pathMethod: Swagger.Operation3 = (pathObject[method.method] = this.buildOperation(controllerName, method));
+  private buildMethod(controllerName: string, method: Tsoa.Method, pathObject: any, defaultProduces?: string) {
+    const pathMethod: Swagger.Operation3 = (pathObject[method.method] = this.buildOperation(controllerName, method, defaultProduces));
     pathMethod.description = method.description;
     pathMethod.summary = method.summary;
     pathMethod.tags = method.tags;
@@ -289,7 +289,7 @@ export class SpecGenerator3 extends SpecGenerator {
     method.extensions.forEach(ext => (pathMethod[ext.key] = ext.value));
   }
 
-  protected buildOperation(controllerName: string, method: Tsoa.Method): Swagger.Operation3 {
+  protected buildOperation(controllerName: string, method: Tsoa.Method, defaultProduces?: string): Swagger.Operation3 {
     const swaggerResponses: { [name: string]: Swagger.Response3 } = {};
 
     method.responses.forEach((res: Tsoa.Response) => {
@@ -298,8 +298,9 @@ export class SpecGenerator3 extends SpecGenerator {
       };
 
       if (res.schema && !isVoidType(res.schema)) {
+        const produces = res.produces || defaultProduces || DEFAULT_RESPONSE_MEDIA_TYPE;
         swaggerResponses[res.name].content = {
-          'application/json': {
+          [produces]: {
             schema: this.getSwaggerType(res.schema),
           } as Swagger.Schema3,
         };
@@ -311,7 +312,7 @@ export class SpecGenerator3 extends SpecGenerator {
             return { ...acc, [exampleLabel === undefined ? `Example ${exampleCounter++}` : exampleLabel]: { value: ex } };
           }, {});
           /* eslint-disable @typescript-eslint/dot-notation */
-          (swaggerResponses[res.name].content || {})['application/json']['examples'] = examples;
+          (swaggerResponses[res.name].content || {})[DEFAULT_RESPONSE_MEDIA_TYPE]['examples'] = examples;
         }
       }
 
@@ -379,7 +380,7 @@ export class SpecGenerator3 extends SpecGenerator {
       description: parameter.description,
       required: parameter.required,
       content: {
-        'application/json': mediaType,
+        [DEFAULT_REQUEST_MEDIA_TYPE]: mediaType,
       },
     };
 

--- a/packages/cli/src/utils/swaggerUtils.ts
+++ b/packages/cli/src/utils/swaggerUtils.ts
@@ -1,3 +1,6 @@
+export const DEFAULT_REQUEST_MEDIA_TYPE = 'application/json';
+export const DEFAULT_RESPONSE_MEDIA_TYPE = 'application/json';
+
 export function getValue(type: 'string' | 'number' | 'integer' | 'boolean', member: any) {
   if (member === null) {
     return null;

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -1,7 +1,7 @@
 import { IsValidHeader } from '../utils/isHeaderType';
 import { HttpStatusCodeLiteral, HttpStatusCodeStringLiteral, OtherValidOpenApiHttpStatusCode } from '../interfaces/response';
 
-export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = {}>(name: string | number, description?: string): Function {
+export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = {}>(name: string | number, description?: string, produces?: string): Function {
   return () => {
     return;
   };
@@ -11,6 +11,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
   name: HttpStatusCodeLiteral | HttpStatusCodeStringLiteral | OtherValidOpenApiHttpStatusCode,
   description?: string,
   example?: ExampleType,
+  produces?: string,
 ): Function {
   return () => {
     return;
@@ -23,6 +24,18 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
  * The type of the responder function should be annotated `TsoaResponse<Status, Data, Headers>` in order to support OpenAPI documentation.
  */
 export function Res(): Function {
+  return () => {
+    return;
+  };
+}
+
+/**
+ * Overrides the default media type of response.
+ * Can be used on controller level or only for specific method
+ *
+ * @link https://swagger.io/docs/specification/media-types/
+ */
+export function Produces(value: string): Function {
   return () => {
     return;
   };

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -11,6 +11,7 @@ export namespace Tsoa {
     methods: Method[];
     name: string;
     path: string;
+    produces?: string;
   }
 
   export interface Method {
@@ -21,6 +22,7 @@ export namespace Tsoa {
     name: string;
     parameters: Parameter[];
     path: string;
+    produces?: string;
     type: Type;
     tags?: string[];
     responses: Response[];
@@ -71,6 +73,7 @@ export namespace Tsoa {
   export interface Response {
     description: string;
     name: string;
+    produces?: string;
     schema?: Type;
     examples?: unknown[];
     exampleLabels?: Array<string | undefined>;

--- a/tests/fixtures/controllers/mediaTypeController.ts
+++ b/tests/fixtures/controllers/mediaTypeController.ts
@@ -35,7 +35,7 @@ export class MediaTypeTestController extends Controller {
 
     const body = { id: model.name.length, name: model.name };
     this.setStatus(202);
-    this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v2+json'); // express and hapi returns it, koa ignores
+    this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v2+json');
     return body;
   }
 }

--- a/tests/fixtures/controllers/mediaTypeController.ts
+++ b/tests/fixtures/controllers/mediaTypeController.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Get, Produces, Path, Post, Response, Res, Route, SuccessResponse, TsoaResponse } from '@tsoa/runtime';
+import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
+
+type UserRequestModel = Pick<UserResponseModel, 'name'>;
+
+@Route('MediaTypeTest')
+@Produces('application/vnd.mycompany.myapp+json')
+export class MediaTypeTestController extends Controller {
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Get('Default/{userId}')
+  public async getDefaultProduces(@Path() userId: number): Promise<UserResponseModel> {
+    this.setHeader('Content-Type', 'application/vnd.mycompany.myapp+json');
+    return Promise.resolve({
+      id: userId,
+      name: 'foo',
+    });
+  }
+
+  @Get('Custom/security.txt')
+  @Produces('text/plain')
+  public async getCustomProduces(): Promise<string> {
+    const securityTxt = 'Contact: mailto: security@example.com\nExpires: 2012-12-12T12:37:00.000Z';
+    this.setHeader('Content-Type', 'text/plain');
+    return securityTxt;
+  }
+
+  @SuccessResponse('202', 'Accepted', 'application/vnd.mycompany.myapp.v2+json')
+  @Response<ErrorResponseModel>('400', 'Bad Request', undefined, 'application/problem+json')
+  @Post('Custom')
+  async postCustomProduces(@Body() model: UserRequestModel, @Res() conflictRes: TsoaResponse<409, { message: string }, { 'Content-Type': 'application/problem+json' }>): Promise<UserResponseModel> {
+    if (model.name === 'bar') {
+      this.setHeader('Content-Type', 'application/problem+json');
+      return conflictRes?.(409, { message: 'Conflict' });
+    }
+
+    const body = { id: model.name.length, name: model.name };
+    this.setStatus(202);
+    this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v2+json'); // express and hapi returns it, koa ignores
+    return body;
+  }
+}

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -12,6 +12,7 @@ import '../controllers/postController';
 import '../controllers/putController';
 
 import '../controllers/methodController';
+import '../controllers/mediaTypeController';
 import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -9,6 +9,7 @@ import '../controllers/postController';
 import '../controllers/putController';
 
 import '../controllers/methodController';
+import '../controllers/mediaTypeController';
 import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -11,6 +11,7 @@ import '../controllers/postController';
 import '../controllers/putController';
 
 import '../controllers/methodController';
+import '../controllers/mediaTypeController';
 import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -460,6 +460,19 @@ describe('Express Server', () => {
     });
   });
 
+  describe('Custom Content-Type', () => {
+    it('should return custom content-type if given', () => {
+      return verifyPostRequest(
+        basePath + '/MediaTypeTest/Custom',
+        { name: 'foo' },
+        (err, res) => {
+          expect(res.type).to.eq('application/vnd.mycompany.myapp.v2+json');
+        },
+        202,
+      );
+    });
+  });
+
   describe('Validate', () => {
     it('should valid minDate and maxDate validation of date type', () => {
       const minDate = '2019-01-01';

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -357,6 +357,19 @@ describe('Hapi Server', () => {
     });
   });
 
+  describe('Custom Content-Type', () => {
+    it('should return custom content-type if given', () => {
+      return verifyPostRequest(
+        basePath + '/MediaTypeTest/Custom',
+        { name: 'foo' },
+        (err, res) => {
+          expect(res.type).to.eq('application/vnd.mycompany.myapp.v2+json');
+        },
+        202,
+      );
+    });
+  });
+
   describe('Validate', () => {
     it('should valid minDate and maxDate validation of date type', () => {
       const minDate = '2019-01-01';

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -303,6 +303,19 @@ describe('Koa Server', () => {
     });
   });
 
+  describe('Custom Content-Type', () => {
+    it('should return custom content-type if given', () => {
+      return verifyPostRequest(
+        basePath + '/MediaTypeTest/Custom',
+        { name: 'foo' },
+        (err, res) => {
+          expect(res.type).to.eq('application/vnd.mycompany.myapp.v2+json');
+        },
+        202,
+      );
+    });
+  });
+
   describe('NoExtends', () => {
     it('should ignore SuccessResponse code and use default code', () => {
       return verifyGetRequest(

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -427,6 +427,33 @@ describe('Schema details generation', () => {
           });
         });
 
+        describe('media types', () => {
+          let mediaTypeTest;
+
+          before(() => {
+            const metadata = new MetadataGenerator('./fixtures/controllers/mediaTypeController.ts').Generate();
+            mediaTypeTest = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+          });
+
+          it('Should use controller Produces decorator as a default media type', () => {
+            const { produces } = mediaTypeTest.paths['/MediaTypeTest/Default/{userId}']?.get;
+
+            expect(produces).to.deep.eq(['application/vnd.mycompany.myapp+json']);
+          });
+
+          it('Should generate custom media type from method Produces decorator', () => {
+            const { produces } = mediaTypeTest.paths['/MediaTypeTest/Custom/security.txt']?.get;
+
+            expect(produces).to.deep.eq(['text/plain']);
+          });
+
+          it('Should generate custom media types from method reponse decorators and Res decorator', () => {
+            const { produces } = mediaTypeTest.paths['/MediaTypeTest/Custom']?.post;
+
+            expect(produces).to.deep.eq(['application/problem+json', 'application/vnd.mycompany.myapp.v2+json']);
+          });
+        });
+
         it('Falls back to the first @Example<>', () => {
           const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
           const exampleSpec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -683,6 +683,43 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           });
         });
 
+        describe('media types', () => {
+          let mediaTypeTest;
+
+          before(() => {
+            const metadata = new MetadataGenerator('./fixtures/controllers/mediaTypeController.ts').Generate();
+            mediaTypeTest = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+          });
+
+          it('Should use controller Produces decorator as a default media type', () => {
+            const [mediaTypeOk] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Default/{userId}']?.get?.responses?.[200]?.content);
+            const [mediaTypeNotFound] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Default/{userId}']?.get?.responses?.[404]?.content);
+
+            expect(mediaTypeOk).to.eql('application/vnd.mycompany.myapp+json');
+            expect(mediaTypeNotFound).to.eql('application/vnd.mycompany.myapp+json');
+          });
+
+          it('Should generate custom media type from method Produces decorator', () => {
+            const [mediaType] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Custom/security.txt']?.get?.responses?.[200]?.content);
+
+            expect(mediaType).to.eql('text/plain');
+          });
+
+          it('Should generate custom media types from method reponse decorators', () => {
+            const [mediaTypeAccepted] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Custom']?.post?.responses?.[202]?.content);
+            const [mediaTypeBadRequest] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Custom']?.post?.responses?.[400]?.content);
+
+            expect(mediaTypeAccepted).to.eql('application/vnd.mycompany.myapp.v2+json');
+            expect(mediaTypeBadRequest).to.eql('application/problem+json');
+          });
+
+          it('Should generate custom media types from header in @Res decorator', () => {
+            const [mediaTypeConflict] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Custom']?.post?.responses?.[409]?.content);
+
+            expect(mediaTypeConflict).to.eql('application/problem+json');
+          });
+        });
+
         it('Supports multiple examples', () => {
           const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
           const exampleSpec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();


### PR DESCRIPTION
problem description: currently `application/json` is hardcoded into generated spec
    
proposed solution: allow specifying custom media type in generated spec
on both controller level by:
  - using new `@Produces` decorator

and on method level by:
  - using new `@Produces` decorator
  - introducing new optional arg for `@SuccessResponse` decorator
  - introducing new optional arg for `@Response` decorator
  - setting `Content-Type` header in `@Res` decorator

impact:
  - cli: controller generator
  - cli: method generator
  - cli: parameter generator
  - cli: spec2 generator
  - cli: spec3 generator
  - runtime: response decorators

    
Closes #1126
Related #968

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

- [x] Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->
1. Someone could think that defining custom media type will also override `content-type` of actual response (which is not a case). However I don't think it's a problem -> if you check the issues from the past you will see that writing custom methods was encouraged - for example #44 #224
2. OAS2 is not affected by this changes
3. ~~I wasn't able to introduce new arg for setting custom media type for `@Res` decorator~~


**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
1. I've tried to show that it is possible to set `@Produces` on controller level
2. I've tried to show that even when `@Produces` is set on controller level it is possible to set it also for specific method
3. I've tried to show that OAS3 media type of responses is possible to be changed by passing new optional arg in `@Response` and `@SuccessResponse` decorators
4. I've tried to show that OAS3 media type of responses is possible to be changed by defining headers for `@Res` decorator