### PR TITLE
Remove CVE-2021-23369 finding for modules using CLI [#1130]

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "deepmerge": "^4.2.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
-    "handlebars": "^4.7.6",
+    "handlebars": "^4.7.7",
     "merge": "^2.1.0",
     "minimatch": "^3.0.4",
     "typescript": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,7 +3575,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.7.6:
+handlebars@^4.7.6, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==


### PR DESCRIPTION
`handlebars@4.7.7` is already in the yarn.lock, but when TSOA is imported,
yarn audit finds this issue, based on version in package.json version
https://github.com/advisories/GHSA-f2jv-r9rf-7988

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- N/A - Have you written unit tests?
- N/A - Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? 
- [x] - This PR is associated with an existing issue? https://github.com/lukeautry/tsoa/issues/1130

**Closing issues**

closes #1130 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

None

**Test plan**

N/A
