### PR TITLE
feat(spec): allow defining multiple media types per response, custom media type of requestBody 

### DIFF
--- a/packages/cli/src/metadataGeneration/controllerGenerator.ts
+++ b/packages/cli/src/metadataGeneration/controllerGenerator.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { getDecorators, getDecoratorValues, getSecurites } from './../utils/decoratorUtils';
+import { getDecorators, getDecoratorValues, getProduces, getSecurites } from './../utils/decoratorUtils';
 import { GenerateMetadataError } from './exceptions';
 import { MetadataGenerator } from './metadataGenerator';
 import { MethodGenerator } from './methodGenerator';
@@ -13,7 +13,7 @@ export class ControllerGenerator {
   private readonly security?: Tsoa.Security[];
   private readonly isHidden?: boolean;
   private readonly commonResponses: Tsoa.Response[];
-  private readonly produces?: string;
+  private readonly produces?: string[];
 
   constructor(private readonly node: ts.ClassDeclaration, private readonly current: MetadataGenerator) {
     this.path = this.getPath();
@@ -136,18 +136,8 @@ export class ControllerGenerator {
     return true;
   }
 
-  private getProduces(): string | undefined {
-    const producesDecorators = getDecorators(this.node, identifier => identifier.text === 'Produces');
-
-    if (!producesDecorators || !producesDecorators.length) {
-      return;
-    }
-    if (producesDecorators.length > 1) {
-      throw new GenerateMetadataError(`Only one Produces decorator allowed in '${this.node.name!.text}' class.`);
-    }
-
-    const [decorator] = producesDecorators;
-    const [produces] = getDecoratorValues(decorator, this.current.typeChecker);
-    return produces;
+  private getProduces(): string[] | undefined {
+    const produces = getProduces(this.node, this.current.typeChecker);
+    return produces.length ? produces : undefined;
   }
 }

--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -115,13 +115,12 @@ export class ParameterGenerator {
     });
   }
 
-  private getProducesFromResHeaders(headers: Tsoa.HeaderType): string | undefined {
+  private getProducesFromResHeaders(headers: Tsoa.HeaderType): string[] | undefined {
     const { properties } = headers;
     const [contentTypeProp] = (properties || []).filter(p => p.name.toLowerCase() === 'content-type' && p.type.dataType === 'enum');
     if (contentTypeProp) {
       const type = contentTypeProp.type as Tsoa.EnumType;
-      const [produces] = type.enums as string[];
-      return produces;
+      return type.enums as string[];
     }
     return;
   }

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -153,7 +153,7 @@ export class SpecGenerator2 extends SpecGenerator {
     return paths;
   }
 
-  private buildMethod(controllerName: string, method: Tsoa.Method, pathObject: any, defaultProduces?: string) {
+  private buildMethod(controllerName: string, method: Tsoa.Method, pathObject: any, defaultProduces?: string[]) {
     const pathMethod: Swagger.Operation = (pathObject[method.method] = this.buildOperation(controllerName, method, defaultProduces));
     pathMethod.description = method.description;
     pathMethod.summary = method.summary;
@@ -187,7 +187,7 @@ export class SpecGenerator2 extends SpecGenerator {
     method.extensions.forEach(ext => (pathMethod[ext.key] = ext.value));
   }
 
-  protected buildOperation(controllerName: string, method: Tsoa.Method, defaultProduces?: string): Swagger.Operation {
+  protected buildOperation(controllerName: string, method: Tsoa.Method, defaultProduces?: string[]): Swagger.Operation {
     const swaggerResponses: { [name: string]: Swagger.Response } = {};
 
     let produces: Array<string | undefined> = [];
@@ -196,7 +196,9 @@ export class SpecGenerator2 extends SpecGenerator {
         description: res.description,
       };
       if (res.schema && !isVoidType(res.schema)) {
-        produces.push(res.produces);
+        if (res.produces) {
+          produces.push(...res.produces);
+        }
         swaggerResponses[res.name].schema = this.getSwaggerType(res.schema) as Swagger.Schema;
       }
       if (res.examples && res.examples[0]) {
@@ -224,7 +226,7 @@ export class SpecGenerator2 extends SpecGenerator {
 
     produces = Array.from(new Set(produces.filter(p => p !== undefined)));
     if (produces.length === 0) {
-      produces = [defaultProduces || DEFAULT_RESPONSE_MEDIA_TYPE];
+      produces = defaultProduces || [DEFAULT_RESPONSE_MEDIA_TYPE];
     }
 
     const operation: Swagger.Operation = {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -235,9 +235,16 @@ export class SpecGenerator2 extends SpecGenerator {
       responses: swaggerResponses,
     };
 
+    const hasBody = method.parameters.some(p => p.in === 'body');
     const hasFormData = method.parameters.some(p => p.in === 'formData');
-    if (hasFormData) {
-      operation.consumes = ['multipart/form-data'];
+    if (hasBody || hasFormData) {
+      operation.consumes = [];
+      if (hasBody) {
+        operation.consumes.push(method.consumes || DEFAULT_REQUEST_MEDIA_TYPE);
+      }
+      if (hasFormData) {
+        operation.consumes.push('multipart/form-data');
+      }
     }
 
     return operation;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -380,12 +380,13 @@ export class SpecGenerator3 extends SpecGenerator {
 
   private buildRequestBody(controllerName: string, method: Tsoa.Method, parameter: Tsoa.Parameter): Swagger.RequestBody {
     const mediaType = this.buildMediaType(controllerName, method, parameter);
+    const consumes = method.consumes || DEFAULT_REQUEST_MEDIA_TYPE;
 
     const requestBody: Swagger.RequestBody = {
       description: parameter.description,
       required: parameter.required,
       content: {
-        [DEFAULT_REQUEST_MEDIA_TYPE]: mediaType,
+        [consumes]: mediaType,
       },
     };
 

--- a/packages/cli/src/utils/decoratorUtils.ts
+++ b/packages/cli/src/utils/decoratorUtils.ts
@@ -74,3 +74,13 @@ export function getPath(decorator: ts.Identifier, typeChecker: ts.TypeChecker): 
 
   return path;
 }
+
+export function getProduces(node: ts.Node, typeChecker: ts.TypeChecker): string[] {
+  const producesDecorators = getDecorators(node, identifier => identifier.text === 'Produces');
+
+  if (!producesDecorators || !producesDecorators.length) {
+    return [];
+  }
+
+  return producesDecorators.map(decorator => getDecoratorValues(decorator, typeChecker)[0]);
+}

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -102,3 +102,16 @@ export function FormField(name?: string): any {
     return;
   };
 }
+
+/**
+ * Overrides the default media type of request.
+ * Can be used on specific method.
+ * Can't be used on controller level.
+ *
+ * @link https://swagger.io/docs/specification/media-types/
+ */
+export function Consumes(value: string): Function {
+  return () => {
+    return;
+  };
+}

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -104,11 +104,11 @@ export function FormField(name?: string): any {
 }
 
 /**
- * Overrides the default media type of request.
+ * Overrides the default media type of request body.
  * Can be used on specific method.
  * Can't be used on controller level.
  *
- * @link https://swagger.io/docs/specification/media-types/
+ * @link https://swagger.io/docs/specification/describing-request-body/
  */
 export function Consumes(value: string): Function {
   return () => {

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -1,7 +1,7 @@
 import { IsValidHeader } from '../utils/isHeaderType';
 import { HttpStatusCodeLiteral, HttpStatusCodeStringLiteral, OtherValidOpenApiHttpStatusCode } from '../interfaces/response';
 
-export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = {}>(name: string | number, description?: string, produces?: string): Function {
+export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = {}>(name: string | number, description?: string, produces?: string | string[]): Function {
   return () => {
     return;
   };
@@ -11,7 +11,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
   name: HttpStatusCodeLiteral | HttpStatusCodeStringLiteral | OtherValidOpenApiHttpStatusCode,
   description?: string,
   example?: ExampleType,
-  produces?: string,
+  produces?: string | string[],
 ): Function {
   return () => {
     return;

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -11,7 +11,7 @@ export namespace Tsoa {
     methods: Method[];
     name: string;
     path: string;
-    produces?: string;
+    produces?: string[];
   }
 
   export interface Method {
@@ -22,7 +22,7 @@ export namespace Tsoa {
     name: string;
     parameters: Parameter[];
     path: string;
-    produces?: string;
+    produces?: string[];
     type: Type;
     tags?: string[];
     responses: Response[];
@@ -73,7 +73,7 @@ export namespace Tsoa {
   export interface Response {
     description: string;
     name: string;
-    produces?: string;
+    produces?: string[];
     schema?: Type;
     examples?: unknown[];
     exampleLabels?: Array<string | undefined>;

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -23,6 +23,7 @@ export namespace Tsoa {
     parameters: Parameter[];
     path: string;
     produces?: string[];
+    consumes?: string;
     type: Type;
     tags?: string[];
     responses: Response[];

--- a/tests/fixtures/controllers/mediaTypeController.ts
+++ b/tests/fixtures/controllers/mediaTypeController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Produces, Path, Post, Response, Res, Route, SuccessResponse, TsoaResponse } from '@tsoa/runtime';
+import { Body, Consumes, Controller, Get, Produces, Path, Post, Response, Res, Route, SuccessResponse, TsoaResponse } from '@tsoa/runtime';
 import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
 
 type UserRequestModel = Pick<UserResponseModel, 'name'>;
@@ -16,6 +16,14 @@ export class MediaTypeTestController extends Controller {
     });
   }
 
+  @SuccessResponse('202', 'Accepted')
+  @Post('Default')
+  async postDefaultProduces(@Body() model: UserRequestModel): Promise<UserResponseModel> {
+    const body = { id: model.name.length, name: model.name };
+    this.setStatus(202);
+    return body;
+  }
+
   @Get('Custom/security.txt')
   @Produces('text/plain')
   public async getCustomProduces(): Promise<string> {
@@ -24,6 +32,7 @@ export class MediaTypeTestController extends Controller {
     return securityTxt;
   }
 
+  @Consumes('application/vnd.mycompany.myapp.v2+json')
   @SuccessResponse('202', 'Accepted', 'application/vnd.mycompany.myapp.v2+json')
   @Response<ErrorResponseModel>('400', 'Bad Request', undefined, 'application/problem+json')
   @Post('Custom')

--- a/tests/fixtures/controllers/requestExpressController.ts
+++ b/tests/fixtures/controllers/requestExpressController.ts
@@ -1,0 +1,113 @@
+import { Request as ExRequest } from 'express';
+import { Body, Controller, Get, Produces, Path, Post, Response, Res, Request, Route, SuccessResponse, TsoaResponse } from '@tsoa/runtime';
+import { ErrorResponseModel, UserResponseModel } from '../../fixtures/testModel';
+
+interface UserResponseV2Model {
+  id: number;
+  username: string;
+}
+
+interface UserResponseV3Model {
+  id: number;
+  nickname: string;
+}
+
+interface UserResponseV4Model {
+  id: number;
+  codename: string;
+}
+
+interface UserRequestV3Model {
+  nickname: string;
+  codename?: string;
+}
+
+interface UserRequestV4Model {
+  codename: string;
+  nickname?: string;
+}
+
+@Route('RequestAcceptHeaderTest')
+@Produces('application/vnd.mycompany.myapp+json')
+@Produces('application/vnd.mycompany.myapp.v2+json')
+export class RequestAcceptHeaderTestController extends Controller {
+  @Get('Default/{userId}')
+  public async getDefaultProduces(@Path() userId: number, @Request() req: ExRequest): Promise<UserResponseModel | UserResponseV2Model> {
+    if (req.accepts(['application/vnd.mycompany.myapp+json', 'application/json'])) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp+json');
+      return Promise.resolve({
+        id: userId,
+        name: 'foo',
+      } as UserResponseModel);
+    } else if (req.accepts('application/vnd.mycompany.myapp.v2+json')) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v2+json');
+      return Promise.resolve({
+        id: userId,
+        username: 'foo',
+      } as UserResponseV2Model);
+    }
+    throw new Error('unsupported media type');
+  }
+
+  @Produces('application/vnd.mycompany.myapp+json')
+  @Produces('application/vnd.mycompany.myapp.v2+json')
+  @Produces('application/vnd.mycompany.myapp.v3+json')
+  @Produces('application/vnd.mycompany.myapp.v4+json')
+  @Get('Multi/{userId}')
+  public async getMultiProduces(@Path() userId: number, @Request() req: ExRequest): Promise<UserResponseModel | UserResponseV2Model | UserResponseV3Model | UserResponseV4Model> {
+    if (req.accepts(['application/vnd.mycompany.myapp+json', 'application/json'])) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp+json');
+      return Promise.resolve({
+        id: userId,
+        name: 'foo',
+      } as UserResponseModel);
+    } else if (req.accepts('application/vnd.mycompany.myapp.v2+json')) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v2+json');
+      return Promise.resolve({
+        id: userId,
+        username: 'foo',
+      } as UserResponseV2Model);
+    } else if (req.accepts('application/vnd.mycompany.myapp.v3+json')) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v3+json');
+      return Promise.resolve({
+        id: userId,
+        nickname: 'foo',
+      } as UserResponseV3Model);
+    } else if (req.accepts('application/vnd.mycompany.myapp.v4+json')) {
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v4+json');
+      return Promise.resolve({
+        id: userId,
+        codename: 'foo',
+      } as UserResponseV4Model);
+    }
+    throw new Error('unsupported media type');
+  }
+
+  @SuccessResponse('202', 'Accepted', ['application/vnd.mycompany.myapp.v3+json', 'application/vnd.mycompany.myapp.v4+json'])
+  @Response<ErrorResponseModel>('400', 'Bad Request', undefined, ['application/problem+json', 'application/json'])
+  @Post('Multi')
+  async postCustomProduces(
+    @Body() model: UserRequestV3Model | UserRequestV4Model,
+    @Res() conflictRes: TsoaResponse<409, { message: string }, { 'Content-Type': 'application/problem+json' }>,
+    @Request() req: ExRequest,
+  ): Promise<UserResponseV3Model | UserResponseV4Model> {
+    const { nickname, codename } = model;
+    if (nickname === 'bar' || codename === 'bar') {
+      this.setHeader('Content-Type', 'application/problem+json');
+      return conflictRes?.(409, { message: 'Conflict' });
+    }
+
+    if (req.headers['content-type'] === 'application/vnd.mycompany.myapp.v3+json') {
+      const body = { id: model.nickname?.length, nickname: model.nickname };
+      this.setStatus(202);
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v3+json');
+      return body as UserResponseV3Model;
+    } else if (req.headers['content-type'] === 'application/vnd.mycompany.myapp.v4+json') {
+      const body = { id: model.codename?.length, codename: model.codename };
+      this.setStatus(202);
+      this.setHeader('Content-Type', 'application/vnd.mycompany.myapp.v4+json');
+      return body as UserResponseV4Model;
+    }
+    throw new Error('unsupported media type');
+  }
+}

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -13,6 +13,7 @@ import '../controllers/putController';
 
 import '../controllers/methodController';
 import '../controllers/mediaTypeController';
+import '../controllers/requestExpressController';
 import '../controllers/parameterController';
 import '../controllers/securityController';
 import '../controllers/testController';

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -382,11 +382,11 @@ describe('Express Server', () => {
     return verifyGetRequest(
       basePath + '/MiddlewareHierarchyTestExpress/test1',
       (err, res) => {
-          const expected = ['base', 'intermediate', 'route', 'test1'];
-          expect(state()).to.eql(expected);
+        const expected = ['base', 'intermediate', 'route', 'test1'];
+        expect(state()).to.eql(expected);
       },
       204,
-    )
+    );
   });
 
   describe('Controller', () => {
@@ -495,6 +495,22 @@ describe('Express Server', () => {
           expect(res.type).to.eq('application/vnd.mycompany.myapp.v2+json');
         },
         202,
+      );
+    });
+
+    it('should return custom content-type based on "Accept" header', () => {
+      return verifyRequest(
+        (err, res) => {
+          const { body, type } = res;
+          expect(body.codename).to.eq('foo');
+          expect(type).to.eq('application/vnd.mycompany.myapp.v4+json');
+        },
+        request => {
+          return request.get(basePath + '/RequestAcceptHeaderTest/Multi/1').set({
+            Accept: 'application/vnd.mycompany.myapp.v4+json',
+          });
+        },
+        200,
       );
     });
   });

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -471,6 +471,14 @@ describe('Schema details generation', () => {
             expect(mediaTypeTestCustom).to.deep.eq(['application/problem+json', 'application/vnd.mycompany.myapp.v2+json']);
             expect(requestAcceptHeaderMulti).to.deep.eq(['application/problem+json', 'application/json', 'application/vnd.mycompany.myapp.v3+json', 'application/vnd.mycompany.myapp.v4+json']);
           });
+
+          it('Should generate custom media type of request body from method Consumes decorator', () => {
+            const { consumes: consumesDefault } = mediaTypeTest.paths['/MediaTypeTest/Default']?.post;
+            const { consumes: consumesCustom } = mediaTypeTest.paths['/MediaTypeTest/Custom']?.post;
+
+            expect(consumesDefault).to.deep.eq(['application/json']);
+            expect(consumesCustom).to.deep.eq(['application/vnd.mycompany.myapp.v2+json']);
+          });
         });
 
         it('Falls back to the first @Example<>', () => {

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -429,10 +429,14 @@ describe('Schema details generation', () => {
 
         describe('media types', () => {
           let mediaTypeTest;
+          let requestAcceptHeaderTest;
 
           before(() => {
             const metadata = new MetadataGenerator('./fixtures/controllers/mediaTypeController.ts').Generate();
             mediaTypeTest = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+            const requestAcceptHeaderMetadata = new MetadataGenerator('./fixtures/controllers/requestExpressController').Generate();
+            requestAcceptHeaderTest = new SpecGenerator2(requestAcceptHeaderMetadata, getDefaultExtendedOptions()).GetSpec();
           });
 
           it('Should use controller Produces decorator as a default media type', () => {
@@ -441,16 +445,31 @@ describe('Schema details generation', () => {
             expect(produces).to.deep.eq(['application/vnd.mycompany.myapp+json']);
           });
 
-          it('Should generate custom media type from method Produces decorator', () => {
-            const { produces } = mediaTypeTest.paths['/MediaTypeTest/Custom/security.txt']?.get;
+          it('Should be possible to define multiple media types on controller level', () => {
+            const { produces } = requestAcceptHeaderTest.paths['/RequestAcceptHeaderTest/Default/{userId}']?.get;
 
-            expect(produces).to.deep.eq(['text/plain']);
+            expect(produces).to.deep.eq(['application/vnd.mycompany.myapp+json', 'application/vnd.mycompany.myapp.v2+json']);
+          });
+
+          it('Should generate custom media type from method Produces decorator', () => {
+            const { produces: mediaTypeTestCustom } = mediaTypeTest.paths['/MediaTypeTest/Custom/security.txt']?.get;
+            const { produces: requestAcceptHeaderMulti } = requestAcceptHeaderTest.paths['/RequestAcceptHeaderTest/Multi/{userId}']?.get;
+
+            expect(mediaTypeTestCustom).to.deep.eq(['text/plain']);
+            expect(requestAcceptHeaderMulti).to.deep.eq([
+              'application/vnd.mycompany.myapp+json',
+              'application/vnd.mycompany.myapp.v2+json',
+              'application/vnd.mycompany.myapp.v3+json',
+              'application/vnd.mycompany.myapp.v4+json',
+            ]);
           });
 
           it('Should generate custom media types from method reponse decorators and Res decorator', () => {
-            const { produces } = mediaTypeTest.paths['/MediaTypeTest/Custom']?.post;
+            const { produces: mediaTypeTestCustom } = mediaTypeTest.paths['/MediaTypeTest/Custom']?.post;
+            const { produces: requestAcceptHeaderMulti } = requestAcceptHeaderTest.paths['/RequestAcceptHeaderTest/Multi']?.post;
 
-            expect(produces).to.deep.eq(['application/problem+json', 'application/vnd.mycompany.myapp.v2+json']);
+            expect(mediaTypeTestCustom).to.deep.eq(['application/problem+json', 'application/vnd.mycompany.myapp.v2+json']);
+            expect(requestAcceptHeaderMulti).to.deep.eq(['application/problem+json', 'application/json', 'application/vnd.mycompany.myapp.v3+json', 'application/vnd.mycompany.myapp.v4+json']);
           });
         });
 

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -740,6 +740,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             expect(mediaTypeConflict).to.eql('application/problem+json');
           });
+
+          it('Should generate custom media type of request body from method Consumes decorator', () => {
+            const [bodyMediaTypeDefault] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Default']?.post?.requestBody?.content);
+            const [bodyMediaTypeCustom] = Object.keys(mediaTypeTest.paths['/MediaTypeTest/Custom']?.post?.requestBody?.content);
+
+            expect(bodyMediaTypeDefault).to.eql('application/json');
+            expect(bodyMediaTypeCustom).to.eql('application/vnd.mycompany.myapp.v2+json');
+          });
         });
 
         it('Supports multiple examples', () => {


### PR DESCRIPTION
Changes:

1) extend commit 323f6776b0
From swagger media types specification: "Web service operations can
accept and return data in different formats, the most common being JSON,
XML and images. You specify the media type in request and response
definitions."

https://swagger.io/docs/specification/media-types/

Related #1126

2) problem description: currently `application/json` is hardcoded into
generated spec

proposed solution: allow specifying custom media type in generated spec
on method level by:
  - using new `@Consumes` decorator

impact:
  - cli: method generator
  - cli: spec2 generator
  - cli: spec3 generator
  - runtime: response decorators

Closes #968

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

1. described in detail in this comment: https://github.com/lukeautry/tsoa/pull/1140#issuecomment-974628592
 2. it is possible to define only one `@Consumes` per method


**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
unit & integration tests
