### PR TITLE
feat: Add support for js config file (closes #745)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,10 +47,12 @@ const authorInformation: Promise<
 
 const getConfig = async (configPath = 'tsoa.json'): Promise<Config> => {
   let config: Config;
+  const ext = path.extname(configPath);
   try {
-    const ext = path.extname(configPath);
     if (ext === '.yaml' || ext === '.yml') {
       config = YAML.load(configPath);
+    } else if (ext === '.js') {
+      config = await import(`${workingDir}/${configPath}`);
     } else {
       const configRaw = await fsReadFile(`${workingDir}/${configPath}`);
       config = JSON.parse(configRaw.toString('utf8'));
@@ -61,8 +63,9 @@ const getConfig = async (configPath = 'tsoa.json'): Promise<Config> => {
     } else if (err.name === 'SyntaxError') {
       // eslint-disable-next-line no-console
       console.error(err);
+      const errorType = ext === '.js' ? 'JS' : 'JSON';
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      throw Error(`Invalid JSON syntax in config at '${configPath}': ${err.message}`);
+      throw Error(`Invalid ${errorType} syntax in config at '${configPath}': ${err.message}`);
     } else {
       // eslint-disable-next-line no-console
       console.error(err);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #745

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

The issue was marked with `help wanted`.

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->
This is a very simple implementation, it doesn't support mjs or TypeScript configs. I'm not sure what the best way to add support for these would be – an option for TS is to use ts-node.

I'd be happy to add some tests checking that the config gets loaded correctly, but I'd need a pointer on where I should put the test to best fit in with the existing ones.

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
