### PR TITLE
Support multerOpts in tsoa.json

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -152,6 +152,7 @@ export interface ExtendedRoutesConfig extends RoutesConfig {
   entryFile: Config['entryFile'];
   noImplicitAdditionalProperties: Exclude<Config['noImplicitAdditionalProperties'], undefined>;
   controllerPathGlobs?: Config['controllerPathGlobs'];
+  multerOpts?: Config['multerOpts'];
 }
 
 const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfig> => {
@@ -182,6 +183,7 @@ const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfi
     entryFile: config.entryFile,
     noImplicitAdditionalProperties,
     controllerPathGlobs: config.controllerPathGlobs,
+    multerOpts: config.multerOpts,
   };
 };
 

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -122,6 +122,7 @@ export class RouteGenerator {
             }),
         ),
       ),
+      multerOpts: this.options.multerOpts,
       useSecurity: this.metadata.controllers.some(controller => controller.methods.some(method => !!method.security.length)),
     });
   }

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -19,7 +19,7 @@ import type { RequestHandler } from 'express';
 import * as express from 'express';
 {{#if useFileUploads}}
 const multer = require('multer');
-const upload = multer();
+const upload = multer({{{json multerOpts}}});
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -23,7 +23,7 @@ import type { Middleware } from 'koa';
 import * as KoaRouter from '@koa/router';
 {{#if useFileUploads}}
 const multer = require('@koa/multer');
-const upload = multer();
+const upload = multer({{{json multerOpts}}});
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -1,4 +1,5 @@
 import { Swagger } from './swagger/swagger';
+import { Options as MulterOpts } from 'multer';
 
 export interface Config {
   /**
@@ -38,6 +39,16 @@ export interface Config {
    * @memberof RoutesConfig
    */
   compilerOptions?: Record<string, unknown>;
+
+  /**
+   * Multer's options to generate multer's middleware.
+   * It doesn't support storage option
+   *
+   * @example {
+   *   "dest": "/tmp"
+   * } Allow multer to write to file instead of using Memory's buffer
+   */
+  multerOpts?: MulterOpts;
 }
 
 /**

--- a/packages/runtime/src/interfaces/file.ts
+++ b/packages/runtime/src/interfaces/file.ts
@@ -1,8 +1,32 @@
-export type File = {
+import { Readable } from 'stream';
+
+/** Object containing file metadata and access information. */
+export interface File {
+  /** Name of the form field associated with this file. */
   fieldname: string;
+  /** Name of the file on the uploader's computer. */
   originalname: string;
+  /**
+   * Value of the `Content-Transfer-Encoding` header for this file.
+   * @deprecated since July 2015
+   * @see RFC 7578, Section 4.7
+   */
   encoding: string;
+  /** Value of the `Content-Type` header for this file. */
   mimetype: string;
+  /** Size of the file in bytes. */
   size: number;
+  /**
+   * A readable stream of this file. Only available to the `_handleFile`
+   * callback for custom `StorageEngine`s.
+   */
+  stream: Readable;
+  /** `DiskStorage` only: Directory to which this file has been uploaded. */
+  destination: string;
+  /** `DiskStorage` only: Name of this file within `destination`. */
+  filename: string;
+  /** `DiskStorage` only: Full path to the uploaded file. */
+  path: string;
+  /** `MemoryStorage` only: A Buffer containing the entire file. */
   buffer: Buffer;
-};
+}

--- a/tests/fixtures/koa-multer-options/server.ts
+++ b/tests/fixtures/koa-multer-options/server.ts
@@ -1,0 +1,28 @@
+import * as Koa from 'koa';
+import * as KoaRouter from '@koa/router';
+
+import '../controllers/postController';
+
+import * as bodyParser from 'koa-bodyparser';
+import { RegisterRoutes } from './routes';
+
+const app = new Koa();
+app.use(bodyParser());
+
+const router = new KoaRouter();
+
+RegisterRoutes(router);
+
+// It's important that this come after the main routes are registered
+app.use(async (context, next) => {
+  try {
+    await next();
+  } catch (err) {
+    context.status = err.status || 500;
+    context.body = err.message || 'An error occurred during the request.';
+  }
+});
+
+app.use(router.routes()).use(router.allowedMethods());
+
+export const server = app.listen();

--- a/tests/integration/koa-multer-options.spec.ts
+++ b/tests/integration/koa-multer-options.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { server } from '../fixtures/koa-multer-options/server';
+import { resolve } from 'path';
+import * as os from 'os';
+
+const basePath = '/v1';
+
+describe('Koa Server (with multerOpts)', () => {
+  describe('file upload', () => {
+    it('can post a file', () => {
+      const formData = { someFile: '@../package.json' };
+      return verifyFileUploadRequest(basePath + '/PostTest/File', formData, (err, res) => {
+        expect(res.body).to.not.be.undefined;
+        expect(res.body.fieldname).to.equal('someFile');
+        expect(res.body.originalname).to.equal('package.json');
+        expect(res.body.encoding).to.be.not.undefined;
+        expect(res.body.mimetype).to.equal('application/json');
+        expect(res.body.path).to.satisfy(value => value.startsWith(os.tmpdir()));
+      });
+    });
+
+    function verifyFileUploadRequest(
+      path: string,
+      formData: any,
+      verifyResponse: (err: any, res: request.Response) => any = () => {
+        /**/
+      },
+      expectedStatus?: number,
+    ) {
+      return verifyRequest(
+        verifyResponse,
+        request =>
+          Object.keys(formData).reduce((req, key) => {
+            const values = [].concat(formData[key]);
+            values.forEach((v: any) => (v.startsWith('@') ? req.attach(key, resolve(__dirname, v.slice(1))) : req.field(key, v)));
+            return req;
+          }, request.post(path)),
+        expectedStatus,
+      );
+    }
+  });
+
+  it('shutdown server', () => server.close());
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(server))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import * as os from 'os';
 import chalk from 'chalk';
 import { generateSpecAndRoutes } from '@tsoa/cli/cli';
 import { generateRoutes } from '@tsoa/cli/module/generate-routes';
@@ -108,6 +109,19 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         entryFile: './fixtures/koa/server.ts',
         middleware: 'koa',
         routesDir: './fixtures/koa',
+      }),
+    ),
+
+    log('Koa Route Generation (with multerOpts)', () =>
+      generateRoutes({
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        basePath: '/v1',
+        entryFile: './fixtures/koa-multer-options/server.ts',
+        middleware: 'koa',
+        routesDir: './fixtures/koa-multer-options',
+        multerOpts: {
+          dest: os.tmpdir(),
+        },
       }),
     ),
     log('Koa Route Generation (but noImplicitAdditionalProperties is set to "throw-on-extras")', () =>


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1111

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

- We are unable to Include storage customization in multerOptions dues to it a custom javascript implementation instead of just a json in tsoa.json 
- We still have a single multer instance for all uploadFile, uploadFiles middleware. So we unable to support per controller options.

**Test plan**
We introduce a new koa's fixture test that only test the post file method + multerOpts to write file's request to os.tmpdir() folder.