### PR TITLE
fix(cli): support types indexed by their own keys

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -299,18 +299,16 @@ export class TypeResolver {
       }
     }
 
-    // Indexed by keyof typeof self
-    if (
-      ts.isIndexedAccessTypeNode(this.typeNode) &&
-      ts.isTypeOperatorNode(this.typeNode.indexType) &&
-      this.typeNode.indexType.operator === ts.SyntaxKind.KeyOfKeyword &&
-      ts.isTypeQueryNode(this.typeNode.objectType) &&
-      ts.isTypeQueryNode(this.typeNode.indexType.type) &&
-      this.typeNode.indexType.type.exprName.getText() === this.typeNode.objectType.exprName.getText()
-    ) {
-      const type = this.current.typeChecker.getTypeFromTypeNode(this.typeNode);
-      const node = this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias)!;
-      return new TypeResolver(node, this.current, this.typeNode, this.context, this.referencer).resolve();
+    // Indexed by keyof typeof value
+    if (ts.isIndexedAccessTypeNode(this.typeNode) && ts.isTypeOperatorNode(this.typeNode.indexType) && this.typeNode.indexType.operator === ts.SyntaxKind.KeyOfKeyword) {
+      const resolveParenthesis = (node: ts.TypeNode) => (ts.isParenthesizedTypeNode(node) ? node.type : node);
+      const objectType = resolveParenthesis(this.typeNode.objectType);
+      const indexType = this.typeNode.indexType.type;
+      if (ts.isTypeQueryNode(objectType) && ts.isTypeQueryNode(indexType) && objectType.exprName.getText() === indexType.exprName.getText()) {
+        const type = this.current.typeChecker.getTypeFromTypeNode(this.typeNode);
+        const node = this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias)!;
+        return new TypeResolver(node, this.current, this.typeNode, this.context, this.referencer).resolve();
+      }
     }
 
     if (ts.isTemplateLiteralTypeNode(this.typeNode)) {

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -2,7 +2,7 @@
 import { Readable } from 'stream';
 import { Controller, Example, Get, OperationId, Query, Request, Route, SuccessResponse, Tags, Res, TsoaResponse } from '@tsoa/runtime';
 import '../duplicateTestModel';
-import { GenericModel, GetterClass, GetterInterface, GetterInterfaceHerited, TestClassModel, TestModel, TestSubModel, SimpleClassWithToJSON } from '../testModel';
+import { GenericModel, GetterClass, GetterInterface, GetterInterfaceHerited, TestClassModel, TestModel, TestSubModel, SimpleClassWithToJSON, IndexedValue } from '../testModel';
 import { ModelService } from './../services/modelService';
 import TsoaTest from 'tsoaTest';
 
@@ -261,6 +261,11 @@ export class GetTestController extends Controller {
   @Get(EnumPaths.PathFromEnum)
   public async getPathFromEnumValue(): Promise<TestModel> {
     return new ModelService().getModel();
+  }
+
+  @Get('IndexedValue')
+  public async getIndexedValue(): Promise<IndexedValue> {
+    return 'FOO';
   }
 }
 

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -2,7 +2,18 @@
 import { Readable } from 'stream';
 import { Controller, Example, Get, OperationId, Query, Request, Route, SuccessResponse, Tags, Res, TsoaResponse } from '@tsoa/runtime';
 import '../duplicateTestModel';
-import { GenericModel, GetterClass, GetterInterface, GetterInterfaceHerited, TestClassModel, TestModel, TestSubModel, SimpleClassWithToJSON, IndexedValue } from '../testModel';
+import {
+  GenericModel,
+  GetterClass,
+  GetterInterface,
+  GetterInterfaceHerited,
+  TestClassModel,
+  TestModel,
+  TestSubModel,
+  SimpleClassWithToJSON,
+  IndexedValue,
+  ParenthesizedIndexedValue,
+} from '../testModel';
 import { ModelService } from './../services/modelService';
 import TsoaTest from 'tsoaTest';
 
@@ -265,6 +276,11 @@ export class GetTestController extends Controller {
 
   @Get('IndexedValue')
   public async getIndexedValue(): Promise<IndexedValue> {
+    return 'FOO';
+  }
+
+  @Get('ParenthesizedIndexedValue')
+  public async getParenthesizedIndexedValue(): Promise<ParenthesizedIndexedValue> {
     return 'FOO';
   }
 }

--- a/tests/fixtures/controllers/unsupportedIndexedTypeController.ts
+++ b/tests/fixtures/controllers/unsupportedIndexedTypeController.ts
@@ -1,0 +1,10 @@
+import { Get, Route } from '@tsoa/runtime';
+import { ForeignIndexedValue } from '../testModel';
+
+@Route('UnsupportedIndexedType')
+export class UnsupportedIndexedTypeController {
+  @Get('Value')
+  public async getValue(): Promise<ForeignIndexedValue> {
+    return 'FOO';
+  }
+}

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -243,6 +243,12 @@ export type IndexedValue = typeof indexedValue[keyof typeof indexedValue];
 // prettier-ignore
 export type ParenthesizedIndexedValue = (typeof indexedValue)[keyof typeof indexedValue];
 
+const otherIndexedValue = {
+  foo: 'fOO',
+} as const;
+
+export type ForeignIndexedValue = typeof indexedValue[keyof typeof otherIndexedValue];
+
 type Maybe<T> = T | null;
 
 export interface TypeAliasModel1 {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -72,6 +72,7 @@ export interface TestModel extends Model {
   unknownType?: unknown;
   genericTypeObject?: Generic<{ foo: string; bar: boolean }>;
   indexed?: Partial<Indexed['foo']>;
+  indexedValue?: IndexedValue;
   record?: Record<'record-foo' | 'record-bar', { data: string }>;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
@@ -230,6 +231,13 @@ interface Indexed {
     bar: string;
   };
 }
+
+const indexedValue = {
+  foo: 'FOO',
+  bar: 'BAR',
+} as const;
+
+export type IndexedValue = typeof indexedValue[keyof typeof indexedValue];
 
 type Maybe<T> = T | null;
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -73,6 +73,7 @@ export interface TestModel extends Model {
   genericTypeObject?: Generic<{ foo: string; bar: boolean }>;
   indexed?: Partial<Indexed['foo']>;
   indexedValue?: IndexedValue;
+  parenthesizedIndexedValue?: ParenthesizedIndexedValue;
   record?: Record<'record-foo' | 'record-bar', { data: string }>;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
@@ -238,6 +239,9 @@ const indexedValue = {
 } as const;
 
 export type IndexedValue = typeof indexedValue[keyof typeof indexedValue];
+
+// prettier-ignore
+export type ParenthesizedIndexedValue = (typeof indexedValue)[keyof typeof indexedValue];
 
 type Maybe<T> = T | null;
 

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -476,6 +476,9 @@ describe('Definition generation', () => {
           indexedValue: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/IndexedValue');
           },
+          parenthesizedIndexedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/ParenthesizedIndexedValue');
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Record_record-foo-or-record-bar._data-string__');
             const schema = getValidatedDefinition('Record_record-foo-or-record-bar._data-string__', currentSpec);

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -473,6 +473,9 @@ describe('Definition generation', () => {
           indexed: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Partial_Indexed-at-foo_');
           },
+          indexedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/IndexedValue');
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Record_record-foo-or-record-bar._data-string__');
             const schema = getValidatedDefinition('Record_record-foo-or-record-bar._data-string__', currentSpec);

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -200,6 +200,13 @@ describe('GET route generation', () => {
     }).to.throw(/^Unable to parse Header Type any.*/);
   });
 
+  it('should reject unsupported indexed types', () => {
+    expect(() => {
+      const invalidMetadata = new MetadataGenerator('./fixtures/controllers/unsupportedIndexedTypeController.ts').Generate();
+      new SpecGenerator2(invalidMetadata, getDefaultExtendedOptions()).GetSpec();
+    }).to.throw(/^Unknown type: IndexedAccessType.*/);
+  });
+
   it('should generate a path description from jsdoc comment', () => {
     const get = getValidatedGetOperation(baseRoute);
     if (!get.description) {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1254,6 +1254,18 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               format: undefined,
             });
           },
+          parenthesizedIndexedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/ParenthesizedIndexedValue');
+            const schema = getComponentSchema('ParenthesizedIndexedValue', currentSpec);
+            expect(schema).to.deep.eq({
+              type: 'string',
+              enum: ['FOO', 'BAR'],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            });
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Record_record-foo-or-record-bar._data-string__');
             const schema = getComponentSchema('Record_record-foo-or-record-bar._data-string__', currentSpec);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1242,6 +1242,18 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           indexed: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Partial_Indexed-at-foo_');
           },
+          indexedValue: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/IndexedValue');
+            const schema = getComponentSchema('IndexedValue', currentSpec);
+            expect(schema).to.deep.eq({
+              type: 'string',
+              enum: ['FOO', 'BAR'],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            });
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Record_record-foo-or-record-bar._data-string__');
             const schema = getComponentSchema('Record_record-foo-or-record-bar._data-string__', currentSpec);


### PR DESCRIPTION
This PR addresses #1122 to support types indexed by their own keys, as they are generated by [Prisma](https://prisma.io) when a model uses enums.

In contrast to the solution proposed in #862, this approach does not rely on the values to equal their keys.

*NOTE:* It only handles the case `(typeof exp)[keyof typeof exp]`, i.e. when both type queries refer to the same expression. So types like `(typeof foo)[keyof typeof bar]` or `Foo[keyof Bar]` are still unsupported and will result in an error just as before.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

