### PR TITLE
fix(resolver): Resolve `keyof` using the type checker

### DIFF
--- a/packages/cli/src/metadataGeneration/exceptions.ts
+++ b/packages/cli/src/metadataGeneration/exceptions.ts
@@ -10,6 +10,14 @@ export class GenerateMetadataError extends Error {
   }
 }
 
+export class GenerateMetaDataWarning {
+  constructor(private message: string, private node: Node | TypeNode, private onlyCurrent = false) {}
+
+  toString() {
+    return `Warning: ${this.message}\n${prettyLocationOfNode(this.node)}\n${prettyTroubleCause(this.node, this.onlyCurrent)}`;
+  }
+}
+
 export function prettyLocationOfNode(node: Node | TypeNode) {
   const sourceFile = node.getSourceFile();
   const token = node.getFirstToken() || node.parent.getFirstToken();

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { getJSDocComment, getJSDocComments, getJSDocTagNames, isExistJSDocTag } from './../utils/jsDocUtils';
 import { getDecorators, getNodeFirstDecoratorValue, isDecorator } from './../utils/decoratorUtils';
 import { getPropertyValidators } from './../utils/validatorUtils';
-import { GenerateMetadataError } from './exceptions';
+import { GenerateMetadataError, GenerateMetaDataWarning } from './exceptions';
 import { getInitializerValue } from './initializer-value';
 import { MetadataGenerator } from './metadataGenerator';
 import { Tsoa, assertNever } from '@tsoa/runtime';
@@ -246,32 +246,42 @@ export class TypeResolver {
     // keyof
     if (ts.isTypeOperatorNode(this.typeNode) && this.typeNode.operator === ts.SyntaxKind.KeyOfKeyword) {
       const type = this.current.typeChecker.getTypeFromTypeNode(this.typeNode);
-      try {
-        if (type.isUnionOrIntersection()) {
-          const literals = type.types.filter(t => t.isLiteral()).reduce((acc, t: ts.LiteralType) => [...acc, t.value.toString()], []);
-          return {
-            dataType: 'enum',
-            enums: literals,
-          };
-        } else if (type.isLiteral()) {
-          return {
-            dataType: 'enum',
-            enums: [type.value.toString()],
-          };
-        } else {
-          const warning = new GenerateMetadataError(
-            `Couldn't resolve keyof reliably, please check the resulting type carefully.
-            Reason: Type was not a literal or an array of literals.`,
-            this.typeNode,
-          );
 
-          console.warn(warning);
+      if (type.isUnion()) {
+        const literals = type.types.filter(t => t.isLiteral()).reduce((acc, t: ts.LiteralType) => [...acc, t.value.toString()], []);
+
+        // Warn on nonsense (`number`, `typeof Symbol.iterator`)
+        if (type.types.find(t => !t.isLiteral()) !== undefined) {
+          const problems = type.types.filter(t => !t.isLiteral()).map(t => this.current.typeChecker.typeToString(t));
+          console.warn(new GenerateMetaDataWarning(`Skipped non-literal type(s) ${problems.join(', ')}`, this.typeNode).toString());
         }
 
-        return new TypeResolver(this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context, this.referencer).resolve();
-      } catch (err) {
-        const indexedTypeName = this.current.typeChecker.typeToString(this.current.typeChecker.getTypeFromTypeNode(this.typeNode.type));
-        throw new GenerateMetadataError(`Could not determine the keys on ${indexedTypeName}`, this.typeNode);
+        return {
+          dataType: 'enum',
+          enums: literals,
+        };
+      } else if (type.isLiteral()) {
+        return {
+          dataType: 'enum',
+          enums: [type.value.toString()],
+        };
+      } else if ((type.getFlags() & ts.TypeFlags.Never) !== 0) {
+        throw new GenerateMetadataError(`TypeOperator 'keyof' on node produced a never type`, this.typeNode);
+      } else {
+        const warning = new GenerateMetaDataWarning(
+          `Couldn't resolve keyof reliably, please check the resulting type carefully.
+            Reason: Type was not a literal or an array of literals.`,
+          this.typeNode,
+        );
+
+        console.warn(warning.toString());
+
+        try {
+          return new TypeResolver(this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context, this.referencer).resolve();
+        } catch (err) {
+          const indexedTypeName = this.current.typeChecker.typeToString(this.current.typeChecker.getTypeFromTypeNode(this.typeNode.type));
+          throw new GenerateMetadataError(`Could not determine the keys on ${indexedTypeName}`, this.typeNode);
+        }
       }
     }
 

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -199,7 +199,14 @@ export interface TestModel extends Model {
    * @extension {"x-key-2": "value-2"}
    */
   extensionComment?: boolean;
+
+  keyofLiteral?: keyof Items;
 }
+
+type Items = {
+  type1: unknown;
+  type2: unknown;
+};
 
 /** @deprecated */
 interface DeprecatedType {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1424,6 +1424,20 @@ describe('Definition generation', () => {
               `for property ${propertyName}`,
             );
           },
+          keyofLiteral: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['type1', 'type2'],
+                default: undefined,
+                description: undefined,
+                format: undefined,
+                example: undefined,
+                'x-nullable': false,
+              },
+              `for property ${propertyName}`,
+            );
+          },
         };
 
         Object.keys(assertionsPerProperty).forEach(aPropertyName => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1854,6 +1854,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                     description: undefined,
                     enum: ['OK', 'KO'],
+                    nullable: false,
                     example: undefined,
                     format: undefined,
                     type: 'string',
@@ -2226,6 +2227,20 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 example: undefined,
                 'x-key-1': 'value-1',
                 'x-key-2': 'value-2',
+              },
+              `for property ${propertyName}`,
+            );
+          },
+          keyofLiteral: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['type1', 'type2'],
+                default: undefined,
+                description: undefined,
+                format: undefined,
+                nullable: false,
+                example: undefined,
               },
               `for property ${propertyName}`,
             );


### PR DESCRIPTION
The old approach was to transform the node into a type and back into a
node to construct a simplified version. However, that approach can break
down silently and without warning.

Now, we try to explicitly get string enums and warn if we are unable to
proceed.

Fixes #1162

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #1162 
