### PR TITLE
feat: Add support for labels on @Example decorator

### DIFF
--- a/packages/runtime/src/decorators/example.ts
+++ b/packages/runtime/src/decorators/example.ts
@@ -1,4 +1,4 @@
-export function Example<T>(exampleModel: T): Function {
+export function Example<T>(exampleModel: T, exampleLabel?: string): Function {
   return () => {
     return;
   };

--- a/tests/fixtures/controllers/exampleController.ts
+++ b/tests/fixtures/controllers/exampleController.ts
@@ -155,4 +155,26 @@ export class ExampleTestController {
   public async responseExamplesWithImportedValue(): Promise<string> {
     return 'test 1';
   }
+
+  /**
+   * @example res 123
+   * @example res 1
+   */
+  @Example<string>(exampleResponse, 'Custom_label')
+  @Get('ResponseExampleWithLabel')
+  public async responseExamplesWithLabel(): Promise<string> {
+    return 'test 1';
+  }
+
+  /**
+   * @example res 123
+   * @example res 1
+   */
+  @Example<string>(exampleResponse, 'OneExample')
+  @Example<string>('another example', 'AnotherExample')
+  @Example<string>('no label example')
+  @Get('ResponseMultiExampleWithLabel')
+  public async responseMultiExampleWithLabel(): Promise<string> {
+    return 'test 1';
+  }
 }

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -509,6 +509,22 @@ describe('Schema details generation', () => {
 
           expect(responses?.[200]?.examples?.['application/json']).to.eq('test example response');
         });
+
+        it('uses the correct imported value for the @Example<> with label', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+          const examples = exampleSpec.paths['/ExampleTest/ResponseExampleWithLabel']?.get?.responses?.[200]?.examples?.['application/json'];
+
+          expect(examples).to.deep.eq('test example response');
+        });
+
+        it('uses the correct imported value for multiple @Example<> with label', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+          const examples = exampleSpec.paths['/ExampleTest/ResponseMultiExampleWithLabel']?.get?.responses?.[200]?.examples?.['application/json'];
+
+          expect(examples).to.deep.eq('test example response');
+        });
       });
     });
   });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -802,6 +802,36 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             },
           });
         });
+
+        it('uses the correct imported value for the @Example<> with label', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+          const examples = exampleSpec.paths['/ExampleTest/ResponseExampleWithLabel']?.get?.responses?.[200]?.content?.['application/json'].examples;
+
+          expect(examples).to.deep.eq({
+            Custom_label: {
+              value: 'test example response',
+            },
+          });
+        });
+
+        it('uses the correct imported value for multiple @Example<> with label', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+          const examples = exampleSpec.paths['/ExampleTest/ResponseMultiExampleWithLabel']?.get?.responses?.[200]?.content?.['application/json'].examples;
+
+          expect(examples).to.deep.eq({
+            OneExample: {
+              value: 'test example response',
+            },
+            AnotherExample: {
+              value: 'another example',
+            },
+            'Example 1': {
+              value: 'no label example',
+            },
+          });
+        });
       });
 
       describe('deprecation', () => {


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? 
- [X] This PR is associated with an existing issue?

***Closing issues***
closes #1157 

### If this is a new feature submission:

- [X] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Users may use same label twice and library will not prevent it (pre-existing issue) which will generate an invalid OpenAPI 3.0 definition

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

It covers scenarios with examples with label and ensures pre-existing scenarios are supported.
No negative cases implemented as they are covered by typescript type checking

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
