### PR TITLE
Allow json form field

### DIFF
--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -224,11 +224,7 @@ export class ParameterGenerator {
 
   private getFormFieldParameter(parameter: ts.ParameterDeclaration): Tsoa.Parameter {
     const parameterName = (parameter.name as ts.Identifier).text;
-    const type: Tsoa.Type = { dataType: 'string' };
-
-    if (!this.supportPathDataType(type)) {
-      throw new GenerateMetadataError(`Parameter '${parameterName}:${type.dataType}' can't be passed as form field parameter in '${this.method.toUpperCase()}'.`, parameter);
-    }
+    const type = this.getValidatedType(parameter);
 
     return {
       description: this.getParameterDescription(parameter),

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -1,4 +1,5 @@
-import { Body, Patch, Post, Query, Route, File, UploadedFile, UploadedFiles, FormField } from '@tsoa/runtime';
+import { Body, Patch, Post, Query, Route, File, UploadedFile, UploadedFiles, FormField, Request } from '@tsoa/runtime';
+import { Request as ExpressRequest } from 'express';
 import { ModelService } from '../services/modelService';
 import { GenericRequest, TestClassModel, TestModel } from '../testModel';
 
@@ -65,6 +66,11 @@ export class PostTestController {
   @Post('ManyFilesAndFormFields')
   public async postWithFiles(@UploadedFiles('someFiles') files: File[], @FormField('a') a: string, @FormField('c') c: string): Promise<File[]> {
     return files;
+  }
+
+  @Post('FileAndJsonFormField')
+  public async postWithFileAndJsonFormField(@Request() req: ExpressRequest, @FormField('json') json: { property: string }): Promise<{ hasFile: boolean; json: { property: string } }> {
+    return { hasFile: !!req.file, json };
   }
 
   @Post('Location')

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -1,6 +1,7 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as methodOverride from 'method-override';
+import * as multer from 'multer';
 import '../controllers/rootController';
 
 import '../controllers/optionsController';
@@ -36,6 +37,13 @@ app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
+app.post('/v1/PostTest/FileAndJsonFormField', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  multer().single('file')(req, res, () => {
+    req.body.json = JSON.parse(req.body.json);
+    next();
+  });
+});
+
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -1,4 +1,5 @@
 import * as Koa from 'koa';
+import * as multer from '@koa/multer';
 import * as KoaRouter from '@koa/router';
 import '../controllers/rootController';
 
@@ -28,6 +29,13 @@ const app = new Koa();
 app.use(bodyParser());
 
 const router = new KoaRouter();
+
+router.post('/v1/PostTest/FileAndJsonFormField', async (ctx, next) => {
+  await multer().single('file')(ctx, () => {
+    ctx.request.body.json = JSON.parse(ctx.request.body.json);
+  });
+  await next();
+});
 
 RegisterRoutes(router);
 

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1419,6 +1419,18 @@ describe('Express Server', () => {
       });
     });
 
+    it('can post a file with a JSON form field', () => {
+      const formData = {
+        json: JSON.stringify({ property: 'value' }),
+        file: '@../package.json',
+      };
+
+      return verifyFileUploadRequest(basePath + '/PostTest/FileAndJsonFormField', formData, (err, res) => {
+        expect(res.body.hasFile).to.be.true;
+        expect(res.body.json).to.deep.equal({ property: 'value' });
+      });
+    });
+
     function verifyFileUploadRequest(
       path: string,
       formData: any,

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1297,6 +1297,18 @@ describe('Koa Server', () => {
       });
     });
 
+    it('can post a file with a JSON form field', () => {
+      const formData = {
+        json: JSON.stringify({ property: 'value' }),
+        file: '@../package.json',
+      };
+
+      return verifyFileUploadRequest(basePath + '/PostTest/FileAndJsonFormField', formData, (err, res) => {
+        expect(res.body.hasFile).to.be.true;
+        expect(res.body.json).to.deep.equal({ property: 'value' });
+      });
+    });
+
     function verifyFileUploadRequest(
       path: string,
       formData: any,


### PR DESCRIPTION
It seems to be a quite common use case to send JSON metadata in a form field when uploading a file.

The users will still have to parse the JSON themselves but TSOA will be flexible enough to validate it if necessary.

Fixes #1027

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests? **Except for HAPI framework, I don't know how to test it.**
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? **Normally not necessary, the open API validation being already tested.**
- [X] This PR is associated with an existing issue? #1027

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [X] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

The chosen approach is quite light so the implementation did not add any complex logic to TSOA.

The counterpart is that users will have to parse themselves JSON and they won't be able to use `@UploadedFile` and `@UploadedFiles` annotations.

Indeed, those annotations add a middleware to parse multipart data and so they will conflict with the middleware added by the users to parse JSON in multipart requests.

The good news is that users will still be able to retrieve uploaded file quite easily by using the request annotation.

**Test plan**

I added integration tests for express and koa frameworks to test that JSON form fields pass the OpenAPI validation.

I don't know how to implement the parsing middleware on hapi framework, help is welcome.