### PR TITLE
Do not use cjs require in generated routes if esm is true

### DIFF
--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -124,6 +124,7 @@ export class RouteGenerator {
       ),
       multerOpts: this.options.multerOpts,
       useSecurity: this.metadata.controllers.some(controller => controller.methods.some(method => !!method.security.length)),
+      esm: this.options.esm,
     });
   }
 

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -9,7 +9,11 @@ import { {{name}} } from '{{modulePath}}';
 {{#if authenticationModule}}
 import { expressAuthentication } from '{{authenticationModule}}';
 // @ts-ignore - no great way to install types from subpackage
+{{#if esm}}
+import * as promiseAny from 'promise.any';
+{{else}}
 const promiseAny = require('promise.any');
+{{/if}}
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -9,7 +9,11 @@ import { {{name}} } from '{{modulePath}}';
 {{#if authenticationModule}}
 import { hapiAuthentication } from '{{authenticationModule}}';
 // @ts-ignore - no great way to install types from subpackage
+{{#if esm}}
+import * as promiseAny from 'promise.any';
+{{else}}
 const promiseAny = require('promise.any');
+{{/if}}
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -13,7 +13,11 @@ import { {{name}} } from '{{modulePath}}';
 {{#if authenticationModule}}
 import { koaAuthentication } from '{{authenticationModule}}';
 // @ts-ignore - no great way to install types from subpackage
+{{#if esm}}
+import * as promiseAny from 'promise.any';
+{{else}}
 const promiseAny = require('promise.any');
+{{/if}}
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';

--- a/tests/esm/fixtures/controllers/securityController.ts
+++ b/tests/esm/fixtures/controllers/securityController.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Route, Security } from '@tsoa/runtime';
+import type { TestModel } from '../testModel.js';
+
+@Security('tsoa_auth')
+@Route('SecurityTest')
+export class SecurityController extends Controller {
+  @Get()
+  public async getHandler(): Promise<TestModel> {
+    return {
+      str: 'str',
+    };
+  }
+}

--- a/tests/esm/fixtures/express/authentication.ts
+++ b/tests/esm/fixtures/express/authentication.ts
@@ -1,0 +1,32 @@
+import * as express from 'express';
+
+export function expressAuthentication(req: express.Request, name: string, scopes?: string[]): Promise<any> {
+  if (name === 'api_key') {
+    let token;
+    if (req.query && req.query.access_token) {
+      token = req.query.access_token;
+    } else {
+      return Promise.reject({ message: 'api_key' });
+    }
+
+    if (token === 'abc123456') {
+      return Promise.resolve({
+        id: 1,
+        name: 'Ironman',
+      });
+    } else if (token === 'xyz123456') {
+      return Promise.resolve({
+        id: 2,
+        name: 'Thor',
+      });
+    } else {
+      return Promise.reject({ message: 'api_key' });
+    }
+  } else {
+    if (req.query && req.query.tsoa && req.query.tsoa === 'abc123456') {
+      return Promise.resolve({});
+    } else {
+      return Promise.reject({ message: 'other' });
+    }
+  }
+}

--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -3,6 +3,7 @@ import methodOverride from 'method-override';
 import bodyParser from 'body-parser';
 
 import './rootController.js';
+import '../controllers/securityController';
 
 import { RegisterRoutes } from './routes.js';
 

--- a/tests/esm/prepare.ts
+++ b/tests/esm/prepare.ts
@@ -33,6 +33,7 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         entryFile: './esm/fixtures/express/server.ts',
         middleware: 'express',
         routesDir: './esm/fixtures/express',
+        authenticationModule: './esm/fixtures/express/authentication.ts',
         esm: true,
       },
       undefined,

--- a/tests/esm/tsoa.json
+++ b/tests/esm/tsoa.json
@@ -5,12 +5,30 @@
     "outputDirectory": "./dist",
     "host": "localhost:3000",
     "basePath": "/v1",
+    "securityDefinitions": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "access_token",
+        "in": "query"
+      },
+      "tsoa_auth": {
+        "type": "oauth2",
+        "authorizationUrl": "http://swagger.io/api/oauth/dialog",
+        "flow": "implicit",
+        "scopes": {
+          "write:pets": "modify things",
+          "read:pets": "read things"
+        }
+      }
+    },
     "yaml": true,
     "specVersion": 2
   },
   "routes": {
     "basePath": "/v1",
     "routesDir": "./fixtures/express",
-    "middleware": "express"
+    "middleware": "express",
+    "authenticationModule": "./fixtures/express/authentication.ts",
+    "esm": true
   }
 }


### PR DESCRIPTION
### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #1176

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->
N/A

**Test plan**
<!-- explain why the unit tests that you added are demonstrating that the feature works -->

I updated the related configuration + added a basic controller fixture that utilizes the `Security` decorator under `tests/esm/fixture`. Basically just brought it a bit closer in line with the existing fixtures.

*Note*:
 I did not 'flesh out' the esm security controller fixture. I only added the bare minimum items needed to generate auth related blocks in the routes. I believe it would be redundant to do so with the existing tests, but please let me know if that isn't the case.

If you checkout [`c3c49cd` (#1177)](https://github.com/lukeautry/tsoa/pull/1177/commits/c3c49cdd4ee405425109971aecfd111aa91b0ec3), you will have the updated tests/esm configuration w/o the fix. Running the tests at this point will give you the traceback detailed in #1176.
