### PR TITLE
fix(cli): Don't truncate synthetic type nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "clean": "lerna run clean --stream",
     "prepare": "yarn build",
     "preversion": "yarn test",
-    "pretest": "lerna run pretest --stream",
     "test": "lerna run test --stream",
     "lint": "eslint . --ext .ts",
     "lint:fix": "yarn run lint --fix",

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -305,7 +305,7 @@ export class TypeResolver {
       if (type === undefined) {
         throw new GenerateMetadataError(`Could not determine ${numberIndexType ? 'number' : 'string'} index on ${this.current.typeChecker.typeToString(objectType)}`, this.typeNode);
       }
-      return new TypeResolver(this.current.typeChecker.typeToTypeNode(type, undefined, undefined)!, this.current, this.typeNode, this.context, this.referencer).resolve();
+      return new TypeResolver(this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context, this.referencer).resolve();
     }
 
     // Indexed by literal
@@ -327,11 +327,11 @@ export class TypeResolver {
       }
       const declaration = this.current.typeChecker.getTypeOfSymbolAtLocation(symbol, this.typeNode.objectType);
       try {
-        return new TypeResolver(this.current.typeChecker.typeToTypeNode(declaration, undefined, undefined)!, this.current, this.typeNode, this.context, this.referencer).resolve();
+        return new TypeResolver(this.current.typeChecker.typeToTypeNode(declaration, undefined, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context, this.referencer).resolve();
       } catch {
         throw new GenerateMetadataError(
           `Could not determine the keys on ${this.current.typeChecker.typeToString(
-            this.current.typeChecker.getTypeFromTypeNode(this.current.typeChecker.typeToTypeNode(declaration, undefined, undefined)!),
+            this.current.typeChecker.getTypeFromTypeNode(this.current.typeChecker.typeToTypeNode(declaration, undefined, ts.NodeBuilderFlags.NoTruncation)!),
           )}`,
           this.typeNode,
         );
@@ -345,7 +345,7 @@ export class TypeResolver {
       const indexType = this.typeNode.indexType.type;
       if (ts.isTypeQueryNode(objectType) && ts.isTypeQueryNode(indexType) && objectType.exprName.getText() === indexType.exprName.getText()) {
         const type = this.current.typeChecker.getTypeFromTypeNode(this.typeNode);
-        const node = this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias)!;
+        const node = this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias | ts.NodeBuilderFlags.NoTruncation)!;
         return new TypeResolver(node, this.current, this.typeNode, this.context, this.referencer).resolve();
       }
     }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Closing issues**

closes #1185 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This approach will likely still fail eventually afaik as there are limits in the type checker (for good reason).

**Test plan**

- Add a sufficiently large indexed access that produces a union that previously failed.
- Check that it now produces the correct output
- This will remain a draft until tests demonstrate a change in behavior

@rossille can you verify that this is working for you?