### PR TITLE
Implement `operationIdTemplate` config parameter.

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -121,6 +121,9 @@ export const validateSpecConfig = async (config: Config): Promise<ExtendedSpecCo
   config.spec.description = config.spec.description || (await descriptionDefault());
   config.spec.license = config.spec.license || (await licenseDefault());
   config.spec.basePath = config.spec.basePath || '/';
+  // defaults to template that may generate non-unique operation ids.
+  // @see https://github.com/lukeautry/tsoa/issues/1005
+  config.spec.operationIdTemplate = config.spec.operationIdTemplate || '{{titleCase method.name}}';
 
   if (!config.spec.contact) {
     config.spec.contact = {};

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -230,7 +230,7 @@ export class SpecGenerator2 extends SpecGenerator {
     }
 
     const operation: Swagger.Operation = {
-      operationId: this.getOperationId(method.name),
+      operationId: this.getOperationId(controllerName, method),
       produces: produces as string[],
       responses: swaggerResponses,
     };
@@ -276,7 +276,7 @@ export class SpecGenerator2 extends SpecGenerator {
       name: 'body',
       schema: {
         properties,
-        title: `${this.getOperationId(method.name)}Body`,
+        title: `${this.getOperationId(controllerName, method)}Body`,
         type: 'object',
       },
     } as Swagger.Parameter;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -367,7 +367,7 @@ export class SpecGenerator3 extends SpecGenerator {
     });
 
     const operation: Swagger.Operation3 = {
-      operationId: this.getOperationId(method.name),
+      operationId: this.getOperationId(controllerName, method),
       responses: swaggerResponses,
     };
 

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -150,6 +150,17 @@ export interface SpecConfig {
   specMerging?: 'immediate' | 'recursive' | 'deepmerge';
 
   /**
+   * Template string for generating operation ids.
+   * This should be a valid handlebars template and is provided
+   * with the following context:
+   *   - 'controllerName' - String name of controller class.
+   *   - 'method' - Tsoa.Method object.
+   *
+   * @default '{{titleCase method.name}}'
+   */
+  operationIdTemplate?: string;
+
+  /**
    * Security Definitions Object
    * A declaration of the security schemes available to be used in the
    * specification. This does not enforce the security schemes on the operations

--- a/tests/fixtures/defaultOptions.ts
+++ b/tests/fixtures/defaultOptions.ts
@@ -18,6 +18,7 @@ export function getDefaultOptions(outputDirectory = '', entryFile = ''): Config 
         name: 'Jane Doe',
         url: 'www.jane-doe.com',
       },
+      operationIdTemplate: '{{titleCase method.name}}',
       outputDirectory,
       securityDefinitions: {
         basic: {

--- a/tests/unit/swagger/config.spec.ts
+++ b/tests/unit/swagger/config.spec.ts
@@ -93,5 +93,14 @@ describe('Configuration', () => {
         done();
       });
     });
+
+    it('should set the default spec operationIdTemplate when not specified', done => {
+      const config: Config = getDefaultOptions('some/output/directory', 'tsoa.json');
+      delete config.spec.operationIdTemplate;
+      validateSpecConfig(config).then((configResult: ExtendedSpecConfig) => {
+        expect(configResult.operationIdTemplate).to.equal('{{titleCase method.name}}');
+        done();
+      });
+    });
   });
 });

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -303,6 +303,26 @@ describe('Schema details generation', () => {
     });
 
     describe('methods', () => {
+      describe('operationId', () => {
+        const optionsWithOperationIdTemplate = Object.assign<{}, ExtendedSpecConfig, Partial<ExtendedSpecConfig>>({}, getDefaultExtendedOptions(), {
+          operationIdTemplate: "{{replace controllerName 'Controller' ''}}_{{titleCase method.name}}",
+        });
+
+        // for backwards compatibility.
+        it('should default to title-cased method name.', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+          const operationId = exampleSpec.paths['/ExampleTest/post_body']?.post?.operationId;
+          expect(operationId).to.eq('Post');
+        });
+        it('should utilize operationIdTemplate if set.', () => {
+          const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+          const exampleSpec = new SpecGenerator2(metadata, optionsWithOperationIdTemplate).GetSpec();
+          const operationId = exampleSpec.paths['/ExampleTest/post_body']?.post?.operationId;
+          expect(operationId).to.eq('ExampleTest_Post');
+        });
+      });
+
       describe('responses', () => {
         describe('should generate headers from method reponse decorator.', () => {
           const metadata = new MetadataGenerator('./fixtures/controllers/responseHeaderController.ts').Generate();


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes #1005


**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

I personally ran into issues stemming from #1005 (namely, OAS3 client code-gen tools) and just applied a quick n' dirty patch (w/ patch-package) as a temporary workaround for a while.
However, after seeing the recent rc0 tag and realizing I would have to go update the patch (:disappointed: ), figured I would just go ahead and push up what I had though would be a good solution to the issue.

I thought it would make the most sense to expose a config parameter to the end user that would allow for defining a simple handlebars template for generating operation ids.

In a nutshell:

 - Solves #1005
 - Avoids "forcing" a different naming scheme that (while maybe solving the problem for most) causes other issues.
 - Provides the most flexibility while still keeping the config as simple as possible.
 - By using the current naming scheme as the default template, its a **non-breaking** change (:tada:).
 - Currently, just the controller name and method are exposed to the handlebars template (which I believe is all anyone would really need?).



**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
Additional tests have been added for the oas2/3 unit test suites for the default/current behavior and 'customized' behavior.
