### PR TITLE
fix(cli): indexed types by their own keys when using TypeReferences

### DIFF
--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -12,7 +12,10 @@ import {
   TestSubModel,
   SimpleClassWithToJSON,
   IndexedValue,
+  IndexedValueReference,
   ParenthesizedIndexedValue,
+  IndexedValueGeneric,
+  IndexedValueTypeReference,
 } from '../testModel';
 import { ModelService } from './../services/modelService';
 import TsoaTest from 'tsoaTest';
@@ -285,6 +288,16 @@ export class GetTestController extends Controller {
 
   @Get('ParenthesizedIndexedValue')
   public async getParenthesizedIndexedValue(): Promise<ParenthesizedIndexedValue> {
+    return 'FOO';
+  }
+
+  @Get('IndexedValueReference')
+  public async getIndexedValueReference(): Promise<IndexedValueReference> {
+    return 'FOO';
+  }
+
+  @Get('IndexedValueGeneric')
+  public async getIndexedValueGeneric(): Promise<IndexedValueGeneric<IndexedValueTypeReference>> {
     return 'FOO';
   }
 }

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -76,6 +76,8 @@ export interface TestModel extends Model {
   indexed?: Partial<Indexed['foo']>;
   indexedValue?: IndexedValue;
   parenthesizedIndexedValue?: ParenthesizedIndexedValue;
+  indexedValueReference?: IndexedValueReference;
+  indexedValueGeneric?: IndexedValueGeneric<IndexedValueTypeReference>;
   record?: Record<'record-foo' | 'record-bar', { data: string }>;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
@@ -246,11 +248,16 @@ const indexedValue = {
   foo: 'FOO',
   bar: 'BAR',
 } as const;
+export type IndexedValueTypeReference = typeof indexedValue;
 
 export type IndexedValue = typeof indexedValue[keyof typeof indexedValue];
 
 // prettier-ignore
 export type ParenthesizedIndexedValue = (typeof indexedValue)[keyof typeof indexedValue];
+
+export type IndexedValueReference = IndexedValueTypeReference[keyof IndexedValueTypeReference];
+
+export type IndexedValueGeneric<Value> = Value[keyof Value];
 
 const otherIndexedValue = {
   foo: 'fOO',

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -494,6 +494,12 @@ describe('Definition generation', () => {
           parenthesizedIndexedValue: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/ParenthesizedIndexedValue');
           },
+          indexedValueReference: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/IndexedValueReference');
+          },
+          indexedValueGeneric: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/IndexedValueGeneric_IndexedValueTypeReference_');
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Record_record-foo-or-record-bar._data-string__');
             const schema = getValidatedDefinition('Record_record-foo-or-record-bar._data-string__', currentSpec);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1338,6 +1338,30 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               format: undefined,
             });
           },
+          indexedValueReference: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/IndexedValueReference');
+            const schema = getComponentSchema('IndexedValueReference', currentSpec);
+            expect(schema).to.deep.eq({
+              type: 'string',
+              enum: ['FOO', 'BAR'],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            });
+          },
+          indexedValueGeneric: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/IndexedValueGeneric_IndexedValueTypeReference_');
+            const schema = getComponentSchema('IndexedValueGeneric_IndexedValueTypeReference_', currentSpec);
+            expect(schema).to.deep.eq({
+              type: 'string',
+              enum: ['FOO', 'BAR'],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            });
+          },
           record: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Record_record-foo-or-record-bar._data-string__');
             const schema = getComponentSchema('Record_record-foo-or-record-bar._data-string__', currentSpec);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? - I guess it's not applicable. No Idea how to find a negative case here
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1220


**Test plan**

I looked at the tests for the core feature and just added Reference and Generic usage.

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
