### PR TITLE
Add support for `termsOfService` Spec field

### DIFF
--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -38,6 +38,9 @@ export class SpecGenerator2 extends SpecGenerator {
     if (this.config.description) {
       spec.info.description = this.config.description;
     }
+    if (this.config.termsOfService) {
+      spec.info.termsOfService = this.config.termsOfService;
+    }
     if (this.config.tags) {
       spec.tags = this.config.tags;
     }

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -54,6 +54,9 @@ export class SpecGenerator3 extends SpecGenerator {
     if (this.config.description) {
       info.description = this.config.description;
     }
+    if (this.config.termsOfService) {
+      info.termsOfService = this.config.termsOfService;
+    }
     if (this.config.license) {
       info.license = { name: this.config.license };
     }

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -99,6 +99,12 @@ export interface SpecConfig {
   description?: string;
 
   /**
+   * Link to the page that describes the terms of service.
+   * Must be in the URL format.
+   */
+  termsOfService?: string;
+
+  /**
    * Contact Information
    */
   contact?: {

--- a/tests/fixtures/defaultOptions.ts
+++ b/tests/fixtures/defaultOptions.ts
@@ -10,6 +10,7 @@ export function getDefaultOptions(outputDirectory = '', entryFile = ''): Config 
     spec: {
       basePath: '/v1',
       description: 'Description of a test API',
+      termsOfService: 'https://example.com/terms/',
       host: 'localhost:3000',
       license: 'MIT',
       name: 'Test API',

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -23,6 +23,9 @@ describe('Schema details generation', () => {
   if (!spec.info.description) {
     throw new Error('No spec info description.');
   }
+  if (!spec.info.termsOfService) {
+    throw new Error('No spec info termsOfService.');
+  }
   if (!spec.info.version) {
     throw new Error('No spec info version.');
   }
@@ -35,6 +38,9 @@ describe('Schema details generation', () => {
   });
   it('should set API description if provided', () => {
     expect(spec.info.description).to.equal(getDefaultExtendedOptions().description);
+  });
+  it('should set API termsOfService if provided', () => {
+    expect(spec.info.termsOfService).to.equal(getDefaultExtendedOptions().termsOfService);
   });
   it('should set API version if provided', () => {
     expect(spec.info.version).to.equal(getDefaultExtendedOptions().version);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -103,6 +103,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(specDefault.spec.info).to.deep.equal({
         title: 'Test API',
         description: 'Description of a test API',
+        termsOfService: 'https://example.com/terms/',
         contact: { email: 'jane@doe.com', name: 'Jane Doe', url: 'www.jane-doe.com' },
         license: { name: 'MIT' },
         version: '1.0.0',


### PR DESCRIPTION
At this moment `tsoa` don't adds `termsOfService` Spec info to the outputting `swagger.json`
This pull request add support for it.