### PR TITLE
feat(cli): Add labels to parameter examples

### DIFF
--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -132,11 +132,12 @@ export class ParameterGenerator {
     if (!this.supportBodyMethod(this.method)) {
       throw new GenerateMetadataError(`@BodyProp('${parameterName}') Can't support in ${this.method.toUpperCase()} method.`);
     }
-
+    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
     return {
       default: getInitializerValue(parameter.initializer, this.current.typeChecker, type),
       description: this.getParameterDescription(parameter),
-      example: this.getParameterExample(parameter, parameterName).examples,
+      example,
+      exampleLabels,
       in: 'body-prop',
       name: getNodeFirstDecoratorValue(this.parameter, this.current.typeChecker, ident => ident.text === 'BodyProp') || parameterName,
       parameterName,
@@ -155,11 +156,14 @@ export class ParameterGenerator {
       throw new GenerateMetadataError(`@Body('${parameterName}') Can't support in ${this.method.toUpperCase()} method.`);
     }
 
+    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
+
     return {
       description: this.getParameterDescription(parameter),
       in: 'body',
       name: parameterName,
-      example: this.getParameterExample(parameter, parameterName).examples,
+      example,
+      exampleLabels,
       parameterName,
       required: !parameter.questionToken && !parameter.initializer,
       type,
@@ -176,10 +180,13 @@ export class ParameterGenerator {
       throw new GenerateMetadataError(`@Header('${parameterName}') Can't support '${type.dataType}' type.`);
     }
 
+    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
+
     return {
       default: getInitializerValue(parameter.initializer, this.current.typeChecker, type),
       description: this.getParameterDescription(parameter),
-      example: this.getParameterExample(parameter, parameterName).examples,
+      example,
+      exampleLabels,
       in: 'header',
       name: getNodeFirstDecoratorValue(this.parameter, this.current.typeChecker, ident => ident.text === 'Header') || parameterName,
       parameterName,
@@ -246,10 +253,13 @@ export class ParameterGenerator {
     const parameterName = (parameter.name as ts.Identifier).text;
     const type = this.getValidatedType(parameter);
 
+    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
+
     const commonProperties = {
       default: getInitializerValue(parameter.initializer, this.current.typeChecker, type),
       description: this.getParameterDescription(parameter),
-      example: this.getParameterExample(parameter, parameterName).examples,
+      example,
+      exampleLabels,
       in: 'query' as const,
       name: getNodeFirstDecoratorValue(this.parameter, this.current.typeChecker, ident => ident.text === 'Query') || parameterName,
       parameterName,
@@ -303,11 +313,12 @@ export class ParameterGenerator {
     if (!this.path.includes(`{${pathName}}`) && !this.path.includes(`:${pathName}`)) {
       throw new GenerateMetadataError(`@Path('${parameterName}') Can't match in URL: '${this.path}'.`);
     }
-    const { examples } = this.getParameterExample(parameter, parameterName);
+    const { examples, exampleLabels } = this.getParameterExample(parameter, parameterName);
     return {
       default: getInitializerValue(parameter.initializer, this.current.typeChecker, type),
       description: this.getParameterDescription(parameter),
       example: examples,
+      exampleLabels,
       in: 'path',
       name: pathName,
       parameterName,

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -436,17 +436,17 @@ export class SpecGenerator3 extends SpecGenerator {
     };
 
     const parameterExamples = parameter.example;
+    const parameterExampleLabels = parameter.exampleLabels;
     if (parameterExamples === undefined) {
       mediaType.example = parameterExamples;
     } else if (parameterExamples.length === 1) {
       mediaType.example = parameterExamples[0];
     } else {
-      mediaType.examples = {};
-      parameterExamples.forEach((example, index) =>
-        Object.assign(mediaType.examples, {
-          [`Example ${index + 1}`]: { value: example } as Swagger.Example3,
-        }),
-      );
+      let exampleCounter = 1;
+      mediaType.examples = parameterExamples.reduce<Swagger.Example['examples']>((acc, ex, currentIndex) => {
+        const exampleLabel = parameterExampleLabels?.[currentIndex];
+        return { ...acc, [exampleLabel === undefined ? `Example ${exampleCounter++}` : exampleLabel]: { value: ex } };
+      }, {});
     }
 
     return mediaType;
@@ -499,17 +499,17 @@ export class SpecGenerator3 extends SpecGenerator {
     parameter.schema = Object.assign({}, parameter.schema, validatorObjs);
 
     const parameterExamples = source.example;
+    const parameterExampleLabels = source.exampleLabels;
     if (parameterExamples === undefined) {
       parameter.example = parameterExamples;
     } else if (parameterExamples.length === 1) {
       parameter.example = parameterExamples[0];
     } else {
-      parameter.examples = {};
-      parameterExamples.forEach((example, index) =>
-        Object.assign(parameter.examples, {
-          [`Example ${index + 1}`]: { value: example } as Swagger.Example3,
-        }),
-      );
+      let exampleCounter = 1;
+      parameter.examples = parameterExamples.reduce<Swagger.Example['examples']>((acc, ex, currentIndex) => {
+        const exampleLabel = parameterExampleLabels?.[currentIndex];
+        return { ...acc, [exampleLabel === undefined ? `Example ${exampleCounter++}` : exampleLabel]: { value: ex } };
+      }, {});
     }
 
     return parameter;

--- a/tests/fixtures/controllers/exampleController.ts
+++ b/tests/fixtures/controllers/exampleController.ts
@@ -147,6 +147,19 @@ export class ExampleTestController {
   }
 
   /**
+   * @example requestBody.CustomLabel "CustomLabel"
+   * @example requestBody. "No Custom Label"
+   * @example requestBody "Unlabeled 1"
+   * @example requestBody "Another unlabeled one"
+   * @example requestBody.CustomLabel2 "CustomLabel2"
+   * @example requestBody "Unlabeled 2"
+   */
+  @Post('CustomBodyExampleLabels')
+  public async customBodyExampleLabels(@Body() requestBody: string): Promise<string> {
+    return 'test custom body labels';
+  }
+
+  /**
    * @example res 123
    * @example res 1
    */

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -364,6 +364,26 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
         });
       });
     });
+
+    it('Supports custom example labels', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
+      const exampleSpec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const examples = exampleSpec.paths['/ExampleTest/CustomBodyExampleLabels']?.post?.requestBody!.content!['application/json'].examples;
+
+      expect(examples).to.deep.eq({
+        '': {
+          value: 'No Custom Label',
+        },
+        CustomLabel: { value: 'CustomLabel' },
+        CustomLabel2: { value: 'CustomLabel2' },
+        'Example 1': { value: 'Unlabeled 1' },
+        'Example 2': { value: 'Another unlabeled one' },
+        'Example 3': {
+          value: 'Unlabeled 2',
+        },
+      });
+    });
   });
 
   describe('paths', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

`closes #1232`

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
Uses the same code / test format as example response labels but just adds the support to parameters
