### PR TITLE
feat: add title to interface to inline requestBody and responses

### DIFF
--- a/packages/cli/src/swagger/specGenerator.ts
+++ b/packages/cli/src/swagger/specGenerator.ts
@@ -112,7 +112,7 @@ export abstract class SpecGenerator {
     // An empty list required: [] is not valid.
     // If all properties are optional, do not specify the required keyword.
     return {
-      title,
+      ...(title && { title }),
       properties,
       ...(additionalProperties && { additionalProperties }),
       ...(required && required.length && { required }),

--- a/packages/cli/src/swagger/specGenerator.ts
+++ b/packages/cli/src/swagger/specGenerator.ts
@@ -59,7 +59,7 @@ export abstract class SpecGenerator {
     }
   }
 
-  protected getSwaggerType(type: Tsoa.Type): Swagger.Schema | Swagger.BaseSchema {
+  protected getSwaggerType(type: Tsoa.Type, title?: string): Swagger.Schema | Swagger.BaseSchema {
     if (type.dataType === 'void' || type.dataType === 'undefined') {
       return this.getSwaggerTypeForVoid(type.dataType);
     } else if (type.dataType === 'refEnum' || type.dataType === 'refObject' || type.dataType === 'refAlias') {
@@ -82,27 +82,27 @@ export abstract class SpecGenerator {
     ) {
       return this.getSwaggerTypeForPrimitiveType(type.dataType);
     } else if (type.dataType === 'array') {
-      return this.getSwaggerTypeForArrayType(type);
+      return this.getSwaggerTypeForArrayType(type, title);
     } else if (type.dataType === 'enum') {
-      return this.getSwaggerTypeForEnumType(type);
+      return this.getSwaggerTypeForEnumType(type, title);
     } else if (type.dataType === 'union') {
-      return this.getSwaggerTypeForUnionType(type);
+      return this.getSwaggerTypeForUnionType(type, title);
     } else if (type.dataType === 'intersection') {
-      return this.getSwaggerTypeForIntersectionType(type);
+      return this.getSwaggerTypeForIntersectionType(type, title);
     } else if (type.dataType === 'nestedObjectLiteral') {
-      return this.getSwaggerTypeForObjectLiteral(type);
+      return this.getSwaggerTypeForObjectLiteral(type, title);
     } else {
       return assertNever(type);
     }
   }
 
-  protected abstract getSwaggerTypeForUnionType(type: Tsoa.UnionType);
+  protected abstract getSwaggerTypeForUnionType(type: Tsoa.UnionType, title?: string);
 
-  protected abstract getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType);
+  protected abstract getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType, title?: string);
 
   protected abstract buildProperties(properties: Tsoa.Property[]): { [propertyName: string]: Swagger.Schema | Swagger.Schema3 };
 
-  public getSwaggerTypeForObjectLiteral(objectLiteral: Tsoa.NestedObjectLiteralType): Swagger.Schema {
+  public getSwaggerTypeForObjectLiteral(objectLiteral: Tsoa.NestedObjectLiteralType, title?: string): Swagger.Schema {
     const properties = this.buildProperties(objectLiteral.properties);
 
     const additionalProperties = objectLiteral.additionalProperties && this.getSwaggerType(objectLiteral.additionalProperties);
@@ -112,6 +112,7 @@ export abstract class SpecGenerator {
     // An empty list required: [] is not valid.
     // If all properties are optional, do not specify the required keyword.
     return {
+      title,
       properties,
       ...(additionalProperties && { additionalProperties }),
       ...(required && required.length && { required }),
@@ -187,9 +188,9 @@ export abstract class SpecGenerator {
     return map[dataType];
   }
 
-  protected getSwaggerTypeForArrayType(arrayType: Tsoa.ArrayType): Swagger.Schema {
+  protected getSwaggerTypeForArrayType(arrayType: Tsoa.ArrayType, title?: string): Swagger.Schema {
     return {
-      items: this.getSwaggerType(arrayType.elementType),
+      items: this.getSwaggerType(arrayType.elementType, title),
       type: 'array',
     };
   }
@@ -204,7 +205,7 @@ export abstract class SpecGenerator {
     return typesUsedInEnum;
   }
 
-  protected abstract getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema2 | Swagger.Schema3;
+  protected abstract getSwaggerTypeForEnumType(enumType: Tsoa.EnumType, title?: string): Swagger.Schema2 | Swagger.Schema3;
 
   protected hasUndefined(property: Tsoa.Property): boolean {
     return property.type.dataType === 'undefined' || (property.type.dataType === 'union' && property.type.types.some(type => type.dataType === 'undefined'));

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -640,21 +640,21 @@ export class SpecGenerator3 extends SpecGenerator {
         if (swaggerType.$ref) {
           return { allOf: [swaggerType], nullable };
         }
-        return { title, ...swaggerType, nullable };
+        return { ...(title && { title }), ...swaggerType, nullable };
       } else {
-        return { title, anyOf: actualSwaggerTypes, nullable };
+        return { ...(title && { title }), anyOf: actualSwaggerTypes, nullable };
       }
     } else {
       if (actualSwaggerTypes.length === 1) {
-        return { title, ...actualSwaggerTypes[0] };
+        return { ...(title && { title }), ...actualSwaggerTypes[0] };
       } else {
-        return { title, anyOf: actualSwaggerTypes };
+        return { ...(title && { title }), anyOf: actualSwaggerTypes };
       }
     }
   }
 
   protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType, title?: string) {
-    return { allOf: type.types.map(x => this.getSwaggerType(x)), title };
+    return { allOf: type.types.map(x => this.getSwaggerType(x)), ...(title && { title }) };
   }
 
   protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType, title?: string): Swagger.Schema3 {
@@ -663,7 +663,7 @@ export class SpecGenerator3 extends SpecGenerator {
     if (types.size === 1) {
       const type = types.values().next().value;
       const nullable = enumType.enums.includes(null) ? true : false;
-      return { title, type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
+      return { ...(title && { title }), type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
     } else {
       const valuesDelimited = Array.from(types).join(',');
       throw new Error(`Enums can only have string or number values, but enum had ${valuesDelimited}`);

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -331,7 +331,7 @@ export class SpecGenerator3 extends SpecGenerator {
           swaggerResponses[res.name].content = {
             ...content,
             [p]: {
-              schema: this.getSwaggerType(res.schema),
+              schema: this.getSwaggerType(res.schema, this.getOperationId(controllerName, method) + 'Response'),
             } as Swagger.Schema3,
           };
         }
@@ -433,7 +433,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     const mediaType: Swagger.MediaType = {
       schema: {
-        ...this.getSwaggerType(parameter.type),
+        ...this.getSwaggerType(parameter.type, this.getOperationId(controllerName, method) + 'RequestBody'),
         ...validators,
       },
     };
@@ -619,7 +619,7 @@ export class SpecGenerator3 extends SpecGenerator {
     }
   }
 
-  protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
+  protected getSwaggerTypeForUnionType(type: Tsoa.UnionType, title?: string) {
     // Filter out nulls and undefineds
     const actualSwaggerTypes = this.removeDuplicateSwaggerTypes(
       this.groupEnums(
@@ -640,30 +640,30 @@ export class SpecGenerator3 extends SpecGenerator {
         if (swaggerType.$ref) {
           return { allOf: [swaggerType], nullable };
         }
-        return { ...swaggerType, nullable };
+        return { title, ...swaggerType, nullable };
       } else {
-        return { anyOf: actualSwaggerTypes, nullable };
+        return { title, anyOf: actualSwaggerTypes, nullable };
       }
     } else {
       if (actualSwaggerTypes.length === 1) {
-        return actualSwaggerTypes[0];
+        return { title, ...actualSwaggerTypes[0] };
       } else {
-        return { anyOf: actualSwaggerTypes };
+        return { title, anyOf: actualSwaggerTypes };
       }
     }
   }
 
-  protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType) {
-    return { allOf: type.types.map(x => this.getSwaggerType(x)) };
+  protected getSwaggerTypeForIntersectionType(type: Tsoa.IntersectionType, title?: string) {
+    return { allOf: type.types.map(x => this.getSwaggerType(x)), title };
   }
 
-  protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType): Swagger.Schema3 {
+  protected getSwaggerTypeForEnumType(enumType: Tsoa.EnumType, title?: string): Swagger.Schema3 {
     const types = this.determineTypesUsedInEnum(enumType.enums);
 
     if (types.size === 1) {
       const type = types.values().next().value;
       const nullable = enumType.enums.includes(null) ? true : false;
-      return { type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
+      return { title, type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
     } else {
       const valuesDelimited = Array.from(types).join(',');
       throw new Error(`Enums can only have string or number values, but enum had ${valuesDelimited}`);

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -331,7 +331,7 @@ export class SpecGenerator3 extends SpecGenerator {
           swaggerResponses[res.name].content = {
             ...content,
             [p]: {
-              schema: this.getSwaggerType(res.schema, this.getOperationId(controllerName, method) + 'Response'),
+              schema: this.getSwaggerType(res.schema, this.config.useTitleTagsForInlineObjects ? this.getOperationId(controllerName, method) + 'Response' : undefined),
             } as Swagger.Schema3,
           };
         }
@@ -433,7 +433,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     const mediaType: Swagger.MediaType = {
       schema: {
-        ...this.getSwaggerType(parameter.type, this.getOperationId(controllerName, method) + 'RequestBody'),
+        ...this.getSwaggerType(parameter.type, this.config.useTitleTagsForInlineObjects ? this.getOperationId(controllerName, method) + 'RequestBody' : undefined),
         ...validators,
       },
     };

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -190,6 +190,12 @@ export interface SpecConfig {
    * @default false
    */
   xEnumVarnames?: boolean;
+
+  /**
+   * Sets a title for inline objects for responses and requestBodies
+   * This helps to generate more consistent clients
+   */
+  useTitleTagsForInlineObjects?: boolean;
 }
 
 export interface RoutesConfig {

--- a/packages/runtime/src/swagger/swagger.ts
+++ b/packages/runtime/src/swagger/swagger.ts
@@ -217,7 +217,7 @@ export namespace Swagger {
 
   export interface Response3 {
     description: string;
-    content?: { [name: string]: Schema & Example };
+    content?: { [name: string]: Schema3 & { schema?: Schema } & Example };
     headers?: { [name: string]: Header3 };
   }
 

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -334,7 +334,7 @@ export class ParameterController {
     //
   }
 
-  @Post('Inline1}')
+  @Post('Inline1')
   public async inline1(@Body() body: { requestString: string; requestNumber: number }): Promise<{ resultString: string; responseNumber: number }> {
     return { resultString: 'a', responseNumber: 1 };
   }

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -333,4 +333,9 @@ export class ParameterController {
   ): Promise<void> {
     //
   }
+
+  @Post('Inline1}')
+  public async inline1(@Body() body: { requestString: string; requestNumber: number }): Promise<{ resultString: string; responseNumber: number }> {
+    return { resultString: 'a', responseNumber: 1 };
+  }
 }

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2547,7 +2547,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
   describe('module declarations with namespaces', () => {
     it('should generate the proper schema for a model declared in a namespace in a module', () => {
       /* tslint:disable:no-string-literal */
-      const ref = specDefault.spec.paths['/GetTest/ModuleRedeclarationAndNamespace'].get?.responses['200'].content?.['application/json']['schema']['$ref'];
+      const ref = specDefault.spec.paths['/GetTest/ModuleRedeclarationAndNamespace'].get?.responses['200'].content?.['application/json']['schema']?.['$ref'];
       /* tslint:enable:no-string-literal */
       expect(ref).to.equal('#/components/schemas/TsoaTest.TestModel73');
       expect(getComponentSchema('TsoaTest.TestModel73', specDefault)).to.deep.equal({
@@ -2603,6 +2603,22 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
       expectTestModelContent(responses?.['400']);
       expectTestModelContent(responses?.['500']);
+    });
+  });
+
+  describe('inline title tag generation', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+
+    it('should generate title tag for request', () => {
+      const currentSpec = new SpecGenerator3(metadata, { ...getDefaultExtendedOptions(), useTitleTagsForInlineObjects: true }).GetSpec();
+      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal('Inline1Response');
+      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.requestBody?.content['application/json'].schema?.title).to.equal('Inline1RequestBody');
+    });
+
+    it('should not generate title tag for request', () => {
+      const currentSpec = new SpecGenerator3(metadata, { ...getDefaultExtendedOptions(), useTitleTagsForInlineObjects: false }).GetSpec();
+      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal(undefined);
+      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
     });
   });
 });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2611,14 +2611,14 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
     it('should generate title tag for request', () => {
       const currentSpec = new SpecGenerator3(metadata, { ...getDefaultExtendedOptions(), useTitleTagsForInlineObjects: true }).GetSpec();
-      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal('Inline1Response');
-      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.requestBody?.content['application/json'].schema?.title).to.equal('Inline1RequestBody');
+      expect(currentSpec.paths['/ParameterTest/Inline1'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal('Inline1Response');
+      expect(currentSpec.paths['/ParameterTest/Inline1'].post?.requestBody?.content['application/json'].schema?.title).to.equal('Inline1RequestBody');
     });
 
     it('should not generate title tag for request', () => {
       const currentSpec = new SpecGenerator3(metadata, { ...getDefaultExtendedOptions(), useTitleTagsForInlineObjects: false }).GetSpec();
-      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal(undefined);
-      expect(currentSpec.paths['/ParameterTest/Inline1}'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
+      expect(currentSpec.paths['/ParameterTest/Inline1'].post?.responses['200'].content?.['application/json'].schema?.title).to.equal(undefined);
+      expect(currentSpec.paths['/ParameterTest/Inline1'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1243

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

This feature allows more consistent client generation as the body and response objects where without a name before and therefore client genreation lead to "inline objects" naming without a qualified name.

before: 
![image](https://user-images.githubusercontent.com/5757263/165069052-a74fe345-feb2-4413-8097-f457f2f9e0e0.png)
after: 
![image](https://user-images.githubusercontent.com/5757263/165069128-b7fe4a43-e8dd-4e67-b495-64ccfc177fb9.png)


**Potential Problems With The Approach**

as this is an additional optional field, I think there are no potential problems

