### PR TITLE
Allow a single body param to included in the schema

### DIFF
--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -284,7 +284,7 @@ export class SpecGenerator3 extends SpecGenerator {
       throw new Error('Either body parameter or form parameters allowed per controller method - not both.');
     }
 
-    if (bodyPropParams.length > 1) {
+    if (bodyPropParams.length > 0) {
       if (!bodyParams.length) {
         bodyParams.push({
           in: 'body',

--- a/tests/fixtures/controllers/exampleController.ts
+++ b/tests/fixtures/controllers/exampleController.ts
@@ -57,6 +57,14 @@ export class ExampleTestController {
   }
 
   /**
+   * @example prop1 "prop1"
+   */
+  @Post('/post_body_prop_single')
+  public async postBodyPropSingle(@BodyProp() prop1: string): Promise<void> {
+    return;
+  }
+
+  /**
    * @example prop1 "prop1_1"
    * @example prop1 "prop1_2"
    * @example prop1 "prop1_3"

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -302,7 +302,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
         });
       });
 
-      it('@BodyProp parameter in Post method', () => {
+      it('Single @BodyProp parameters in Post method', () => {
+        const postBodyParams = exampleSpec.paths['/ExampleTest/post_body_prop_single'].post?.requestBody?.content?.['application/json'];
+        expect(postBodyParams?.schema?.required).to.have.lengthOf(1);
+        expect(postBodyParams?.schema?.properties).to.have.property('prop1');
+      });
+
+      it('Two @BodyProp parameters in Post method', () => {
         const postBodyParams = exampleSpec.paths['/ExampleTest/post_body_prop'].post?.requestBody?.content?.['application/json'];
         expect(postBodyParams?.schema?.required).to.have.lengthOf(2);
         expect(postBodyParams?.schema?.properties).to.have.property('prop1');


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1287 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**
None.

**Test plan**

Added in a new test that validates that a single body property can be processed. Test correctly failed prior to the code being corrected. 
Corrected code in packages/cli/src/swagger/specGenerator3.ts so that a single property is processed. 
Re-ran tests all tests passed.
