### PR TITLE
fix: typescript 4.8 support and improve test suite

### DIFF
--- a/.github/workflows/runTestsOnPush.yml
+++ b/.github/workflows/runTestsOnPush.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [12, 14, 16, 18]
         os: [macos-latest, ubuntu-latest, windows-latest]
         typescript-version: [4.6, 4.8]
 

--- a/.github/workflows/runTestsOnPush.yml
+++ b/.github/workflows/runTestsOnPush.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         node-version: [12, 14, 16, 17]
         os: [macos-latest, ubuntu-latest, windows-latest]
+        typescript-version: [4.6, 4.8]
 
     steps:
       - uses: actions/checkout@master
@@ -21,8 +22,23 @@ jobs:
       - name: Install Yarn
         run: npm install -g yarn
 
+      - name: Set resolutions to correct typescript version
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: package.json
+          field: resolutions
+          value: "{ \"typescript\": \"${{ matrix.typescript-version }}\"}"
+          parse_json: true
+
+      # for yarn3
+      # - name: Set Typescript version
+      #  run: yarn set resolution typescript ${{ matrix.typescript-version }}
+
       - name: Install
         run: yarn install --ignore-scripts
+
+      - name: Output ts version
+        run: npx tsc --version
 
       - name: Build
         run: yarn run build

--- a/.github/workflows/runTestsOnPush.yml
+++ b/.github/workflows/runTestsOnPush.yml
@@ -35,10 +35,10 @@ jobs:
       #  run: yarn set resolution typescript ${{ matrix.typescript-version }}
 
       - name: Install
-        run: yarn install --ignore-scripts
+        run: yarn install --ignore-scripts --no-lockfile
 
       - name: Output ts version
-        run: npx tsc --version
+        run: yarn tsc --version
 
       - name: Build
         run: yarn run build

--- a/packages/cli/src/utils/decoratorUtils.ts
+++ b/packages/cli/src/utils/decoratorUtils.ts
@@ -1,8 +1,17 @@
 import * as ts from 'typescript';
 import { getInitializerValue } from '../metadataGeneration/initializer-value';
 
+function tsHasDecorators(ts): ts is {
+  canHaveDecorators(node: ts.Node): node is any;
+  getDecorators(node: ts.Node): readonly ts.Decorator[] | undefined;
+} {
+  return typeof ts.canHaveDecorators === 'function';
+}
+
 export function getDecorators(node: ts.Node, isMatching: (identifier: ts.Identifier) => boolean) {
-  const decorators = node.decorators;
+  // beginning in ts4.8 node.decorator is undefined, use getDecorators instead.
+  const decorators = tsHasDecorators(ts) && ts.canHaveDecorators(node) ? ts.getDecorators(node) : node.decorators;
+
   if (!decorators || !decorators.length) {
     return [];
   }

--- a/packages/runtime/src/decorators/middlewares.ts
+++ b/packages/runtime/src/decorators/middlewares.ts
@@ -34,7 +34,7 @@ function decorator(fn: (value: any) => void) {
  * @param middlewares
  * @returns
  */
-export function Middlewares<T>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
+export function Middlewares<T extends Function | Object>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
   return decorator(target => {
     if (mws) {
       const current = fetchMiddlewares<T>(target);
@@ -49,6 +49,6 @@ export function Middlewares<T>(...mws: Array<Middleware<T>>): ClassDecorator & M
  * @param target
  * @returns list of middlewares
  */
-export function fetchMiddlewares<T>(target: any): Array<Middleware<T>> {
+export function fetchMiddlewares<T extends Function | Object>(target: any): Array<Middleware<T>> {
   return Reflect.getMetadata(TSOA_MIDDLEWARES, target) || [];
 }


### PR DESCRIPTION
this is an initial implementation for ts 4.8 support, but still WIP, 
there are some tests failing, maybe @WoH knows more about this?

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1300 
and probablay closes #1301


**Test plan**

unit tests are now running with typescirpt 4.6 and 4.8. I tested it with other version too, but there are some changes that require at least typescript 4.5 in the codebase. We could add this information somewhere that at least typescript 4.5 is required?