### PR TITLE
Add entryFile as command line argument

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -210,6 +210,12 @@ const basePathArgs = {
   string: true,
 } as const;
 
+const entryFileArgs = {
+  describe: 'Entry file path',
+  required: false,
+  string: true,
+} as const;
+
 const yarmlArgs = {
   describe: 'Swagger spec yaml format',
   required: false,
@@ -224,6 +230,7 @@ const jsonArgs = {
 
 export interface ConfigArgs {
   basePath?: string;
+  entryFile?: string;
   configuration?: string | Config;
 }
 
@@ -241,6 +248,7 @@ export function runCLI() {
       'Generate OpenAPI spec',
       {
         basePath: basePathArgs,
+        entryFile: entryFileArgs,
         configuration: configurationArgs,
         host: hostArgs,
         json: jsonArgs,
@@ -253,6 +261,7 @@ export function runCLI() {
       'Generate routes',
       {
         basePath: basePathArgs,
+        entryFile: entryFileArgs,
         configuration: configurationArgs,
       },
       args => routeGenerator(args),
@@ -262,6 +271,7 @@ export function runCLI() {
       'Generate OpenAPI spec and routes',
       {
         basePath: basePathArgs,
+        entryFile: entryFileArgs,
         configuration: configurationArgs,
         host: hostArgs,
         json: jsonArgs,
@@ -282,6 +292,9 @@ async function SpecGenerator(args: SwaggerArgs) {
     const config = await resolveConfig(args.configuration);
     if (args.basePath) {
       config.spec.basePath = args.basePath;
+    }
+    if (args.entryFile) {
+      config.entryFile = args.entryFile;
     }
     if (args.host) {
       config.spec.host = args.host;
@@ -310,6 +323,9 @@ async function routeGenerator(args: ConfigArgs) {
     if (args.basePath) {
       config.routes.basePath = args.basePath;
     }
+    if (args.entryFile) {
+      config.entryFile = args.entryFile;
+    }
 
     const compilerOptions = validateCompilerOptions(config.compilerOptions);
     const routesConfig = await validateRoutesConfig(config);
@@ -327,6 +343,9 @@ export async function generateSpecAndRoutes(args: SwaggerArgs, metadata?: Tsoa.M
     const config = await resolveConfig(args.configuration);
     if (args.basePath) {
       config.spec.basePath = args.basePath;
+    }
+    if (args.entryFile) {
+      config.entryFile = args.entryFile;
     }
     if (args.host) {
       config.spec.host = args.host;


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

Adding the entryFile as an argument in the cli will allow for a monorepos to build different deployments based on the imported controllers for that service.

```
tsoa spec-and-routes --entryFile src/entrypoints/userService.ts
tsoa spec-and-routes --entryFile src/entrypoints/cartService.ts
tsoa spec-and-routes --entryFile src/entrypoints/checkoutService.ts
```