### PR TITLE
Add root security option

### DIFF
--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -14,7 +14,13 @@ export class MetadataGenerator {
   private referenceTypeMap: Tsoa.ReferenceTypeMap = {};
   private circularDependencyResolvers = new Array<(referenceTypes: Tsoa.ReferenceTypeMap) => void>();
 
-  constructor(entryFile: string, private readonly compilerOptions?: ts.CompilerOptions, private readonly ignorePaths?: string[], controllers?: string[]) {
+  constructor(
+    entryFile: string,
+    private readonly compilerOptions?: ts.CompilerOptions,
+    private readonly ignorePaths?: string[],
+    controllers?: string[],
+    private readonly rootSecurity: Tsoa.Security[] = [],
+  ) {
     TypeResolver.clearCache();
     this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers) : ts.createProgram([entryFile], compilerOptions || {});
     this.typeChecker = this.program.getTypeChecker();
@@ -224,7 +230,7 @@ export class MetadataGenerator {
       throw new Error('no controllers found, check tsoa configuration');
     }
     return this.controllerNodes
-      .map(classDeclaration => new ControllerGenerator(classDeclaration, this))
+      .map(classDeclaration => new ControllerGenerator(classDeclaration, this, this.rootSecurity))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
   }

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -17,7 +17,7 @@ export const generateRoutes = async (
   metadata?: Tsoa.Metadata,
 ) => {
   if (!metadata) {
-    metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, ignorePaths, routesConfig.controllerPathGlobs).Generate();
+    metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, ignorePaths, routesConfig.controllerPathGlobs, routesConfig.rootSecurity).Generate();
   }
 
   const routeGenerator = new RouteGenerator(metadata, routesConfig);

--- a/packages/cli/src/module/generate-spec.ts
+++ b/packages/cli/src/module/generate-spec.ts
@@ -24,7 +24,7 @@ export const generateSpec = async (
   metadata?: Tsoa.Metadata,
 ) => {
   if (!metadata) {
-    metadata = new MetadataGenerator(swaggerConfig.entryFile, compilerOptions, ignorePaths, swaggerConfig.controllerPathGlobs).Generate();
+    metadata = new MetadataGenerator(swaggerConfig.entryFile, compilerOptions, ignorePaths, swaggerConfig.controllerPathGlobs, swaggerConfig.rootSecurity).Generate();
   }
 
   let spec: Swagger.Spec;

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -170,7 +170,7 @@ export class SpecGenerator2 extends SpecGenerator {
     }
 
     if (method.security) {
-      pathMethod.security = method.security as any[];
+      pathMethod.security = method.security;
     }
 
     pathMethod.parameters = method.parameters

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -86,8 +86,8 @@ export class SpecGenerator3 extends SpecGenerator {
     return components;
   }
 
-  private translateSecurityDefinitions(definitions: { [name: string]: Swagger.Security }) {
-    const defs: { [name: string]: Swagger.Security } = {};
+  private translateSecurityDefinitions(definitions: { [name: string]: Swagger.SecuritySchemes }) {
+    const defs: { [name: string]: Swagger.SecuritySchemes } = {};
     Object.keys(definitions).forEach(key => {
       if (definitions[key].type === 'basic') {
         defs[key] = {
@@ -263,7 +263,7 @@ export class SpecGenerator3 extends SpecGenerator {
     }
 
     if (method.security) {
-      pathMethod.security = method.security as any[];
+      pathMethod.security = method.security;
     }
 
     const bodyParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'body');

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -173,7 +173,7 @@ export interface SpecConfig {
    * and only serves to provide the relevant details for each scheme.
    */
   securityDefinitions?: {
-    [name: string]: Swagger.Security;
+    [name: string]: Swagger.SecuritySchemes;
   };
 
   /**
@@ -196,6 +196,12 @@ export interface SpecConfig {
    * This helps to generate more consistent clients
    */
   useTitleTagsForInlineObjects?: boolean;
+
+  /**
+   * Applies a default security to the entire API.
+   * Can be overridden with @Security or @NoSecurity decorators on controllers or methods
+   */
+  rootSecurity?: Swagger.Security[];
 }
 
 export interface RoutesConfig {

--- a/packages/runtime/src/swagger/swagger.ts
+++ b/packages/runtime/src/swagger/swagger.ts
@@ -26,7 +26,7 @@ export namespace Swagger {
     parameters?: { [name: string]: Parameter };
     responses?: { [name: string]: Response };
     security?: Security[];
-    securityDefinitions?: { [name: string]: Security };
+    securityDefinitions?: { [name: string]: SecuritySchemes };
   }
 
   export interface Spec3 extends Spec {
@@ -45,7 +45,7 @@ export namespace Swagger {
     requestBodies?: { [name: string]: unknown };
     responses?: { [name: string]: Response };
     schemas?: { [name: string]: Schema3 };
-    securitySchemes?: { [name: string]: Security };
+    securitySchemes?: { [name: string]: SecuritySchemes };
   }
 
   export interface Server {
@@ -385,5 +385,8 @@ export namespace Swagger {
     [flowName in OAuth2FlowTypes]?: OAuth2SecurityFlow3;
   };
   export type OAuth2FlowTypes = 'authorizationCode' | 'implicit' | 'password' | 'clientCredentials';
-  export type Security = BasicSecurity | BasicSecurity3 | ApiKeySecurity | OAuth2AccessCodeSecurity | OAuth2ApplicationSecurity | OAuth2ImplicitSecurity | OAuth2PasswordSecurity | OAuth2Security3;
+  export type SecuritySchemes = BasicSecurity | BasicSecurity3 | ApiKeySecurity | OAuth2AccessCodeSecurity | OAuth2ApplicationSecurity | OAuth2ImplicitSecurity | OAuth2PasswordSecurity | OAuth2Security3;
+  export interface Security {
+    [key: string]: string[];
+  }
 }

--- a/tests/fixtures/controllers/noSecurityOnController.ts
+++ b/tests/fixtures/controllers/noSecurityOnController.ts
@@ -1,0 +1,30 @@
+import { Get, Request, Response, Route, Security, NoSecurity } from '@tsoa/runtime';
+import { ErrorResponseModel, UserResponseModel } from '../testModel';
+
+interface RequestWithUser {
+  user?: any;
+}
+
+@NoSecurity()
+@Route('NoSecurity')
+export class NoSecurityOnController {
+  @Response<ErrorResponseModel>('default', 'Unexpected error')
+  @Security('api_key')
+  @Get()
+  public async GetWithApi(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Get('UndefinedSecurity')
+  public async GetWithImplicitSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+
+  @Response<ErrorResponseModel>('404', 'Not Found')
+  @Get('NoSecurity')
+  @NoSecurity()
+  public async GetWithNoSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
+    return Promise.resolve(request.user);
+  }
+}

--- a/tests/fixtures/controllers/noSecurityOnController.ts
+++ b/tests/fixtures/controllers/noSecurityOnController.ts
@@ -15,15 +15,13 @@ export class NoSecurityOnController {
     return Promise.resolve(request.user);
   }
 
-  @Response<ErrorResponseModel>('404', 'Not Found')
   @Get('UndefinedSecurity')
   public async GetWithImplicitSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
-    return Promise.resolve(request.user);
+    return Promise.resolve({ id: 1, name: "static" });
   }
 
-  @Response<ErrorResponseModel>('404', 'Not Found')
-  @Get('NoSecurity')
   @NoSecurity()
+  @Get('NoSecurity')
   public async GetWithNoSecurity(@Request() request: RequestWithUser): Promise<UserResponseModel> {
     return Promise.resolve(request.user);
   }

--- a/tests/fixtures/express-root-security/server.ts
+++ b/tests/fixtures/express-root-security/server.ts
@@ -1,0 +1,25 @@
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import '../controllers/noSecurityOnController';
+import '../controllers/pathlessGetController';
+
+import { RegisterRoutes } from './routes';
+
+export const app: express.Express = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+RegisterRoutes(app);
+
+// It's important that this come after the main routes are registered
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const status = err.status || 500;
+  const body: any = {
+    fields: err.fields || undefined,
+    message: err.message || 'An error occurred during the request.',
+    name: err.name,
+    status,
+  };
+  res.status(status).json(body);
+});
+
+app.listen();

--- a/tests/integration/express-server-root-security.spec.ts
+++ b/tests/integration/express-server-root-security.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as request from 'supertest';
+import { app } from '../fixtures/express-root-security/server';
+import { TestModel, UserResponseModel } from '../fixtures/testModel';
+
+const basePath = '/v1';
+
+describe('Express Server with api_key Root Security', () => {
+  describe('Controller with undefined security', () => {
+    const emptyHandler = (_err: unknown, _res: unknown) => {
+      // This is an empty handler
+    };
+
+    it('returns a model if the correct API key is given', () => {
+      return verifyGetRequest(basePath + '/Current?access_token=abc123456', (_err, res) => {
+        const model = res.body as TestModel;
+        expect(model.id).to.equal(1);
+      });
+    });
+
+    it('returns 401 for an invalid key', () => {
+      return verifyGetRequest(basePath + '/Current?access_token=invalid', emptyHandler, 401);
+    });
+  });
+
+  describe('Controller with @NoSecurity', () => {
+    const emptyHandler = (_err: unknown, _res: unknown) => {
+      // This is an empty handler
+    };
+
+    it('returns a model without auth for a request with undefined method security', () => {
+      return verifyGetRequest(basePath + '/NoSecurity/UndefinedSecurity', (_err, res) => {
+        const model = res.body as UserResponseModel;
+        expect(model.id).to.equal(1);
+      });
+    });
+
+    describe('method with @Security(api_key)', () => {
+      it('returns 401 for an invalid key', () => {
+        return verifyGetRequest(basePath + '/NoSecurity?access_token=invalid', emptyHandler, 401);
+      });
+      
+      it('returns a model with a valid key', () => {
+        return verifyGetRequest(basePath + '/NoSecurity?access_token=abc123456', (_err, res) => {
+          const model = res.body as UserResponseModel;
+          expect(model.id).to.equal(1);
+        });
+      });
+    });
+  });
+
+  function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
+    return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
+  }
+
+  function verifyRequest(verifyResponse: (err: any, res: request.Response) => any, methodOperation: (request: request.SuperTest<any>) => request.Test, expectedStatus = 200) {
+    return new Promise<void>((resolve, reject) => {
+      methodOperation(request(app))
+        .expect(expectedStatus)
+        .end((err: any, res: any) => {
+          let parsedError: any;
+          try {
+            parsedError = JSON.parse(res.error);
+          } catch (err) {
+            parsedError = res?.error;
+          }
+
+          if (err) {
+            reject({
+              error: err,
+              response: parsedError,
+            });
+            return;
+          }
+
+          verifyResponse(parsedError, res);
+          resolve();
+        });
+    });
+  }
+});

--- a/tests/prepare.ts
+++ b/tests/prepare.ts
@@ -85,6 +85,21 @@ const log = async <T>(label: string, fn: () => Promise<T>) => {
         metadata,
       ),
     ),
+    log('Express Route Generation, rootSecurity', () =>
+      generateRoutes(
+        {
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          authenticationModule: './fixtures/express/authentication.ts',
+          basePath: '/v1',
+          entryFile: './fixtures/express-root-security/server.ts',
+          middleware: 'express',
+          routesDir: './fixtures/express-root-security',
+          rootSecurity: [
+            { api_key: [], },
+          ],
+        },
+      ),
+    ),
     log('Koa Route Generation', () =>
       generateRoutes({
         noImplicitAdditionalProperties: 'silently-remove-extras',

--- a/tests/unit/swagger/pathGeneration/rootSecurityRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/rootSecurityRoutes.spec.ts
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+import 'mocha';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
+import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
+import { VerifyPath } from '../../utilities/verifyPath';
+import type { Swagger } from '@tsoa/runtime';
+
+describe('Security route generation with root security', () => {
+  describe('with @Security() on controller', () => {
+    const noSecurityControllerMetadata = new MetadataGenerator(
+      './fixtures/controllers/noSecurityController.ts',
+      undefined,
+      undefined,
+      undefined, [{
+        root_level_auth: []
+    }]).Generate();
+    const noSecuritySpec = new SpecGenerator2(noSecurityControllerMetadata, getDefaultExtendedOptions()).GetSpec();
+
+    it('should use the method level security over root/controller security', () => {
+      const path = verifyPath(noSecuritySpec, '/NoSecurityTest');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([{ api_key: [] }]);
+    });
+
+    it('should generate a route with no security if method has @NoSecurity()', () => {
+      const path = verifyPath(noSecuritySpec, '/NoSecurityTest/Anonymous');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([]);
+    });
+
+    it('should use controller level security if nothing specified on method', () => {
+      const path = verifyPath(noSecuritySpec, '/NoSecurityTest/Oauth');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([{ tsoa_auth: ['write:pets', 'read:pets'] }]);
+    });
+
+  });
+
+  describe('with undefined controller level security', () => {
+    const plainControllerMetadata = new MetadataGenerator(
+      './fixtures/controllers/pathlessGetController.ts',
+      undefined,
+      undefined,
+      undefined, [{
+        root_level_auth: []
+    }]).Generate();
+    const plainSpec = new SpecGenerator2(plainControllerMetadata, getDefaultExtendedOptions()).GetSpec();
+
+    it('should use root level security if no security defined on method', () => {
+      const path = verifyPath(plainSpec, '/Current', 'TestModel');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([{
+        root_level_auth: []
+      }]);
+    });
+
+  });
+
+  describe('with @NoSecurity() on controller', () => {
+    const noSecurityControllerMetadata = new MetadataGenerator(
+      './fixtures/controllers/noSecurityOnController.ts',
+      undefined,
+      undefined,
+      undefined, [{
+        root_level_auth: []
+    }]).Generate();
+    const noSecurityOnControllerSpec = new SpecGenerator2(noSecurityControllerMetadata, getDefaultExtendedOptions()).GetSpec();
+
+    it('should use the method level security over root/controller security', () => {
+      const path = verifyPath(noSecurityOnControllerSpec, '/NoSecurity');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([{ api_key: [] }]);
+    });
+
+    it('should have no security if method has nothing specified', () => {
+      const path = verifyPath(noSecurityOnControllerSpec, '/NoSecurity/UndefinedSecurity');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([]);
+    });
+
+    it('should have no security if method has @NoSecurity()', () => {
+      const path = verifyPath(noSecurityOnControllerSpec, '/NoSecurity/NoSecurity');
+
+      if (!path.get) {
+        throw new Error('No get operation.');
+      }
+
+      expect(path.get.security).to.deep.equal([]);
+    });
+
+  })
+
+  function verifyPath(spec: Swagger.Spec2, route: string, model = 'UserResponseModel') {
+    return VerifyPath(spec, route, path => path.get, undefined, false, `#/definitions/${model}`);
+  }
+});


### PR DESCRIPTION
This adds a new config field `spec.rootSecurity` to tsoa.json that lets you apply OpenAPI security to every controller/method.
The security is layered and you can override it in the controller or method.
e.g. `@NoSecurity()` on a controller disables the root level security, and you can turn it back on with `@Security()` on a method in that controller.

This does not add the root level security to the OpenAPI document, but it does add it to every method where it's used.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Some slightly weird config passing in cli.js because the config is in the swagger spec section but is used by both swagger and routes generation.

**Test plan**
Covered all the combinations in some new unit tests.
I tried out the cli for spec, route and both and it works as expected.
