### PR TITLE
Add new Queries decorator to include all query parameters in one sing…

### DIFF
--- a/packages/cli/src/metadataGeneration/methodGenerator.ts
+++ b/packages/cli/src/metadataGeneration/methodGenerator.ts
@@ -89,6 +89,13 @@ export class MethodGenerator {
       })
       .reduce((flattened, params) => [...flattened, ...params], []);
 
+    this.validateBodyParameters(parameters);
+    this.validateQueryParameters(parameters);
+
+    return parameters;
+  }
+
+  private validateBodyParameters(parameters: Tsoa.Parameter[]) {
     const bodyParameters = parameters.filter(p => p.in === 'body');
     const bodyProps = parameters.filter(p => p.in === 'body-prop');
 
@@ -104,7 +111,18 @@ export class MethodGenerator {
     if (hasBodyParameter && hasFormDataParameters) {
       throw new Error(`@Body or @BodyProp cannot be used with @FormField, @UploadedFile, or @UploadedFiles in '${this.getCurrentLocation()}' method.`);
     }
-    return parameters;
+  }
+
+  private validateQueryParameters(parameters: Tsoa.Parameter[]) {
+    const queryParameters = parameters.filter(p => p.in === 'query');
+    const queriesParameters = parameters.filter(p => p.in === 'queries');
+
+    if (queriesParameters.length > 1) {
+      throw new GenerateMetadataError(`Only one queries parameter allowed in '${this.getCurrentLocation()}' method.`);
+    }
+    if (queriesParameters.length > 0 && queryParameters.length > 0) {
+      throw new GenerateMetadataError(`Choose either during @Query or @Queries in '${this.getCurrentLocation()}' method.`);
+    }
   }
 
   private getExtensions() {

--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -28,6 +28,8 @@ export class ParameterGenerator {
         return [this.getHeaderParameter(this.parameter)];
       case 'Query':
         return this.getQueryParameters(this.parameter);
+      case 'Queries':
+        return [this.getQueriesParameters(this.parameter)];
       case 'Path':
         return [this.getPathParameter(this.parameter)];
       case 'Res':
@@ -249,6 +251,26 @@ export class ParameterGenerator {
     };
   }
 
+  private getQueriesParameters(parameter: ts.ParameterDeclaration): Tsoa.Parameter {
+    const parameterName = (parameter.name as ts.Identifier).text;
+    const type = this.getValidatedType(parameter);
+
+    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
+
+    return {
+      description: this.getParameterDescription(parameter),
+      in: 'queries',
+      name: parameterName,
+      example,
+      exampleLabels,
+      parameterName,
+      required: !parameter.questionToken && !parameter.initializer,
+      type,
+      validators: getParameterValidators(this.parameter, parameterName),
+      deprecated: this.getParameterDeprecation(parameter),
+    };
+  }
+
   private getQueryParameters(parameter: ts.ParameterDeclaration): Tsoa.Parameter[] {
     const parameterName = (parameter.name as ts.Identifier).text;
     const type = this.getValidatedType(parameter);
@@ -383,7 +405,7 @@ export class ParameterGenerator {
   }
 
   private supportParameterDecorator(decoratorName: string) {
-    return ['header', 'query', 'path', 'body', 'bodyprop', 'request', 'res', 'inject', 'uploadedfile', 'uploadedfiles', 'formfield'].some(d => d === decoratorName.toLocaleLowerCase());
+    return ['header', 'query', 'queries', 'path', 'body', 'bodyprop', 'request', 'res', 'inject', 'uploadedfile', 'uploadedfiles', 'formfield'].some(d => d === decoratorName.toLocaleLowerCase());
   }
 
   private supportPathDataType(parameterType: Tsoa.Type) {

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -239,6 +239,8 @@ export function RegisterRoutes(app: express.Router) {
                     return request;
                 case 'query':
                     return validationService.ValidateParam(args[key], request.query[name], name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
+                case 'queries':
+                    return validationService.ValidateParam(args[key], request.query, name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'path':
                     return validationService.ValidateParam(args[key], request.params[name], name, fieldErrors, undefined, {{{json minimalSwaggerConfig}}});
                 case 'header':

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -332,6 +332,8 @@ export function RegisterRoutes(server: any) {
                 return request;
             case 'query':
                 return validationService.ValidateParam(args[key], request.query[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}})
+            case 'queries':
+                return validationService.ValidateParam(args[key], request.query, name, errorFields, undefined, {{{json minimalSwaggerConfig}}})
             case 'path':
                 return validationService.ValidateParam(args[key], request.params[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}})
             case 'header':

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -240,6 +240,8 @@ export function RegisterRoutes(router: KoaRouter) {
                 return context.request;
             case 'query':
                 return validationService.ValidateParam(args[key], context.request.query[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
+            case 'queries':
+                return validationService.ValidateParam(args[key], context.request.query, name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'path':
                 return validationService.ValidateParam(args[key], context.params[name], name, errorFields, undefined, {{{json minimalSwaggerConfig}}});
             case 'header':

--- a/packages/cli/src/swagger/specGenerator.ts
+++ b/packages/cli/src/swagger/specGenerator.ts
@@ -210,4 +210,19 @@ export abstract class SpecGenerator {
   protected hasUndefined(property: Tsoa.Property): boolean {
     return property.type.dataType === 'undefined' || (property.type.dataType === 'union' && property.type.types.some(type => type.dataType === 'undefined'));
   }
+
+  protected queriesPropertyToQueryParameter(property: Tsoa.Property): Tsoa.Parameter {
+    return {
+      parameterName: property.name,
+      example: [property.example as any],
+      description: property.description,
+      in: 'query',
+      name: property.name,
+      required: property.required,
+      type: property.type,
+      default: property.default,
+      validators: property.validators,
+      deprecated: property.deprecated,
+    };
+  }
 }

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -299,13 +299,13 @@ export class SpecGenerator2 extends SpecGenerator {
     return parameter;
   }
 
-  private buildQueriesParameter(source: Tsoa.Parameter): Swagger.Parameter3[] {
-    if (source.type.dataType === 'refAlias' && source.type.type.dataType === 'nestedObjectLiteral') {
-      const properties = source.type.type.properties;
+  private buildQueriesParameter(source: Tsoa.Parameter): Swagger.Parameter2[] {
+    if (source.type.dataType === 'refObject' || source.type.dataType === 'nestedObjectLiteral') {
+      const properties = source.type.properties;
 
       return properties.map(property => this.buildParameter(this.queriesPropertyToQueryParameter(property)));
     }
-    return [];
+    throw new Error(`Queries '${source.name}' parameter must be an object.`);
   }
 
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter2 {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -173,11 +173,21 @@ export class SpecGenerator2 extends SpecGenerator {
       pathMethod.security = method.security;
     }
 
+    const queriesParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'queries');
+
     pathMethod.parameters = method.parameters
       .filter(p => {
-        return !(p.in === 'request' || p.in === 'body-prop' || p.in === 'res');
+        return ['request', 'body-prop', 'res', 'queries'].indexOf(p.in) === -1;
       })
       .map(p => this.buildParameter(p));
+
+    if (queriesParams.length > 1) {
+      throw new Error('Only one queries parameter allowed per controller method.');
+    }
+
+    if (queriesParams.length === 1) {
+      pathMethod.parameters.push(...this.buildQueriesParameter(queriesParams[0]));
+    }
 
     const bodyPropParameter = this.buildBodyPropParameter(controllerName, method);
     if (bodyPropParameter) {
@@ -287,6 +297,15 @@ export class SpecGenerator2 extends SpecGenerator {
       parameter.schema.required = required;
     }
     return parameter;
+  }
+
+  private buildQueriesParameter(source: Tsoa.Parameter): Swagger.Parameter3[] {
+    if (source.type.dataType === 'refAlias' && source.type.type.dataType === 'nestedObjectLiteral') {
+      const properties = source.type.type.properties;
+
+      return properties.map(property => this.buildParameter(this.queriesPropertyToQueryParameter(property)));
+    }
+    return [];
   }
 
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter2 {

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -468,12 +468,12 @@ export class SpecGenerator3 extends SpecGenerator {
   }
 
   private buildQueriesParameter(source: Tsoa.Parameter): Swagger.Parameter3[] {
-    if (source.type.dataType === 'refAlias' && source.type.type.dataType === 'nestedObjectLiteral') {
-      const properties = source.type.type.properties;
+    if (source.type.dataType === 'refObject' || source.type.dataType === 'nestedObjectLiteral') {
+      const properties = source.type.properties;
 
       return properties.map(property => this.buildParameter(this.queriesPropertyToQueryParameter(property)));
     }
-    return [];
+    throw new Error(`Queries '${source.name}' parameter must be an object.`);
   }
 
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter3 {
@@ -534,8 +534,6 @@ export class SpecGenerator3 extends SpecGenerator {
         const exampleLabel = parameterExampleLabels?.[currentIndex];
         return { ...acc, [exampleLabel === undefined ? `Example ${exampleCounter++}` : exampleLabel]: { value: ex } };
       }, {});
-
-      console.log(parameter.examples);
     }
 
     return parameter;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -269,12 +269,21 @@ export class SpecGenerator3 extends SpecGenerator {
     const bodyParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'body');
     const bodyPropParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'body-prop');
     const formParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'formData');
+    const queriesParams: Tsoa.Parameter[] = method.parameters.filter(p => p.in === 'queries');
 
     pathMethod.parameters = method.parameters
       .filter(p => {
-        return ['body', 'formData', 'request', 'body-prop', 'res'].indexOf(p.in) === -1;
+        return ['body', 'formData', 'request', 'body-prop', 'res', 'queries'].indexOf(p.in) === -1;
       })
       .map(p => this.buildParameter(p));
+
+    if (queriesParams.length > 1) {
+      throw new Error('Only one queries parameter allowed per controller method.');
+    }
+
+    if (queriesParams.length === 1) {
+      pathMethod.parameters.push(...this.buildQueriesParameter(queriesParams[0]));
+    }
 
     if (bodyParams.length > 1) {
       throw new Error('Only one body parameter allowed per controller method.');
@@ -458,6 +467,15 @@ export class SpecGenerator3 extends SpecGenerator {
     return mediaType;
   }
 
+  private buildQueriesParameter(source: Tsoa.Parameter): Swagger.Parameter3[] {
+    if (source.type.dataType === 'refAlias' && source.type.type.dataType === 'nestedObjectLiteral') {
+      const properties = source.type.type.properties;
+
+      return properties.map(property => this.buildParameter(this.queriesPropertyToQueryParameter(property)));
+    }
+    return [];
+  }
+
   private buildParameter(source: Tsoa.Parameter): Swagger.Parameter3 {
     const parameter = {
       description: source.description,
@@ -516,6 +534,8 @@ export class SpecGenerator3 extends SpecGenerator {
         const exampleLabel = parameterExampleLabels?.[currentIndex];
         return { ...acc, [exampleLabel === undefined ? `Example ${exampleCounter++}` : exampleLabel]: { value: ex } };
       }, {});
+
+      console.log(parameter.examples);
     }
 
     return parameter;

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -51,6 +51,15 @@ export function Query(name?: string): Function {
 }
 
 /**
+ * Inject all query values in a single object
+ */
+export function Queries(): Function {
+  return () => {
+    return;
+  };
+}
+
+/**
  * Inject value from Http header
  *
  * @param {string} [name] The name of the header parameter

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -40,7 +40,7 @@ export namespace Tsoa {
     parameterName: string;
     example?: Array<{ [exampleName: string]: Swagger.Example3 }>;
     description?: string;
-    in: 'query' | 'header' | 'path' | 'formData' | 'body' | 'body-prop' | 'request' | 'res';
+    in: 'query' | 'queries' | 'header' | 'path' | 'formData' | 'body' | 'body-prop' | 'request' | 'res';
     name: string;
     required?: boolean;
     type: Type;

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -1,6 +1,6 @@
 ///<reference path="../tsoaTestModule.d.ts" />
 import { Readable } from 'stream';
-import { Controller, Example, Get, OperationId, Query, Request, Response, Route, SuccessResponse, Tags, Res, TsoaResponse } from '@tsoa/runtime';
+import { Controller, Example, Get, OperationId, Query, Request, Response, Route, SuccessResponse, Tags, Res, TsoaResponse, Queries } from '@tsoa/runtime';
 import '../duplicateTestModel';
 import {
   GenericModel,
@@ -142,6 +142,17 @@ export class GetTestController extends Controller {
     model.numberValue = numberPathParam;
     model.boolValue = booleanPathParam;
     model.stringValue = stringPathParam;
+
+    return model;
+  }
+
+  @Get('AllQueriesInOneObject')
+  public async getAllQueriesInOneObject(@Queries() queryParams: QueryParams) {
+    const model = new ModelService().getModel();
+    model.optionalString = queryParams.optionalStringParam;
+    model.numberValue = queryParams.numberParam;
+    model.boolValue = queryParams.booleanParam;
+    model.stringValue = queryParams.stringParam;
 
     return model;
   }
@@ -314,4 +325,11 @@ export interface CustomError extends Error {
 
 export interface Result {
   value: 'success' | 'failure';
+}
+
+export interface QueryParams {
+  numberParam: number;
+  stringParam: string;
+  booleanParam: boolean;
+  optionalStringParam?: string;
 }

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -157,6 +157,22 @@ export class GetTestController extends Controller {
     return model;
   }
 
+  @Get('WildcardQueries')
+  public async getWildcardQueries(@Queries() queryParams: { [name: string]: any }) {
+    const model = new ModelService().getModel();
+    model.anyType = queryParams;
+
+    return model;
+  }
+
+  @Get('TypedRecordQueries')
+  public async getTypedRecordQueries(@Queries() queryParams: { [name: string]: number }) {
+    const model = new ModelService().getModel();
+    model.anyType = queryParams;
+
+    return model;
+  }
+
   @Get('ResponseWithUnionTypeProperty')
   public async getResponseWithUnionTypeProperty(): Promise<Result> {
     return {

--- a/tests/fixtures/controllers/invalidNestedQueriesController.ts
+++ b/tests/fixtures/controllers/invalidNestedQueriesController.ts
@@ -4,7 +4,7 @@ import { ModelService } from '../services/modelService';
 @Route('Controller')
 export class InvalidNestedQueriesController extends Controller {
   @Get('nestedQueriesMethod')
-  public nestedQueriesMethod(@Queries() _nestedQueries: QueriesObject) {
+  public nestedQueriesMethod(@Queries() nestedQueries: QueriesObject) {
     return new ModelService().getModel();
   }
 }

--- a/tests/fixtures/controllers/invalidNestedQueriesController.ts
+++ b/tests/fixtures/controllers/invalidNestedQueriesController.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Route, Queries } from '@tsoa/runtime';
+import { ModelService } from '../services/modelService';
+
+@Route('Controller')
+export class InvalidNestedQueriesController extends Controller {
+  @Get('nestedQueriesMethod')
+  public nestedQueriesMethod(@Queries() _nestedQueries: QueriesObject) {
+    return new ModelService().getModel();
+  }
+}
+
+export interface QueriesObject {
+  name: string;
+  nestedObject: NestedQueriesObject;
+}
+
+export interface NestedQueriesObject {
+  nestedName: string;
+}

--- a/tests/fixtures/controllers/invalidQueriesController.ts
+++ b/tests/fixtures/controllers/invalidQueriesController.ts
@@ -1,11 +1,15 @@
-import { Get, Queries, Query, Route } from '@tsoa/runtime';
+import { Get, Queries, Route } from '@tsoa/runtime';
 import { ModelService } from '../services/modelService';
 import { TestModel } from '../testModel';
 
 @Route('QueriesTest')
 export class InvalidQueriesTestController {
   @Get('WithMultipleQueries')
-  public async getWithMultipleQueriesParams(@Queries() _firstParam: TestModel, @Queries() _secondParam: TestModel): Promise<TestModel> {
+  public async getWithMultipleQueriesParams(@Queries() _firstParam: QueriesObject, @Queries() _secondParam: QueriesObject): Promise<TestModel> {
     return new ModelService().getModel();
   }
+}
+
+interface QueriesObject {
+  name: string;
 }

--- a/tests/fixtures/controllers/invalidQueriesController.ts
+++ b/tests/fixtures/controllers/invalidQueriesController.ts
@@ -1,0 +1,11 @@
+import { Get, Queries, Query, Route } from '@tsoa/runtime';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+@Route('QueriesTest')
+export class InvalidQueriesTestController {
+  @Get('WithMultipleQueries')
+  public async getWithMultipleQueriesParams(@Queries() _firstParam: TestModel, @Queries() _secondParam: TestModel): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}

--- a/tests/fixtures/controllers/invalidQueryController.ts
+++ b/tests/fixtures/controllers/invalidQueryController.ts
@@ -1,0 +1,11 @@
+import { Get, Queries, Query, Route } from '@tsoa/runtime';
+import { ModelService } from '../services/modelService';
+import { TestModel } from '../testModel';
+
+@Route('QueryTest')
+export class InvalidQueryTestController {
+  @Get('QueryAndQueries')
+  public async getQueryAndQueries(@Queries() _myModel: TestModel, @Query() _stringValue: string): Promise<TestModel> {
+    return new ModelService().getModel();
+  }
+}

--- a/tests/fixtures/controllers/invalidQueryController.ts
+++ b/tests/fixtures/controllers/invalidQueryController.ts
@@ -5,7 +5,11 @@ import { TestModel } from '../testModel';
 @Route('QueryTest')
 export class InvalidQueryTestController {
   @Get('QueryAndQueries')
-  public async getQueryAndQueries(@Queries() _myModel: TestModel, @Query() _stringValue: string): Promise<TestModel> {
+  public async getQueryAndQueries(@Queries() _queriesObject: QueriesObject, @Query() _stringValue: string): Promise<TestModel> {
     return new ModelService().getModel();
   }
+}
+
+interface QueriesObject {
+  name: string;
 }

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -1,4 +1,4 @@
-import { Body, BodyProp, Get, Header, Path, Post, Query, Request, Route, Res, TsoaResponse, Deprecated } from '@tsoa/runtime';
+import { Body, BodyProp, Get, Header, Path, Post, Query, Request, Route, Res, TsoaResponse, Deprecated, Queries } from '@tsoa/runtime';
 import { Gender, ParameterTestModel } from '../testModel';
 
 @Route('ParameterTest')
@@ -64,6 +64,35 @@ export class ParameterController {
       lastname,
       nicknames,
       weight,
+    });
+  }
+
+  /**
+   * Queries test paramater
+   *
+   * @param {object} queryParams Queries description
+   *
+   * @example queryParams {
+   *  "firstname": "first1",
+   *  "lastname": "last1",
+   *  "age": 1
+   * }
+   * @example queryParams {
+   *  "firstname": "first2",
+   *  "lastname": "last2",
+   *  "age": 2
+   * }
+   */
+  @Get('Queries')
+  public async getQueries(@Queries() queryParams: ParameterTestModel): Promise<ParameterTestModel> {
+    return Promise.resolve<ParameterTestModel>({
+      age: queryParams.age,
+      firstname: queryParams.firstname,
+      gender: queryParams.gender,
+      human: queryParams.human,
+      lastname: queryParams.lastname,
+      nicknames: queryParams.nicknames,
+      weight: queryParams.weight,
     });
   }
 

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -141,6 +141,53 @@ describe('Express Server', () => {
     });
   });
 
+  it('accepts any parameter using a wildcard', () => {
+    const object = {
+      foo: 'foo',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/WildcardQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(object.foo);
+      expect(queryParams.anyType.bar).to.equal(String(object.bar));
+      expect(queryParams.anyType.baz).to.equal(String(object.baz));
+    });
+  });
+
+  it('should reject incompatible entries for typed wildcard', () => {
+    const object = {
+      foo: '2',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(
+      basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`,
+      (err, _res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['queryParams.baz'].message).to.equal('invalid float number');
+      },
+      400,
+    );
+  });
+
+  it('accepts numbered parameters using a wildcard', () => {
+    const object = {
+      foo: '3',
+      bar: 10,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(Number(object.foo));
+      expect(queryParams.anyType.bar).to.equal(object.bar);
+    });
+  });
+
   it('should reject invalid additionalProperties', () => {
     const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
 

--- a/tests/integration/dynamic-controllers-express-server.spec.ts
+++ b/tests/integration/dynamic-controllers-express-server.spec.ts
@@ -126,6 +126,21 @@ describe('Express Server', () => {
     });
   });
 
+  it('parses queries parameters in one single object', () => {
+    const numberValue = 10;
+    const boolValue = true;
+    const stringValue = 'the-string';
+
+    return verifyGetRequest(basePath + `/GetTest/AllQueriesInOneObject?booleanParam=${boolValue.toString()}&stringParam=${stringValue}&numberParam=${numberValue}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.numberValue).to.equal(numberValue);
+      expect(queryParams.boolValue).to.equal(boolValue);
+      expect(queryParams.stringValue).to.equal(stringValue);
+      expect(queryParams.optionalString).to.be.undefined;
+    });
+  });
+
   it('should reject invalid additionalProperties', () => {
     const invalidValues = ['invalid', null, [], 1, { foo: null }, { foo: 1 }, { foo: [] }, { foo: {} }, { foo: { foo: 'bar' } }];
 
@@ -984,6 +999,19 @@ describe('Express Server', () => {
   describe('Parameter data', () => {
     it('parses query parameters', () => {
       return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
+        const model = res.body as ParameterTestModel;
+        expect(model.firstname).to.equal('Tony');
+        expect(model.lastname).to.equal('Stark');
+        expect(model.age).to.equal(45);
+        expect(model.weight).to.equal(82.1);
+        expect(model.human).to.equal(true);
+        expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
+      });
+    });
+
+    it('parses queries parameters', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/Queries?firstname=Tony&lastname=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -131,6 +131,21 @@ describe('Express Server', () => {
     });
   });
 
+  it('parses queries parameters in one single object', () => {
+    const numberValue = 10;
+    const boolValue = true;
+    const stringValue = 'the-string';
+
+    return verifyGetRequest(basePath + `/GetTest/AllQueriesInOneObject?booleanParam=${boolValue.toString()}&stringParam=${stringValue}&numberParam=${numberValue}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.numberValue).to.equal(numberValue);
+      expect(queryParams.boolValue).to.equal(boolValue);
+      expect(queryParams.stringValue).to.equal(stringValue);
+      expect(queryParams.optionalString).to.be.undefined;
+    });
+  });
+
   it('Should return on @Res', () => {
     return verifyGetRequest(
       basePath + '/GetTest/Res',
@@ -1165,6 +1180,19 @@ describe('Express Server', () => {
   describe('Parameter data', () => {
     it('parses query parameters', () => {
       return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
+        const model = res.body as ParameterTestModel;
+        expect(model.firstname).to.equal('Tony');
+        expect(model.lastname).to.equal('Stark');
+        expect(model.age).to.equal(45);
+        expect(model.weight).to.equal(82.1);
+        expect(model.human).to.equal(true);
+        expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
+      });
+    });
+
+    it('parses queries parameters', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/Queries?firstname=Tony&lastname=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -146,6 +146,53 @@ describe('Express Server', () => {
     });
   });
 
+  it('accepts any parameter using a wildcard', () => {
+    const object = {
+      foo: 'foo',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/WildcardQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(object.foo);
+      expect(queryParams.anyType.bar).to.equal(String(object.bar));
+      expect(queryParams.anyType.baz).to.equal(String(object.baz));
+    });
+  });
+
+  it('should reject incompatible entries for typed wildcard', () => {
+    const object = {
+      foo: '2',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(
+      basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`,
+      (err, _res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['queryParams.baz'].message).to.equal('invalid float number');
+      },
+      400,
+    );
+  });
+
+  it('accepts numbered parameters using a wildcard', () => {
+    const object = {
+      foo: '3',
+      bar: 10,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(Number(object.foo));
+      expect(queryParams.anyType.bar).to.equal(object.bar);
+    });
+  });
+
   it('Should return on @Res', () => {
     return verifyGetRequest(
       basePath + '/GetTest/Res',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -125,6 +125,53 @@ describe('Hapi Server', () => {
     });
   });
 
+  it('accepts any parameter using a wildcard', () => {
+    const object = {
+      foo: 'foo',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/WildcardQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(object.foo);
+      expect(queryParams.anyType.bar).to.equal(String(object.bar));
+      expect(queryParams.anyType.baz).to.equal(String(object.baz));
+    });
+  });
+
+  it('should reject incompatible entries for typed wildcard', () => {
+    const object = {
+      foo: '2',
+      bar: 10,
+      baz: true,
+    };
+
+    return verifyGetRequest(
+      basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`,
+      (err, _res) => {
+        const body = JSON.parse(err.text);
+        expect(body.fields['queryParams.baz'].message).to.equal('invalid float number');
+      },
+      400,
+    );
+  });
+
+  it('accepts numbered parameters using a wildcard', () => {
+    const object = {
+      foo: '3',
+      bar: 10,
+    };
+
+    return verifyGetRequest(basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.anyType.foo).to.equal(Number(object.foo));
+      expect(queryParams.anyType.bar).to.equal(object.bar);
+    });
+  });
+
   it('parsed body parameters', () => {
     const data = getFakeModel();
 

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -110,6 +110,21 @@ describe('Hapi Server', () => {
     });
   });
 
+  it('parses queries parameters in one single object', () => {
+    const numberValue = 10;
+    const boolValue = true;
+    const stringValue = 'the-string';
+
+    return verifyGetRequest(basePath + `/GetTest/AllQueriesInOneObject?booleanParam=${boolValue.toString()}&stringParam=${stringValue}&numberParam=${numberValue}`, (_err, res) => {
+      const queryParams = res.body as TestModel;
+
+      expect(queryParams.numberValue).to.equal(numberValue);
+      expect(queryParams.boolValue).to.equal(boolValue);
+      expect(queryParams.stringValue).to.equal(stringValue);
+      expect(queryParams.optionalString).to.be.undefined;
+    });
+  });
+
   it('parsed body parameters', () => {
     const data = getFakeModel();
 
@@ -1077,6 +1092,19 @@ describe('Hapi Server', () => {
   describe('Parameter data', () => {
     it('parses query parameters', () => {
       return verifyGetRequest(basePath + '/ParameterTest/Query?firstname=Tony&last_name=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
+        const model = res.body as ParameterTestModel;
+        expect(model.firstname).to.equal('Tony');
+        expect(model.lastname).to.equal('Stark');
+        expect(model.age).to.equal(45);
+        expect(model.weight).to.equal(82.1);
+        expect(model.human).to.equal(true);
+        expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
+      });
+    });
+
+    it('parses queries parameters', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/Queries?firstname=Tony&lastname=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
         const model = res.body as ParameterTestModel;
         expect(model.firstname).to.equal('Tony');
         expect(model.lastname).to.equal('Stark');

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1067,6 +1067,19 @@ describe('Koa Server', () => {
       });
     });
 
+    it('parses queries parameters', () => {
+      return verifyGetRequest(basePath + '/ParameterTest/Queries?firstname=Tony&lastname=Stark&age=45&weight=82.1&human=true&gender=MALE&nicknames=Ironman&nicknames=Iron Man', (_err, res) => {
+        const model = res.body as ParameterTestModel;
+        expect(model.firstname).to.equal('Tony');
+        expect(model.lastname).to.equal('Stark');
+        expect(model.age).to.equal(45);
+        expect(model.weight).to.equal(82.1);
+        expect(model.human).to.equal(true);
+        expect(model.gender).to.equal('MALE');
+        expect(model.nicknames).to.deep.equal(['Ironman', 'Iron Man']);
+      });
+    });
+
     it('parses path parameters', () => {
       return verifyGetRequest(basePath + '/ParameterTest/Path/Tony/Stark/45/82.1/true/MALE', (_err, res) => {
         const model = res.body as ParameterTestModel;

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1080,6 +1080,53 @@ describe('Koa Server', () => {
       });
     });
 
+    it('accepts any parameter using a wildcard', () => {
+      const object = {
+        foo: 'foo',
+        bar: 10,
+        baz: true,
+      };
+
+      return verifyGetRequest(basePath + `/GetTest/WildcardQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`, (_err, res) => {
+        const queryParams = res.body as TestModel;
+
+        expect(queryParams.anyType.foo).to.equal(object.foo);
+        expect(queryParams.anyType.bar).to.equal(String(object.bar));
+        expect(queryParams.anyType.baz).to.equal(String(object.baz));
+      });
+    });
+
+    it('should reject incompatible entries for typed wildcard', () => {
+      const object = {
+        foo: '2',
+        bar: 10,
+        baz: true,
+      };
+
+      return verifyGetRequest(
+        basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}&baz=${String(object.baz)}`,
+        (err, _res) => {
+          const body = JSON.parse(err.text);
+          expect(body.fields['queryParams.baz'].message).to.equal('invalid float number');
+        },
+        400,
+      );
+    });
+
+    it('accepts numbered parameters using a wildcard', () => {
+      const object = {
+        foo: '3',
+        bar: 10,
+      };
+
+      return verifyGetRequest(basePath + `/GetTest/TypedRecordQueries?foo=${object.foo}&bar=${object.bar}`, (_err, res) => {
+        const queryParams = res.body as TestModel;
+
+        expect(queryParams.anyType.foo).to.equal(Number(object.foo));
+        expect(queryParams.anyType.bar).to.equal(object.bar);
+      });
+    });
+
     it('parses path parameters', () => {
       return verifyGetRequest(basePath + '/ParameterTest/Path/Tony/Stark/45/82.1/true/MALE', (_err, res) => {
         const model = res.body as ParameterTestModel;

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -463,6 +463,38 @@ describe('Metadata generation', () => {
       expect(nicknamesParam.example).to.be.undefined;
     });
 
+    it('should generate a queries parameter', () => {
+      const method = controller.methods.find(m => m.name === 'getQueries');
+      if (!method) {
+        throw new Error('Method getQueries not defined!');
+      }
+      const parameter = method.parameters.find(param => param.parameterName === 'queryParams');
+      if (!parameter) {
+        throw new Error('Parameter queryParams not defined!');
+      }
+
+      expect(method.parameters.length).to.equal(1);
+      expect(parameter.description).to.equal('Queries description');
+      expect(parameter.in).to.equal('queries');
+      expect(parameter.name).to.equal('queryParams');
+      expect(parameter.parameterName).to.equal('queryParams');
+      expect(parameter.required).to.be.true;
+      expect(parameter.example).not.to.be.undefined;
+      expect(parameter.example).to.deep.equal([
+        {
+          firstname: 'first1',
+          lastname: 'last1',
+          age: 1,
+        },
+        {
+          firstname: 'first2',
+          lastname: 'last2',
+          age: 2,
+        },
+      ]);
+      expect((parameter.example as unknown[]).length).to.be.equal(2);
+    });
+
     it('should generate a path parameter', () => {
       const method = controller.methods.find(m => m.name === 'getPath');
       if (!method) {

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -204,6 +204,13 @@ describe('GET route generation', () => {
     }).to.throw("Only one queries parameter allowed in 'InvalidQueriesTestController.getWithMultipleQueriesParams' method.");
   });
 
+  it('should reject nested Query object inside Queries decorator', () => {
+    expect(() => {
+      const invalidMetadata = new MetadataGenerator('./fixtures/controllers/invalidNestedQueriesController.ts').Generate();
+      new SpecGenerator2(invalidMetadata, getDefaultExtendedOptions()).GetSpec();
+    }).to.throw("@Queries('nestedQueries') nested property 'nestedObject' Can't support 'refObject' type. \n in 'InvalidNestedQueriesController.nestedQueriesMethod'");
+  });
+
   it('should reject invalid header types', function () {
     this.timeout(10_000);
     expect(() => {

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -190,6 +190,20 @@ describe('GET route generation', () => {
     }).to.throw("@Query('myModel') Can't support 'refObject' type. \n in 'InvalidGetTestController.getModelWithComplex'");
   });
 
+  it('should reject Query and Queries decorators at the same time', () => {
+    expect(() => {
+      const invalidMetadata = new MetadataGenerator('./fixtures/controllers/invalidQueryController.ts').Generate();
+      new SpecGenerator2(invalidMetadata, getDefaultExtendedOptions()).GetSpec();
+    }).to.throw("Choose either during @Query or @Queries in 'InvalidQueryTestController.getQueryAndQueries' method.");
+  });
+
+  it('should reject multiple Queries decorators', () => {
+    expect(() => {
+      const invalidMetadata = new MetadataGenerator('./fixtures/controllers/invalidQueriesController.ts').Generate();
+      new SpecGenerator2(invalidMetadata, getDefaultExtendedOptions()).GetSpec();
+    }).to.throw("Only one queries parameter allowed in 'InvalidQueriesTestController.getWithMultipleQueriesParams' method.");
+  });
+
   it('should reject invalid header types', function () {
     this.timeout(10_000);
     expect(() => {


### PR DESCRIPTION
This PR adds a new `@Queries` decorator that accepts an object and wraps all the query parameters into it. This is something very useful for example if the request has a lot of filter parameters that we want to handle. It has been requested several times for example in [this issue](https://github.com/lukeautry/tsoa/issues/353).

I have tried to keep this new decorator behavior as similar as the Body and the BodyProps decorators were implemented.

Use example:

```typescript
export interface QueryParams {
  numberParam: number;
  stringParam: string;
  booleanParam: boolean;
  optionalStringParam?: string;
}


@Get('AllQueriesInOneObject')
public async getAllQueriesInOneObject(@Queries() queryParams: QueryParams) {
  const model = new ModelService().getModel();
  model.optionalString = queryParams.optionalStringParam;
  model.numberValue = queryParams.numberParam;
  model.boolValue = queryParams.booleanParam;
  model.stringValue = queryParams.stringParam;

  return model;
}
```
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue? (https://github.com/lukeautry/tsoa/issues/353)

### If this is a new feature submission:

- [X] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

I have not tested yet if it would be a problem to have both the Queries and the Query decorator in one single function. It would be nice to add some test cases testing this.

**Test plan**

For what I wanted, the code is working as expected. I have tried to keep this new decorator as similar as you have implemented the Body and the BodyProps decorators. I still want to add more tests to check the doc generation but wanted to check if this approach was the correct one before continuing.
