### PR TITLE
Fix template literal path generation

### DIFF
--- a/packages/cli/src/metadataGeneration/initializer-value.ts
+++ b/packages/cli/src/metadataGeneration/initializer-value.ts
@@ -16,6 +16,7 @@ export const getInitializerValue = (initializer?: ts.Expression | ts.ImportSpeci
       return arrayLiteral.elements.map(element => getInitializerValue(element, typeChecker));
     }
     case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
       return (initializer as ts.StringLiteral).text;
     case ts.SyntaxKind.TrueKeyword:
       return true;

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -135,6 +135,16 @@ export class ParameterController {
   }
 
   /**
+   * Path test paramater
+   *
+   * @param {string} id ID description
+   */
+  @Get(`PathTemplateLiteral/{id}`)
+  public async getPathTemplateLiteral(@Path() id: string): Promise<void> {
+    return;
+  }
+
+  /**
    * Header test paramater
    *
    * @param {string} firstname Firstname description

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -463,7 +463,7 @@ describe('Metadata generation', () => {
       expect(nicknamesParam.example).to.be.undefined;
     });
 
-    it('should generate an path parameter', () => {
+    it('should generate a path parameter', () => {
       const method = controller.methods.find(m => m.name === 'getPath');
       if (!method) {
         throw new Error('Method getPath not defined!');
@@ -523,7 +523,7 @@ describe('Metadata generation', () => {
       expect(genderParam.type.dataType).to.equal('refEnum');
     });
 
-    it('should generate an path parameter from colon delimiter path params', () => {
+    it('should generate a path parameter from colon delimiter path params', () => {
       const method = controller.methods.find(m => m.name === 'getPathColonDelimiter');
       if (!method) {
         throw new Error('Method getPathColonDelimiter not defined!');
@@ -578,6 +578,23 @@ describe('Metadata generation', () => {
       expect(genderParam.description).to.equal('Gender description');
       expect(genderParam.required).to.be.true;
       expect(genderParam.type.dataType).to.equal('refEnum');
+    });
+
+    it('should generate a path parameter from template literal', () => {
+      const method = controller.methods.find(m => m.name === 'getPathTemplateLiteral');
+      if (!method) {
+        throw new Error('Method getPathTemplateLiteral not defined!');
+      }
+
+      expect(method.parameters.length).to.equal(1);
+
+      const idParam = method.parameters[0];
+      expect(idParam.in).to.equal('path');
+      expect(idParam.name).to.equal('id');
+      expect(idParam.parameterName).to.equal('id');
+      expect(idParam.description).to.equal('ID description');
+      expect(idParam.required).to.be.true;
+      expect(idParam.type.dataType).to.equal('string');
     });
 
     it('should generate an header parameter', () => {


### PR DESCRIPTION
### Background
- trying to upgrade `@tsoa/cli` from 3.9.0 to 3.14.1 is failing on my project
- narrowed problem down to decorators using template literals:
```ts
@Put(`/posts/{id}`)
```
- these are unnecessary and could be converted into strings:
```ts
@Put('/posts/{id}')
```
- but ideally tsoa doesn't break with these two equally valid string representations 

### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?


**Potential Problems With The Approach**

- unclear to me if there are other consumers of `getInitializerValue` that might have problems with this

**Test plan**
- include a template literal `@Path` and ensure it generates the correct metadata
- `yarn run test` passes for me locally
    - `yarn run lint` is failing on Github Actions and locally unrelated to this PR

**Notes**
- Cause appears to be #1061
