### PR TITLE
Use a variable to determine if a type should be added or not when resolved.

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -26,6 +26,7 @@ export class TypeResolver {
     private readonly parentNode?: ts.Node,
     private context: Context = {},
     private readonly referencer?: ts.TypeNode,
+    private readonly add: boolean = true,
   ) {}
 
   public static clearCache() {
@@ -419,7 +420,10 @@ export class TypeResolver {
 
     const referenceType = this.getReferenceType(typeReference);
 
-    this.current.AddReferenceType(referenceType);
+    if (this.add) {
+      this.current.AddReferenceType(referenceType);
+    }
+
     return referenceType;
   }
 
@@ -596,7 +600,7 @@ export class TypeResolver {
     };
   }
 
-  private getReferenceType(node: ts.TypeReferenceType): Tsoa.ReferenceType {
+  private getReferenceType(node: ts.TypeReferenceType, add = true): Tsoa.ReferenceType {
     let type: ts.EntityName;
     if (ts.isTypeReferenceNode(node)) {
       type = node.typeName;
@@ -647,7 +651,7 @@ export class TypeResolver {
 
       let referenceType: Tsoa.ReferenceType;
       if (ts.isTypeAliasDeclaration(declaration)) {
-        referenceType = this.getTypeAliasReference(declaration, name, node);
+        referenceType = this.getTypeAliasReference(declaration, name, node, add);
       } else if (ts.isEnumMember(declaration)) {
         referenceType = {
           dataType: 'refEnum',
@@ -670,7 +674,7 @@ export class TypeResolver {
     }
   }
 
-  private getTypeAliasReference(declaration: ts.TypeAliasDeclaration, name: string, referencer: ts.TypeReferenceType): Tsoa.ReferenceType {
+  private getTypeAliasReference(declaration: ts.TypeAliasDeclaration, name: string, referencer: ts.TypeReferenceType, add = true): Tsoa.ReferenceType {
     const example = this.getNodeExample(declaration);
 
     return {
@@ -679,7 +683,7 @@ export class TypeResolver {
       description: this.getNodeDescription(declaration),
       refName: this.getRefTypeName(name),
       format: this.getNodeFormat(declaration),
-      type: new TypeResolver(declaration.type, this.current, declaration, this.context, this.referencer || referencer).resolve(),
+      type: new TypeResolver(declaration.type, this.current, declaration, this.context, this.referencer || referencer, add).resolve(),
       validators: getPropertyValidators(declaration) || {},
       ...(example && { example }),
     };
@@ -1053,18 +1057,18 @@ export class TypeResolver {
       return properties;
     }
 
-    heritageClauses.forEach(clause => {
+    for (const clause of heritageClauses) {
       if (!clause.types) {
-        return;
+        continue;
       }
 
-      clause.types.forEach(t => {
+      for (const t of clause.types) {
         const baseEntityName = t.expression as ts.EntityName;
 
         // create subContext
         const resetCtx = this.typeArgumentsToContext(t, baseEntityName, this.context);
 
-        const referenceType = this.getReferenceType(t);
+        const referenceType = this.getReferenceType(t, false);
         if (referenceType) {
           if (referenceType.dataType === 'refEnum') {
             // since it doesn't have properties to iterate over, then we don't do anything with it
@@ -1088,8 +1092,8 @@ export class TypeResolver {
 
         // reset subContext
         this.context = resetCtx;
-      });
-    });
+      }
+    }
 
     return properties;
   }

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -26,7 +26,7 @@ export class TypeResolver {
     private readonly parentNode?: ts.Node,
     private context: Context = {},
     private readonly referencer?: ts.TypeNode,
-    private readonly add: boolean = true,
+    private readonly addToRefTypeMap: boolean = true,
   ) {}
 
   public static clearCache() {
@@ -420,7 +420,7 @@ export class TypeResolver {
 
     const referenceType = this.getReferenceType(typeReference);
 
-    if (this.add) {
+    if (this.addToRefTypeMap) {
       this.current.AddReferenceType(referenceType);
     }
 
@@ -600,7 +600,7 @@ export class TypeResolver {
     };
   }
 
-  private getReferenceType(node: ts.TypeReferenceType, add = true): Tsoa.ReferenceType {
+  private getReferenceType(node: ts.TypeReferenceType, addToRefTypeMap = true): Tsoa.ReferenceType {
     let type: ts.EntityName;
     if (ts.isTypeReferenceNode(node)) {
       type = node.typeName;
@@ -651,7 +651,7 @@ export class TypeResolver {
 
       let referenceType: Tsoa.ReferenceType;
       if (ts.isTypeAliasDeclaration(declaration)) {
-        referenceType = this.getTypeAliasReference(declaration, name, node, add);
+        referenceType = this.getTypeAliasReference(declaration, name, node, addToRefTypeMap);
       } else if (ts.isEnumMember(declaration)) {
         referenceType = {
           dataType: 'refEnum',
@@ -674,7 +674,7 @@ export class TypeResolver {
     }
   }
 
-  private getTypeAliasReference(declaration: ts.TypeAliasDeclaration, name: string, referencer: ts.TypeReferenceType, add = true): Tsoa.ReferenceType {
+  private getTypeAliasReference(declaration: ts.TypeAliasDeclaration, name: string, referencer: ts.TypeReferenceType, addToRefTypeMap = true): Tsoa.ReferenceType {
     const example = this.getNodeExample(declaration);
 
     return {
@@ -683,7 +683,7 @@ export class TypeResolver {
       description: this.getNodeDescription(declaration),
       refName: this.getRefTypeName(name),
       format: this.getNodeFormat(declaration),
-      type: new TypeResolver(declaration.type, this.current, declaration, this.context, this.referencer || referencer, add).resolve(),
+      type: new TypeResolver(declaration.type, this.current, declaration, this.context, this.referencer || referencer, addToRefTypeMap).resolve(),
       validators: getPropertyValidators(declaration) || {},
       ...(example && { example }),
     };

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -122,6 +122,7 @@ export interface TestModel extends Model {
 
     defaultArgs?: DefaultTestModel;
     heritageCheck?: HeritageTestModel;
+    heritageCheck2?: HeritageTestModel2;
   };
 
   genericMultiNested?: GenericRequest<GenericRequest<TypeAliasModel1>>;
@@ -412,6 +413,12 @@ export interface TestSubModel2 extends TestSubModel {
 }
 
 export interface HeritageTestModel extends TypeAlias4, Partial<Omit<UserResponseModel, 'id'>> {}
+
+export interface HeritageBaseModel {
+  value: string;
+}
+
+export type HeritageTestModel2 = HeritageBaseModel
 
 export interface DefaultTestModel<T = Word, U = Omit<ErrorResponseModel, 'status'>> {
   t: GenericRequest<T>;

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -418,7 +418,8 @@ export interface HeritageBaseModel {
   value: string;
 }
 
-export type HeritageTestModel2 = HeritageBaseModel
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface HeritageTestModel2 extends HeritageBaseModel {}
 
 export interface DefaultTestModel<T = Word, U = Omit<ErrorResponseModel, 'status'>> {
   t: GenericRequest<T>;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -98,17 +98,27 @@ describe('Definition generation', () => {
 
   describe('Interface-based generation', () => {
     it('should not generate a definition for heritage interfaces', () => {
-      allSpecs.forEach(currentSpec => {
-        const expectedModels = [
-          // TypeAlias4 is a herritage interface for HeritageTestModel, so it should not be found.
-          // If typeAlias4 is ever added to the test model itself, this test may fail even if the it is still working.
-          // In case of failure, check to see if TypeAlias4 is being used not as a heritage type.
-          'TypeAlias4',
-        ];
-        expectedModels.forEach(modelName => {
-          ValidateOmitted(modelName, currentSpec);
-        });
-      });
+      const expectedModel = 'HeritageTestModel2';
+      let modelFound = false;
+
+      for (const currentSpec of allSpecs) {
+        // HeritageBaseModel is a herritage interface for HeritageTestModel2, so it should not be found.
+        // If HeritageBaseModel is ever added to the test model itself, this test may fail even if the it is still working.
+        // In case of failure, check to see if HeritageBaseModel is being used not as a heritage type.
+
+        const notExpectedModels = ['HeritageBaseModel'];
+
+        if (currentSpec.spec.definitions && currentSpec.spec.definitions[expectedModel]) {
+          for (const modelName of notExpectedModels) {
+            modelFound = true;
+            ValidateOmitted(modelName, currentSpec);
+          }
+        }
+      }
+
+      if (!modelFound) {
+        throw new Error(`${expectedModel} should not have been automatically generated in at least one model.  False positive averted.`);
+      }
     });
 
     it('should generate a definition for referenced models', () => {
@@ -842,6 +852,7 @@ describe('Definition generation', () => {
                   readonlyClass: { $ref: '#/definitions/Readonly_TestClassModel_', description: undefined, format: undefined, example: undefined },
                   defaultArgs: { $ref: '#/definitions/DefaultTestModel', description: undefined, format: undefined, example: undefined },
                   heritageCheck: { $ref: '#/definitions/HeritageTestModel', description: undefined, format: undefined, example: undefined },
+                  heritageCheck2: { $ref: '#/definitions/HeritageTestModel2', description: undefined, format: undefined, example: undefined },
                 },
                 type: 'object',
                 default: undefined,
@@ -1253,6 +1264,26 @@ describe('Definition generation', () => {
                   },
                 },
                 required: ['value4'],
+                type: 'object',
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
+                description: undefined,
+              },
+              `for schema linked by property ${propertyName}`,
+            );
+
+            const heritageCheck2 = getValidatedDefinition('HeritageTestModel2', currentSpec);
+            expect(heritageCheck2).to.deep.eq(
+              {
+                properties: {
+                  value: {
+                    default: undefined,
+                    description: undefined,
+                    format: undefined,
+                    example: undefined,
+                    type: 'string',
+                  },
+                },
+                required: ['value'],
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
                 description: undefined,

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -100,7 +100,9 @@ describe('Definition generation', () => {
     it('should not generate a definition for heritage interfaces', () => {
       allSpecs.forEach(currentSpec => {
         const expectedModels = [
-          //TypeAlias4 is a herritage interface for HeritageTestModel
+          // TypeAlias4 is a herritage interface for HeritageTestModel, so it should not be found.
+          // If typeAlias4 is ever added to the test model itself, this test may fail even if the it is still working.
+          // In case of failure, check to see if TypeAlias4 is being used not as a heritage type.
           'TypeAlias4',
         ];
         expectedModels.forEach(modelName => {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -66,6 +66,17 @@ describe('Definition generation', () => {
     return definition;
   };
 
+  const ValidateOmitted = (name: string, chosenSpec: SpecAndName) => {
+    if (!chosenSpec.spec.definitions) {
+      return;
+    }
+
+    const definition = chosenSpec.spec.definitions[name];
+    if (definition) {
+      throw new Error(`${name} should not have been automatically generated in ${chosenSpec.specName}.`);
+    }
+  };
+
   function forSpec(chosenSpec: SpecAndName): string {
     return `for the ${chosenSpec.specName} spec`;
   }
@@ -86,6 +97,18 @@ describe('Definition generation', () => {
   });
 
   describe('Interface-based generation', () => {
+    it('should not generate a definition for heritage interfaces', () => {
+      allSpecs.forEach(currentSpec => {
+        const expectedModels = [
+          //TypeAlias4 is a herritage interface for HeritageTestModel
+          'TypeAlias4',
+        ];
+        expectedModels.forEach(modelName => {
+          ValidateOmitted(modelName, currentSpec);
+        });
+      });
+    });
+
     it('should generate a definition for referenced models', () => {
       allSpecs.forEach(currentSpec => {
         const expectedModels = [

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1767,6 +1767,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   readonlyClass: { $ref: '#/components/schemas/Readonly_TestClassModel_', description: undefined, format: undefined, example: undefined },
                   defaultArgs: { $ref: '#/components/schemas/DefaultTestModel', description: undefined, format: undefined, example: undefined },
                   heritageCheck: { $ref: '#/components/schemas/HeritageTestModel', description: undefined, format: undefined, example: undefined },
+                  heritageCheck2: { $ref: '#/components/schemas/HeritageTestModel2', description: undefined, format: undefined, example: undefined },
                 },
                 type: 'object',
                 default: undefined,
@@ -2234,6 +2235,20 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   name: { type: 'string', description: undefined, format: undefined, example: undefined, default: undefined },
                 },
                 required: ['value4'],
+                type: 'object',
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+                description: undefined,
+              },
+              `for schema linked by property ${propertyName}`,
+            );
+
+            const heritageCheck2 = getComponentSchema('HeritageTestModel2', currentSpec);
+            expect(heritageCheck2).to.deep.eq(
+              {
+                properties: {
+                  value: { type: 'string', description: undefined, format: undefined, example: undefined, default: undefined },
+                },
+                required: ['value'],
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Closing issues**

closes #1330 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->

Negative test was added, though it is relatively brittle.  The goal of this change is to ensure that heritage types for interfaces do not get added to the refType map simply because they are heritage types.  To test this, first a new model was created, HeritageTestModel2.  This was done so that any changes changes to or expectations upon HeritageTestModel will not affect this test.  HeritageTestModel extends HeritageBaseModel. In the fixture that includes HeritageTestModel, a test was added to ensure that HeritageTestModel2 is created, but HeritageBaseModel is not.  This can be broken if HeritageTestModel2's heritage is changed, and the the test will still pass.  It can also be broken be adding HeritageBaseModel to the model so that it is included in the refType map.  This would cause the test to fail even though it is doing what it is supposed to do.  It was verified that by adding a type which is in the refType map, the test fails.

Another test was added so that if HeritageTestModel2 is never found, it alerts the tester that this was a false positive.