### PR TITLE
Fix for custom route generator - move default middleware in CLI

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -196,7 +196,6 @@ const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfi
 
   const noImplicitAdditionalProperties = determineNoImplicitAdditionalSetting(config.noImplicitAdditionalProperties);
   config.routes.basePath = config.routes.basePath || '/';
-  config.routes.middleware = config.routes.middleware || 'express';
 
   return {
     ...config.routes,

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -29,9 +29,6 @@ export async function generateRoutes<Config extends ExtendedRoutesConfig>(
 
 async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: Tsoa.Metadata, routesConfig: Config) {
   // default route generator for express/koa/hapi
-  if (routesConfig.middleware !== undefined || routesConfig.middlewareTemplate !== undefined) {
-    return new DefaultRouteGenerator(metadata, routesConfig);
-  }
   // custom route generator
   if (routesConfig.routeGenerator !== undefined) {
     try {
@@ -45,7 +42,11 @@ async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: 
       return new module.default(metadata, routesConfig);
     }
   }
+  if (routesConfig.middleware !== undefined || routesConfig.middlewareTemplate !== undefined) {
+    return new DefaultRouteGenerator(metadata, routesConfig);
+  }
   else {
-    throw new Error("Routes cannot be generated. One of 'middleware', 'middlewareTemplate', or 'routeGenerator' must be confgured")
+    routesConfig.middleware = 'express';
+    return new DefaultRouteGenerator(metadata, routesConfig);
   }
 }

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -45,4 +45,7 @@ async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: 
       return new module.default(metadata, routesConfig);
     }
   }
+  else {
+    throw new Error("Routes cannot be generated. One of 'middleware', 'middlewareTemplate', or 'routeGenerator' must be confgured")
+  }
 }


### PR DESCRIPTION
Fixes issue that prevents using the new custom generator from the CLI because a default is set to 'express'. Keeps the default of using 'express', but moves setting of this default to later in the process to accommodate custom route generators.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Test plan**

Fully backwards compatible with existing tests and configurations
