### PR TITLE
Allow custom routeGenerator to be passed as type reference.

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { MetadataGenerator } from './metadataGeneration/metadataGenerator';
 import { generateRoutes } from './module/generate-routes';
 import { generateSpec } from './module/generate-spec';
 import { fsExists, fsReadFile } from './utils/fs';
+import { AbstractRouteGenerator } from './routeGeneration/routeGenerator';
 
 const workingDir: string = process.cwd();
 
@@ -172,7 +173,7 @@ export interface ExtendedRoutesConfig extends RoutesConfig {
   controllerPathGlobs?: Config['controllerPathGlobs'];
   multerOpts?: Config['multerOpts'];
   rootSecurity?: Config['spec']['rootSecurity'];
-  routeGenerator?: string | any;
+  routeGenerator?: string | typeof AbstractRouteGenerator | unknown;
 }
 
 const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfig> => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -172,7 +172,7 @@ export interface ExtendedRoutesConfig extends RoutesConfig {
   controllerPathGlobs?: Config['controllerPathGlobs'];
   multerOpts?: Config['multerOpts'];
   rootSecurity?: Config['spec']['rootSecurity'];
-  routeGenerator?: string;
+  routeGenerator?: string | any;
 }
 
 const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfig> => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -167,13 +167,15 @@ export const validateSpecConfig = async (config: Config): Promise<ExtendedSpecCo
   };
 };
 
+type RouteGeneratorImpl = new (metadata: Tsoa.Metadata, options: ExtendedRoutesConfig) => AbstractRouteGenerator<any>;
+
 export interface ExtendedRoutesConfig extends RoutesConfig {
   entryFile: Config['entryFile'];
   noImplicitAdditionalProperties: Exclude<Config['noImplicitAdditionalProperties'], undefined>;
   controllerPathGlobs?: Config['controllerPathGlobs'];
   multerOpts?: Config['multerOpts'];
   rootSecurity?: Config['spec']['rootSecurity'];
-  routeGenerator?: string | typeof AbstractRouteGenerator | unknown;
+  routeGenerator?: string | RouteGeneratorImpl;
 }
 
 const validateRoutesConfig = async (config: Config): Promise<ExtendedRoutesConfig> => {

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -5,7 +5,6 @@ import { Tsoa } from '@tsoa/runtime';
 import { DefaultRouteGenerator } from '../routeGeneration/defaultRouteGenerator';
 import { fsMkDir } from '../utils/fs';
 import path = require('path');
-import { AbstractRouteGenerator } from '../routeGeneration/routeGenerator';
 
 export async function generateRoutes<Config extends ExtendedRoutesConfig>(
   routesConfig: Config,
@@ -31,24 +30,21 @@ export async function generateRoutes<Config extends ExtendedRoutesConfig>(
 async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: Tsoa.Metadata, routesConfig: Config) {
   // default route generator for express/koa/hapi
   // custom route generator
-  if (routesConfig.routeGenerator !== undefined) {
-    if (typeof routesConfig.routeGenerator === 'string') {
+  const routeGenerator = routesConfig.routeGenerator;
+  if (routeGenerator !== undefined) {
+    if (typeof routeGenerator === 'string') {
       try {
         // try as a module import
-        const module = await import(routesConfig.routeGenerator);
+        const module = await import(routeGenerator);
         return new module.default(metadata, routesConfig);
       } catch (_err) {
         // try to find a relative import path
-        const relativePath = path.relative(__dirname, routesConfig.routeGenerator);
+        const relativePath = path.relative(__dirname, routeGenerator);
         const module = await import(relativePath);
         return new module.default(metadata, routesConfig);
       }
     } else {
-      if (routesConfig.routeGenerator.prototype instanceof AbstractRouteGenerator<any>) {
-        return new routesConfig.routeGenerator(metadata, routesConfig);
-      } else {
-        throw new Error('routeGenerator is not a string nor a type that extends AbstractRouteGenerator');
-      }
+      return new routeGenerator(metadata, routesConfig);
     }
   }
   if (routesConfig.middleware !== undefined || routesConfig.middlewareTemplate !== undefined) {

--- a/tests/esm/fixtures/templating/dummyRouteGenerator.ts
+++ b/tests/esm/fixtures/templating/dummyRouteGenerator.ts
@@ -1,0 +1,14 @@
+import { AbstractRouteGenerator } from '@tsoa/cli';
+
+export class DummyRouteGenerator extends AbstractRouteGenerator<any> {
+  private static CALL_COUNT = 0;
+
+  GenerateCustomRoutes(): Promise<void> {
+    DummyRouteGenerator.CALL_COUNT += 1;
+    return Promise.resolve(undefined);
+  }
+
+  public static getCallCount(): number {
+    return this.CALL_COUNT;
+  }
+}

--- a/tests/esm/unit/templating/routeGenerator.spec.ts
+++ b/tests/esm/unit/templating/routeGenerator.spec.ts
@@ -25,19 +25,5 @@ describe('RouteGenerator', () => {
       // Assert
       expect(DummyRouteGenerator.getCallCount()).gt(0);
     });
-
-    it('should throw an exception when the provided routeGenerator has incorrect type', async () => {
-      // Arrange
-      const routesConfig: ExtendedRoutesConfig = {
-        entryFile: 'index.ts',
-        noImplicitAdditionalProperties: 'silently-remove-extras',
-        routesDir: 'dist/routes',
-        controllerPathGlobs: ['fixtures/controllers/*.ts'],
-        routeGenerator: 1337,
-      };
-
-      // Act / Assert
-      expect(generateRoutes(routesConfig)).to.eventually.be.rejectedWith(Error);
-    });
   });
 });

--- a/tests/esm/unit/templating/routeGenerator.spec.ts
+++ b/tests/esm/unit/templating/routeGenerator.spec.ts
@@ -1,0 +1,43 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+import { ExtendedRoutesConfig, generateRoutes } from 'tsoa';
+import { DummyRouteGenerator } from '../../fixtures/templating/dummyRouteGenerator';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('RouteGenerator', () => {
+  describe('.generateRoutes', () => {
+    it('should instance and call a custom route generator provided as type reference', async () => {
+      // Arrange
+      const routesConfig: ExtendedRoutesConfig = {
+        entryFile: 'index.ts',
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        routesDir: 'dist/routes',
+        controllerPathGlobs: ['fixtures/controllers/*.ts'],
+        routeGenerator: DummyRouteGenerator,
+      };
+
+      // Act
+      await generateRoutes(routesConfig);
+
+      // Assert
+      expect(DummyRouteGenerator.getCallCount()).gt(0);
+    });
+
+    it('should throw an exception when the provided routeGenerator has incorrect type', async () => {
+      // Arrange
+      const routesConfig: ExtendedRoutesConfig = {
+        entryFile: 'index.ts',
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        routesDir: 'dist/routes',
+        controllerPathGlobs: ['fixtures/controllers/*.ts'],
+        routeGenerator: 1337,
+      };
+
+      // Act / Assert
+      expect(generateRoutes(routesConfig)).to.eventually.be.rejectedWith(Error);
+    });
+  });
+});


### PR DESCRIPTION
This commit fixes #1373 by allowing a custom type to be passed to generateRoutes() routeGenerator. It is fully backwards compatible with the existing implementation.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #1373 

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

This commit is backwards compatible.

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
I didn't add any test as I didn't want to fiddle with ESM/CommonJS configs in the test suite. This commit does not change the existing behavior of the original implementation.