### PR TITLE
Fix CLI issue where -c didn't work

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as YAML from 'yamljs';
-import yargs from 'yargs';
+import * as yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { Config, RoutesConfig, SpecConfig, Tsoa } from '@tsoa/runtime';
 import { MetadataGenerator } from './metadataGeneration/metadataGenerator';


### PR DESCRIPTION
I created an extremely simple test project that worked and then narrowed the actual code down to this change.  I didn't see any unit tests for running the CLI, which is why I didn't add any new ones.  I think if there were existing tests, they would have broken whenever the yargs upgrade was made.

closes #1363
