### PR TITLE
feat: allow handling a path that has a suffix like :download

### DIFF
--- a/packages/cli/src/utils/pathUtils.ts
+++ b/packages/cli/src/utils/pathUtils.ts
@@ -25,7 +25,7 @@ export function convertColonPathParams(path: string) {
     return path;
   }
 
-  const normalised = path.replace(/:([^/]+)/g, '{$1}');
+  const normalised = path.replace(/:([^/:[\]]+)/g, '{$1}');
   return normalised;
 }
 

--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -146,6 +146,14 @@ export class GetTestController extends Controller {
     return model;
   }
 
+  @Get('{numberPathParam}:download')
+  public async getWithFormatSuffix(numberPathParam: number) {
+    const model = new ModelService().getModel();
+    model.numberValue = numberPathParam;
+
+    return model;
+  }
+
   @Get('AllQueriesInOneObject')
   public async getAllQueriesInOneObject(@Queries() queryParams: QueryParams) {
     const model = new ModelService().getModel();

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -164,6 +164,16 @@ export class ParameterController {
   }
 
   /**
+   * Query test paramater
+   *
+   * @param {string} firstname Firstname description
+   */
+  @Get('PathColonDelimiter/:firstname[:]download')
+  public async getPathWithSuffix(@Path() firstname: string): Promise<string> {
+    return Promise.resolve(firstname);
+  }
+
+  /**
    * Path test paramater
    *
    * @param {string} id ID description

--- a/tests/unit/swagger/common/paths.spec.ts
+++ b/tests/unit/swagger/common/paths.spec.ts
@@ -75,6 +75,10 @@ describe('Colon path params conversion', () => {
     expect(convertColonPathParams('/path1/:pathParam/path2')).to.equal('/path1/{pathParam}/path2');
   });
 
+  it('should leave [:]something alone in path', () => {
+    expect(convertColonPathParams(':pathParam[:]something')).to.equal('{pathParam}[:]something');
+  });
+
   it('should handle empty path', () => {
     expect(convertColonPathParams('')).to.equal('');
   });

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -612,6 +612,23 @@ describe('Metadata generation', () => {
       expect(genderParam.type.dataType).to.equal('refEnum');
     });
 
+    it('should generate a path parameter from colon delimiter path params with a [:]suffix', () => {
+      const method = controller.methods.find(m => m.name === 'getPathWithSuffix');
+      if (!method) {
+        throw new Error('Method getPathWithSuffix not defined!');
+      }
+
+      expect(method.parameters.length).to.equal(1);
+
+      const firstnameParam = method.parameters[0];
+      expect(firstnameParam.in).to.equal('path');
+      expect(firstnameParam.name).to.equal('firstname');
+      expect(firstnameParam.parameterName).to.equal('firstname');
+      expect(firstnameParam.description).to.equal('Firstname description');
+      expect(firstnameParam.required).to.be.true;
+      expect(firstnameParam.type.dataType).to.equal('string');
+    });
+
     it('should generate a path parameter from template literal', () => {
       const method = controller.methods.find(m => m.name === 'getPathTemplateLiteral');
       if (!method) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1390

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

**Test plan**

I think/hope that existing test coverage ensures that this doesn't break anything.
