### PR TITLE
Add default number type configuration

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -144,6 +144,10 @@ export const validateSpecConfig = async (config: Config): Promise<ExtendedSpecCo
     config.spec.contact.url = config.spec.contact.url || author?.url;
   }
 
+  if (!config.defaultNumberType) {
+    config.defaultNumberType = 'double';
+  }
+
   if (config.spec.rootSecurity) {
     if (!Array.isArray(config.spec.rootSecurity)) {
       throw new Error('spec.rootSecurity must be an array');
@@ -371,7 +375,7 @@ export async function generateSpecAndRoutes(args: SwaggerArgs, metadata?: Tsoa.M
     const swaggerConfig = await validateSpecConfig(config);
 
     if (!metadata) {
-      metadata = new MetadataGenerator(config.entryFile, compilerOptions, config.ignore, config.controllerPathGlobs, config.spec.rootSecurity).Generate();
+      metadata = new MetadataGenerator(config.entryFile, compilerOptions, config.ignore, config.controllerPathGlobs, config.spec.rootSecurity, config.defaultNumberType).Generate();
     }
 
     await Promise.all([generateRoutes(routesConfig, compilerOptions, config.ignore, metadata), generateSpec(swaggerConfig, compilerOptions, config.ignore, metadata)]);

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -2,7 +2,7 @@ import mm from 'minimatch';
 import { importClassesFromDirectories } from '../utils/importClassesFromDirectories';
 import { ControllerGenerator } from './controllerGenerator';
 import { GenerateMetadataError } from './exceptions';
-import { Tsoa } from '@tsoa/runtime';
+import {Config, Tsoa} from '@tsoa/runtime';
 import { TypeResolver } from './typeResolver';
 import { getDecorators } from '../utils/decoratorUtils';
 import { type TypeChecker, type Program, type ClassDeclaration, type CompilerOptions, createProgram, forEachChild, isClassDeclaration } from 'typescript';
@@ -20,6 +20,7 @@ export class MetadataGenerator {
     private readonly ignorePaths?: string[],
     controllers?: string[],
     private readonly rootSecurity: Tsoa.Security[] = [],
+    public readonly defaultNumberType: NonNullable<Config['defaultNumberType']> = 'double'
   ) {
     TypeResolver.clearCache();
     this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers) : createProgram([entryFile], compilerOptions || {});

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -2,7 +2,7 @@ import mm from 'minimatch';
 import { importClassesFromDirectories } from '../utils/importClassesFromDirectories';
 import { ControllerGenerator } from './controllerGenerator';
 import { GenerateMetadataError } from './exceptions';
-import {Config, Tsoa} from '@tsoa/runtime';
+import { Config, Tsoa } from '@tsoa/runtime';
 import { TypeResolver } from './typeResolver';
 import { getDecorators } from '../utils/decoratorUtils';
 import { type TypeChecker, type Program, type ClassDeclaration, type CompilerOptions, createProgram, forEachChild, isClassDeclaration } from 'typescript';

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -459,16 +459,18 @@ export class TypeResolver {
       return;
     }
 
+    const defaultNumberType = this.current.defaultNumberType
+
     if (resolution.resolvedType === 'number') {
       if (!parentNode) {
-        return { dataType: 'double' };
+        return { dataType: defaultNumberType};
       }
 
       const tags = getJSDocTagNames(parentNode).filter(name => {
         return ['isInt', 'isLong', 'isFloat', 'isDouble'].some(m => m === name);
       });
       if (tags.length === 0) {
-        return { dataType: 'double' };
+        return { dataType: defaultNumberType };
       }
 
       switch (tags[0]) {
@@ -481,7 +483,7 @@ export class TypeResolver {
         case 'isDouble':
           return { dataType: 'double' };
         default:
-          return { dataType: 'double' };
+          return { dataType: defaultNumberType };
       }
     } else if (resolution.resolvedType === 'string') {
       return {

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -5,6 +5,7 @@ import { Tsoa } from '@tsoa/runtime';
 import { DefaultRouteGenerator } from '../routeGeneration/defaultRouteGenerator';
 import { fsMkDir } from '../utils/fs';
 import path = require('path');
+import {Config as BaseConfig } from "@tsoa/runtime";
 
 export async function generateRoutes<Config extends ExtendedRoutesConfig>(
   routesConfig: Config,
@@ -14,9 +15,10 @@ export async function generateRoutes<Config extends ExtendedRoutesConfig>(
    * pass in cached metadata returned in a previous step to speed things up
    */
   metadata?: Tsoa.Metadata,
+  defaultNumberType?: BaseConfig['defaultNumberType']
 ) {
   if (!metadata) {
-    metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, ignorePaths, routesConfig.controllerPathGlobs, routesConfig.rootSecurity).Generate();
+    metadata = new MetadataGenerator(routesConfig.entryFile, compilerOptions, ignorePaths, routesConfig.controllerPathGlobs, routesConfig.rootSecurity, defaultNumberType).Generate();
   }
 
   const routeGenerator = await getRouteGenerator(metadata, routesConfig);

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -5,7 +5,7 @@ import { Tsoa } from '@tsoa/runtime';
 import { DefaultRouteGenerator } from '../routeGeneration/defaultRouteGenerator';
 import { fsMkDir } from '../utils/fs';
 import path = require('path');
-import {Config as BaseConfig } from "@tsoa/runtime";
+import { Config as BaseConfig } from "@tsoa/runtime";
 
 export async function generateRoutes<Config extends ExtendedRoutesConfig>(
   routesConfig: Config,

--- a/packages/cli/src/module/generate-spec.ts
+++ b/packages/cli/src/module/generate-spec.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import * as YAML from 'yamljs';
 import { ExtendedSpecConfig } from '../cli';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
-import { Tsoa, Swagger } from '@tsoa/runtime';
+import {Tsoa, Swagger, Config} from '@tsoa/runtime';
 import { SpecGenerator2 } from '../swagger/specGenerator2';
 import { SpecGenerator3 } from '../swagger/specGenerator3';
 import { fsMkDir, fsWriteFile } from '../utils/fs';
@@ -22,9 +22,10 @@ export const generateSpec = async (
    * pass in cached metadata returned in a previous step to speed things up
    */
   metadata?: Tsoa.Metadata,
+  defaultNumberType?: Config['defaultNumberType']
 ) => {
   if (!metadata) {
-    metadata = new MetadataGenerator(swaggerConfig.entryFile, compilerOptions, ignorePaths, swaggerConfig.controllerPathGlobs, swaggerConfig.rootSecurity).Generate();
+    metadata = new MetadataGenerator(swaggerConfig.entryFile, compilerOptions, ignorePaths, swaggerConfig.controllerPathGlobs, swaggerConfig.rootSecurity, defaultNumberType).Generate();
   }
 
   let spec: Swagger.Spec;

--- a/packages/cli/src/module/generate-spec.ts
+++ b/packages/cli/src/module/generate-spec.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import * as YAML from 'yamljs';
 import { ExtendedSpecConfig } from '../cli';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
-import {Tsoa, Swagger, Config} from '@tsoa/runtime';
+import { Tsoa, Swagger, Config } from '@tsoa/runtime';
 import { SpecGenerator2 } from '../swagger/specGenerator2';
 import { SpecGenerator3 } from '../swagger/specGenerator3';
 import { fsMkDir, fsWriteFile } from '../utils/fs';

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -49,6 +49,13 @@ export interface Config {
    * } Allow multer to write to file instead of using Memory's buffer
    */
   multerOpts?: MulterOpts;
+
+
+  /*
+   * OpenAPI number type to be used for TypeScript's 'number', when there isn't a type annotation
+   * @default double
+   */
+  defaultNumberType?: 'double' | 'float' | 'integer' | 'long'
 }
 
 /**

--- a/tests/fixtures/controllers/annotatedTypesController.ts
+++ b/tests/fixtures/controllers/annotatedTypesController.ts
@@ -1,0 +1,35 @@
+import {Route} from "@tsoa/runtime/decorators/route";
+import {Get} from "@tsoa/runtime/decorators/methods";
+
+@Route('AnnotatedTypesTest')
+export class AnnotatedTypesController {
+
+  @Get('/default')
+  public async getDefault(): Promise<{
+    number: number
+  }> {
+    return {
+      number: 5
+    }
+  }
+
+  @Get('/integer')
+  public async getInteger(): Promise<{
+    /** @isInt */
+    number: number
+  }> {
+    return {
+      number: 5
+    }
+  }
+
+  @Get('/double')
+  public async getDouble(): Promise<{
+    /** @isDouble */
+    number: number
+  }> {
+    return {
+      number: 5
+    }
+  }
+}

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1,9 +1,9 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 import 'mocha';
-import {MetadataGenerator} from '@tsoa/cli/metadataGeneration/metadataGenerator';
-import {Tsoa} from '@tsoa/runtime';
-import {SpecGenerator2} from '@tsoa/cli/swagger/specGenerator2';
-import {getDefaultExtendedOptions} from '../../../fixtures/defaultOptions';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { Tsoa } from '@tsoa/runtime';
+import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
+import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
 
 describe('Metadata generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -177,7 +177,7 @@ describe('Metadata generation', () => {
       const defaultResponse = method.responses[2];
       expect(defaultResponse.name).to.equal('default');
       expect(defaultResponse.description).to.equal('Unexpected error');
-      expect(defaultResponse.examples).to.deep.equal([{status: 500, message: 'Something went wrong!'}]);
+      expect(defaultResponse.examples).to.deep.equal([{ status: 500, message: 'Something went wrong!' }]);
 
       const successResponse = method.responses[3];
       expect(successResponse.name).to.equal('200');
@@ -306,18 +306,15 @@ describe('Metadata generation', () => {
       }
 
       const expectedExtensions = [
-        {key: 'x-attKey', value: 'attValue'},
-        {key: 'x-attKey1', value: 123},
-        {key: 'x-attKey2', value: true},
-        {key: 'x-attKey3', value: null},
-        {key: 'x-attKey4', value: {test: 'testVal'}},
-        {key: 'x-attKey5', value: ['y0', 'y1', 123, true, null]},
-        {key: 'x-attKey6', value: [{y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null}, {y2: 'yt2'}]},
-        {key: 'x-attKey7', value: {test: ['testVal', 123, true, null]}},
-        {
-          key: 'x-attKey8',
-          value: {test: {testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]]}}
-        },
+        { key: 'x-attKey', value: 'attValue' },
+        { key: 'x-attKey1', value: 123 },
+        { key: 'x-attKey2', value: true },
+        { key: 'x-attKey3', value: null },
+        { key: 'x-attKey4', value: { test: 'testVal' } },
+        { key: 'x-attKey5', value: ['y0', 'y1', 123, true, null] },
+        { key: 'x-attKey6', value: [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }] },
+        { key: 'x-attKey7', value: { test: ['testVal', 123, true, null] } },
+        { key: 'x-attKey8', value: { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } } },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);
@@ -376,8 +373,8 @@ describe('Metadata generation', () => {
       const genderParam = method.parameters[2];
       expect(genderParam.example).not.to.be.undefined;
       expect(genderParam.example).to.deep.equal([
-        {MALE: 'MALE', FEMALE: 'FEMALE'},
-        {MALE: 'MALE2', FEMALE: 'FEMALE2'},
+        { MALE: 'MALE', FEMALE: 'FEMALE' },
+        { MALE: 'MALE2', FEMALE: 'FEMALE2' },
       ]);
       expect((genderParam.example as unknown[]).length).to.be.equal(2);
 
@@ -462,7 +459,7 @@ describe('Metadata generation', () => {
       expect(nicknamesParam.required).to.be.true;
       expect(nicknamesParam.type.dataType).to.equal('array');
       expect(nicknamesParam.collectionFormat).to.equal('multi');
-      expect(nicknamesParam.type.elementType).to.deep.equal({dataType: 'string'});
+      expect(nicknamesParam.type.elementType).to.deep.equal({ dataType: 'string' });
       expect(nicknamesParam.example).to.be.undefined;
     });
 
@@ -1047,47 +1044,39 @@ describe('Metadata generation', () => {
 
   describe('AnnotatedTypesControllerGenerator', () => {
     const metadata = new MetadataGenerator('./fixtures/controllers/annotatedTypesController.ts').Generate();
-    const metadataIntDefault = new MetadataGenerator(
-      './fixtures/controllers/annotatedTypesController.ts',
-      undefined, undefined, undefined, undefined,
-      'integer'
-    ).Generate();
+    const metadataIntDefault = new MetadataGenerator('./fixtures/controllers/annotatedTypesController.ts', undefined, undefined, undefined, undefined, 'integer').Generate();
 
     const controller = metadata.controllers.find(controller => controller.name === 'AnnotatedTypesController');
     const controllerIntDefault = metadataIntDefault.controllers.find(controller => controller.name === 'AnnotatedTypesController');
 
     if (!controller || !controllerIntDefault) throw new Error('AnnotatedTypesController not defined!');
 
-
-    const getControllerNumberMethods = (controller) => {
+    const getControllerNumberMethods = controller => {
       const getDefault = controller.methods.find(method => method.name === 'getDefault');
       const getDouble = controller.methods.find(method => method.name === 'getDouble');
       const getInteger = controller.methods.find(method => method.name === 'getInteger');
       if (!getDefault || !getDouble || !getInteger) throw new Error('Methods not defined!');
-      return {getDefault, getDouble, getInteger}
-    }
+      return { getDefault, getDouble, getInteger };
+    };
 
     const checkNumberType = (method: Tsoa.Method, numberType: string) => {
-      const numberDataType =
-        (method.responses[0].schema as Tsoa.NestedObjectLiteralType)
-          .properties.find(p => p.name === 'number')
-          ?.type.dataType
+      const numberDataType = (method.responses[0].schema as Tsoa.NestedObjectLiteralType).properties.find(p => p.name === 'number')?.type.dataType;
 
-      expect(numberDataType).to.equal(numberType)
-    }
+      expect(numberDataType).to.equal(numberType);
+    };
 
     it('Double default number type is applied correctly', () => {
-      const {getDefault, getDouble, getInteger} = getControllerNumberMethods(controller)
-      checkNumberType(getDefault, 'double')
-      checkNumberType(getDouble, 'double')
-      checkNumberType(getInteger, 'integer')
+      const { getDefault, getDouble, getInteger } = getControllerNumberMethods(controller);
+      checkNumberType(getDefault, 'double');
+      checkNumberType(getDouble, 'double');
+      checkNumberType(getInteger, 'integer');
     });
 
-    it.only('Integer default number type is applied correctly', () => {
-      const {getDefault, getDouble, getInteger} = getControllerNumberMethods(controllerIntDefault)
-      checkNumberType(getDefault, 'integer')
-      checkNumberType(getDouble, 'double')
-      checkNumberType(getInteger, 'integer')
+    it('Integer default number type is applied correctly', () => {
+      const { getDefault, getDouble, getInteger } = getControllerNumberMethods(controllerIntDefault);
+      checkNumberType(getDefault, 'integer');
+      checkNumberType(getDouble, 'double');
+      checkNumberType(getInteger, 'integer');
     });
   });
 });

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import 'mocha';
-import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
-import { Tsoa } from '@tsoa/runtime';
-import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
-import { getDefaultExtendedOptions } from '../../../fixtures/defaultOptions';
+import {MetadataGenerator} from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import {Tsoa} from '@tsoa/runtime';
+import {SpecGenerator2} from '@tsoa/cli/swagger/specGenerator2';
+import {getDefaultExtendedOptions} from '../../../fixtures/defaultOptions';
 
 describe('Metadata generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -177,7 +177,7 @@ describe('Metadata generation', () => {
       const defaultResponse = method.responses[2];
       expect(defaultResponse.name).to.equal('default');
       expect(defaultResponse.description).to.equal('Unexpected error');
-      expect(defaultResponse.examples).to.deep.equal([{ status: 500, message: 'Something went wrong!' }]);
+      expect(defaultResponse.examples).to.deep.equal([{status: 500, message: 'Something went wrong!'}]);
 
       const successResponse = method.responses[3];
       expect(successResponse.name).to.equal('200');
@@ -306,15 +306,18 @@ describe('Metadata generation', () => {
       }
 
       const expectedExtensions = [
-        { key: 'x-attKey', value: 'attValue' },
-        { key: 'x-attKey1', value: 123 },
-        { key: 'x-attKey2', value: true },
-        { key: 'x-attKey3', value: null },
-        { key: 'x-attKey4', value: { test: 'testVal' } },
-        { key: 'x-attKey5', value: ['y0', 'y1', 123, true, null] },
-        { key: 'x-attKey6', value: [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }] },
-        { key: 'x-attKey7', value: { test: ['testVal', 123, true, null] } },
-        { key: 'x-attKey8', value: { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } } },
+        {key: 'x-attKey', value: 'attValue'},
+        {key: 'x-attKey1', value: 123},
+        {key: 'x-attKey2', value: true},
+        {key: 'x-attKey3', value: null},
+        {key: 'x-attKey4', value: {test: 'testVal'}},
+        {key: 'x-attKey5', value: ['y0', 'y1', 123, true, null]},
+        {key: 'x-attKey6', value: [{y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null}, {y2: 'yt2'}]},
+        {key: 'x-attKey7', value: {test: ['testVal', 123, true, null]}},
+        {
+          key: 'x-attKey8',
+          value: {test: {testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]]}}
+        },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);
@@ -373,8 +376,8 @@ describe('Metadata generation', () => {
       const genderParam = method.parameters[2];
       expect(genderParam.example).not.to.be.undefined;
       expect(genderParam.example).to.deep.equal([
-        { MALE: 'MALE', FEMALE: 'FEMALE' },
-        { MALE: 'MALE2', FEMALE: 'FEMALE2' },
+        {MALE: 'MALE', FEMALE: 'FEMALE'},
+        {MALE: 'MALE2', FEMALE: 'FEMALE2'},
       ]);
       expect((genderParam.example as unknown[]).length).to.be.equal(2);
 
@@ -459,7 +462,7 @@ describe('Metadata generation', () => {
       expect(nicknamesParam.required).to.be.true;
       expect(nicknamesParam.type.dataType).to.equal('array');
       expect(nicknamesParam.collectionFormat).to.equal('multi');
-      expect(nicknamesParam.type.elementType).to.deep.equal({ dataType: 'string' });
+      expect(nicknamesParam.type.elementType).to.deep.equal({dataType: 'string'});
       expect(nicknamesParam.example).to.be.undefined;
     });
 
@@ -1039,6 +1042,52 @@ describe('Metadata generation', () => {
       }
       expect(method.responses[0].name).to.equal(200);
       expect(method.responses[0].description).to.equal(description);
+    });
+  });
+
+  describe('AnnotatedTypesControllerGenerator', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/annotatedTypesController.ts').Generate();
+    const metadataIntDefault = new MetadataGenerator(
+      './fixtures/controllers/annotatedTypesController.ts',
+      undefined, undefined, undefined, undefined,
+      'integer'
+    ).Generate();
+
+    const controller = metadata.controllers.find(controller => controller.name === 'AnnotatedTypesController');
+    const controllerIntDefault = metadataIntDefault.controllers.find(controller => controller.name === 'AnnotatedTypesController');
+
+    if (!controller || !controllerIntDefault) throw new Error('AnnotatedTypesController not defined!');
+
+
+    const getControllerNumberMethods = (controller) => {
+      const getDefault = controller.methods.find(method => method.name === 'getDefault');
+      const getDouble = controller.methods.find(method => method.name === 'getDouble');
+      const getInteger = controller.methods.find(method => method.name === 'getInteger');
+      if (!getDefault || !getDouble || !getInteger) throw new Error('Methods not defined!');
+      return {getDefault, getDouble, getInteger}
+    }
+
+    const checkNumberType = (method: Tsoa.Method, numberType: string) => {
+      const numberDataType =
+        (method.responses[0].schema as Tsoa.NestedObjectLiteralType)
+          .properties.find(p => p.name === 'number')
+          ?.type.dataType
+
+      expect(numberDataType).to.equal(numberType)
+    }
+
+    it('Double default number type is applied correctly', () => {
+      const {getDefault, getDouble, getInteger} = getControllerNumberMethods(controller)
+      checkNumberType(getDefault, 'double')
+      checkNumberType(getDouble, 'double')
+      checkNumberType(getInteger, 'integer')
+    });
+
+    it.only('Integer default number type is applied correctly', () => {
+      const {getDefault, getDouble, getInteger} = getControllerNumberMethods(controllerIntDefault)
+      checkNumberType(getDefault, 'integer')
+      checkNumberType(getDouble, 'double')
+      checkNumberType(getInteger, 'integer')
     });
   });
 });


### PR DESCRIPTION
Hi, some time back I've asked about default number types, but unfortunately the issue was closed as stale - https://github.com/lukeautry/tsoa/issues/1408. I went ahead and implemented it anyway as it is super useful for my project. I think it's quite useful, as double as the default number type isn't suitable, if the backend uses for example number ids for entities. The amount of annotation is then just too damn high. 

I wasn't sure how to write proper test for this, as I could find any configuration tests.


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Put `closes #1408`

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

**Test plan**

