### PR TITLE
feat: Document required + default as optional

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,31 +5,31 @@
       "type": "node",
       "request": "launch",
       "name": "Mocha TS Tests",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceRoot}/tests",
       "env": {
         "NODE_ENV": "tsoa_test"
       },
-      "args": ["'**/*spec.ts'", "--debug", "--debug-brk", "--require", "ts-node/register", "--require", "tsconfig-paths/register", "--colors"],
+      "args": ["**/*.spec.ts"],
+      "runtimeArgs": ["--inspect", "--inspect-brk"],
       "preLaunchTask": "prepareFiles",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "protocol": "inspector"
+      "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",
       "request": "launch",
       "name": "Mocha TS Tests: Current File",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceRoot}/tests",
       "env": {
         "NODE_ENV": "tsoa_test"
       },
-      "args": ["${file}", "--debug", "--debug-brk", "--require", "ts-node/register", "--require", "tsconfig-paths/register", "--colors"],
+      "args": ["${file}", "--timeout", "0"],
+      "runtimeArgs": ["--inspect", "--inspect-brk"],
       "preLaunchTask": "prepareFiles",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "protocol": "inspector"
+      "internalConsoleOptions": "neverOpen"
     },
     {
       "name": "Generate",

--- a/packages/cli/src/swagger/specGenerator.ts
+++ b/packages/cli/src/swagger/specGenerator.ts
@@ -107,7 +107,7 @@ export abstract class SpecGenerator {
 
     const additionalProperties = objectLiteral.additionalProperties && this.getSwaggerType(objectLiteral.additionalProperties);
 
-    const required = objectLiteral.properties.filter(prop => prop.required && !this.hasUndefined(prop)).map(prop => prop.name);
+    const required = objectLiteral.properties.filter(prop => prop.required && !this.hasUndefined(prop) && prop.default == null).map(prop => prop.name);
 
     // An empty list required: [] is not valid.
     // If all properties are optional, do not specify the required keyword.
@@ -218,7 +218,7 @@ export abstract class SpecGenerator {
       description: property.description,
       in: 'query',
       name: property.name,
-      required: property.required,
+      required: property.required && property.default == null,
       type: property.type,
       default: property.default,
       validators: property.validators,

--- a/packages/cli/src/swagger/specGenerator.ts
+++ b/packages/cli/src/swagger/specGenerator.ts
@@ -107,7 +107,7 @@ export abstract class SpecGenerator {
 
     const additionalProperties = objectLiteral.additionalProperties && this.getSwaggerType(objectLiteral.additionalProperties);
 
-    const required = objectLiteral.properties.filter(prop => prop.required && !this.hasUndefined(prop) && prop.default == null).map(prop => prop.name);
+    const required = objectLiteral.properties.filter(prop => this.isRequiredWithoutDefault(prop) && !this.hasUndefined(prop)).map(prop => prop.name);
 
     // An empty list required: [] is not valid.
     // If all properties are optional, do not specify the required keyword.
@@ -218,11 +218,15 @@ export abstract class SpecGenerator {
       description: property.description,
       in: 'query',
       name: property.name,
-      required: property.required && property.default == null,
+      required: this.isRequiredWithoutDefault(property),
       type: property.type,
       default: property.default,
       validators: property.validators,
       deprecated: property.deprecated,
     };
+  }
+
+  protected isRequiredWithoutDefault(prop: Tsoa.Property | Tsoa.Parameter): boolean | undefined {
+    return prop.required && prop.default == null;
   }
 }

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -82,7 +82,7 @@ export class SpecGenerator2 extends SpecGenerator {
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
       if (referenceType.dataType === 'refObject') {
-        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p)).map(p => p.name);
+        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p) && p.default == null).map(p => p.name);
         definitions[referenceType.refName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
@@ -281,7 +281,7 @@ export class SpecGenerator2 extends SpecGenerator {
         properties[p.name].description = p.description;
         properties[p.name].example = p.example === undefined ? undefined : p.example[0];
 
-        if (p.required) {
+        if (p.required && p.default == null) {
           required.push(p.name);
         }
       });
@@ -320,7 +320,7 @@ export class SpecGenerator2 extends SpecGenerator {
       description: source.description,
       in: source.in,
       name: source.name,
-      required: source.required,
+      required: source.required && source.default == null,
     } as Swagger.Parameter2;
     if (source.deprecated) {
       parameter['x-deprecated'] = true;

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -82,7 +82,7 @@ export class SpecGenerator2 extends SpecGenerator {
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
       if (referenceType.dataType === 'refObject') {
-        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p) && p.default == null).map(p => p.name);
+        const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
         definitions[referenceType.refName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
@@ -281,7 +281,7 @@ export class SpecGenerator2 extends SpecGenerator {
         properties[p.name].description = p.description;
         properties[p.name].example = p.example === undefined ? undefined : p.example[0];
 
-        if (p.required && p.default == null) {
+        if (this.isRequiredWithoutDefault(p)) {
           required.push(p.name);
         }
       });
@@ -320,7 +320,7 @@ export class SpecGenerator2 extends SpecGenerator {
       description: source.description,
       in: source.in,
       name: source.name,
-      required: source.required && source.default == null,
+      required: this.isRequiredWithoutDefault(source),
     } as Swagger.Parameter2;
     if (source.deprecated) {
       parameter['x-deprecated'] = true;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -151,7 +151,7 @@ export class SpecGenerator3 extends SpecGenerator {
       const referenceType = this.metadata.referenceTypeMap[typeName];
 
       if (referenceType.dataType === 'refObject') {
-        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p)).map(p => p.name);
+        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p) && p.default == null).map(p => p.name);
         schema[referenceType.refName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
@@ -369,7 +369,7 @@ export class SpecGenerator3 extends SpecGenerator {
             headers[each.name] = {
               schema: this.getSwaggerType(each.type) as Swagger.Schema3,
               description: each.description,
-              required: each.required,
+              required: each.required && each.default == null,
             };
           });
         } else {
@@ -393,7 +393,7 @@ export class SpecGenerator3 extends SpecGenerator {
     for (const parameter of parameters) {
       const mediaType = this.buildMediaType(controllerName, method, parameter);
       properties[parameter.name] = mediaType.schema!;
-      if (parameter.required) {
+      if (parameter.required && parameter.default == null) {
         required.push(parameter.name);
       }
       if (parameter.deprecated) {
@@ -423,7 +423,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     const requestBody: Swagger.RequestBody = {
       description: parameter.description,
-      required: parameter.required,
+      required: parameter.required && parameter.default == null,
       content: {
         [consumes]: mediaType,
       },
@@ -481,7 +481,7 @@ export class SpecGenerator3 extends SpecGenerator {
       description: source.description,
       in: source.in,
       name: source.name,
-      required: source.required,
+      required: source.required && source.default == null,
       schema: {
         default: source.default,
         format: undefined,

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -151,7 +151,7 @@ export class SpecGenerator3 extends SpecGenerator {
       const referenceType = this.metadata.referenceTypeMap[typeName];
 
       if (referenceType.dataType === 'refObject') {
-        const required = referenceType.properties.filter(p => p.required && !this.hasUndefined(p) && p.default == null).map(p => p.name);
+        const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
         schema[referenceType.refName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
@@ -369,7 +369,7 @@ export class SpecGenerator3 extends SpecGenerator {
             headers[each.name] = {
               schema: this.getSwaggerType(each.type) as Swagger.Schema3,
               description: each.description,
-              required: each.required && each.default == null,
+              required: this.isRequiredWithoutDefault(each),
             };
           });
         } else {
@@ -393,7 +393,7 @@ export class SpecGenerator3 extends SpecGenerator {
     for (const parameter of parameters) {
       const mediaType = this.buildMediaType(controllerName, method, parameter);
       properties[parameter.name] = mediaType.schema!;
-      if (parameter.required && parameter.default == null) {
+      if (this.isRequiredWithoutDefault(parameter)) {
         required.push(parameter.name);
       }
       if (parameter.deprecated) {
@@ -423,7 +423,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     const requestBody: Swagger.RequestBody = {
       description: parameter.description,
-      required: parameter.required && parameter.default == null,
+      required: this.isRequiredWithoutDefault(parameter),
       content: {
         [consumes]: mediaType,
       },
@@ -481,7 +481,7 @@ export class SpecGenerator3 extends SpecGenerator {
       description: source.description,
       in: source.in,
       name: source.name,
-      required: source.required && source.default == null,
+      required: this.isRequiredWithoutDefault(source),
       schema: {
         default: source.default,
         format: undefined,

--- a/tests/.mocharc.json
+++ b/tests/.mocharc.json
@@ -1,8 +1,8 @@
 {
   "extension": ["ts"],
-  "spec": ["**/*.spec.ts"],
   "timeout": "5000",
   "exclude": ["esm/**/*"],
   "require": ["ts-node/register", "tsconfig-paths/register"],
-  "exit": true
+  "exit": true,
+  "colors": true
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf --glob dist fixtures/*/routes.ts fixtures/*/customRoutes.ts fixtures/*/custom-route-generator/routes/*",
     "prepare-test": "cross-env NODE_ENV=tsoa_test ts-node --require=tsconfig-paths/register ./prepare.ts",
     "pretest": "yarn clean && yarn prepare-test && yarn typecheck",
-    "test": "cross-env NODE_ENV=tsoa_test mocha",
+    "test": "cross-env NODE_ENV=tsoa_test mocha \"**/*.spec.ts\"",
     "typecheck": "tsc"
   },
   "author": "Luke Autry <lukeautry@gmail.com> (http://www.lukeautry.com)",

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2844,4 +2844,29 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(currentSpec.paths['/ParameterTest/Inline1'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
     });
   });
+
+  describe('defaults on required properties should be documented as optional', () => {
+    it('on models', () => {
+      const testModel = getComponentSchema('TestModel', specDefault);
+
+      const prop = testModel.properties?.boolValue;
+
+      expect(prop).to.deep.eq(
+        {
+          type: 'boolean',
+          default: 'true',
+          description: undefined,
+          format: undefined,
+          example: undefined,
+        },
+        'boolValue has a default value of true',
+      );
+
+      expect(testModel.required).to.be.an('array');
+      expect(testModel.required).to.not.contain('boolValue', 'boolValue is not required');
+
+      // Others should still be required
+      expect(testModel.required).to.contain('boolArray', 'boolArray is required');
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,12 +6413,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
-
-typescript@^5.1.6:
+"typescript@>=3 < 6", typescript@^5.0.2, typescript@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==


### PR DESCRIPTION
Required + default does not make sense – if a value is required, the client must always send it, and the default value is never used.

For user convenience however, it makes sense in TypeScript to declare non-optional + default, since the validation layer fills defaults on required properties.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Should be considered breaking. Even though it should only reflect the actual behavior of the validation more accurately.
