### PR TITLE
fix(ESM): support mts and cts files

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -375,7 +375,7 @@ export async function generateSpecAndRoutes(args: SwaggerArgs, metadata?: Tsoa.M
     const swaggerConfig = await validateSpecConfig(config);
 
     if (!metadata) {
-      metadata = new MetadataGenerator(config.entryFile, compilerOptions, config.ignore, config.controllerPathGlobs, config.spec.rootSecurity, config.defaultNumberType).Generate();
+      metadata = new MetadataGenerator(config.entryFile, compilerOptions, config.ignore, config.controllerPathGlobs, config.spec.rootSecurity, config.defaultNumberType, config.routes.esm).Generate();
     }
 
     await Promise.all([generateRoutes(routesConfig, compilerOptions, config.ignore, metadata), generateSpec(swaggerConfig, compilerOptions, config.ignore, metadata)]);

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -21,7 +21,7 @@ export class MetadataGenerator {
     controllers?: string[],
     private readonly rootSecurity: Tsoa.Security[] = [],
     public readonly defaultNumberType: NonNullable<Config['defaultNumberType']> = 'double',
-    esm: boolean = false,
+    esm = false,
   ) {
     TypeResolver.clearCache();
     this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers, esm) : createProgram([entryFile], compilerOptions || {});

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -20,10 +20,11 @@ export class MetadataGenerator {
     private readonly ignorePaths?: string[],
     controllers?: string[],
     private readonly rootSecurity: Tsoa.Security[] = [],
-    public readonly defaultNumberType: NonNullable<Config['defaultNumberType']> = 'double'
+    public readonly defaultNumberType: NonNullable<Config['defaultNumberType']> = 'double',
+    esm: boolean = false,
   ) {
     TypeResolver.clearCache();
-    this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers) : createProgram([entryFile], compilerOptions || {});
+    this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers, esm) : createProgram([entryFile], compilerOptions || {});
     this.typeChecker = this.program.getTypeChecker();
   }
 
@@ -42,8 +43,8 @@ export class MetadataGenerator {
     };
   }
 
-  private setProgramToDynamicControllersFiles(controllers: string[]) {
-    const allGlobFiles = importClassesFromDirectories(controllers);
+  private setProgramToDynamicControllersFiles(controllers: string[], esm: boolean) {
+    const allGlobFiles = importClassesFromDirectories(controllers, esm ? ['.mts', '.ts', '.cts']: ['.ts']);
     if (allGlobFiles.length === 0) {
       throw new GenerateMetadataError(`[${controllers.join(', ')}] globs found 0 controllers.`);
     }

--- a/packages/cli/src/routeGeneration/defaultRouteGenerator.ts
+++ b/packages/cli/src/routeGeneration/defaultRouteGenerator.ts
@@ -41,16 +41,21 @@ export class DefaultRouteGenerator extends AbstractRouteGenerator<ExtendedRoutes
   }
 
   public async GenerateRoutes(middlewareTemplate: string) {
+    const allowedExtensions = this.options.esm ? ['.ts', '.mts', '.cts'] : ['.ts'];
+
     if (!fs.lstatSync(this.options.routesDir).isDirectory()) {
       throw new Error(`routesDir should be a directory`);
-    } else if (this.options.routesFileName !== undefined && !this.options.routesFileName.endsWith('.ts')) {
-      throw new Error(`routesFileName should have a '.ts' extension`);
+    } else if (this.options.routesFileName !== undefined) {
+      const ext = path.extname(this.options.routesFileName);
+      if (!allowedExtensions.includes(ext)) {
+        throw new Error(`routesFileName should be a valid typescript file.`);
+      }
     }
 
     const fileName = `${this.options.routesDir}/${this.options.routesFileName || 'routes.ts'}`;
     const content = this.buildContent(middlewareTemplate);
 
-    if(await this.shouldWriteFile(fileName, content)){
+    if (await this.shouldWriteFile(fileName, content)) {
       await fsWriteFile(fileName, content);
     }
   }

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -143,8 +143,26 @@ export abstract class AbstractRouteGenerator<Config extends ExtendedRoutesConfig
   }
 
   protected getRelativeImportPath(fileLocation: string) {
-    fileLocation = fileLocation.replace(/.ts$/, ''); // no ts extension in import
-    return `./${path.relative(this.options.routesDir, fileLocation).replace(/\\/g, '/')}${this.options.esm ? '.js' : ''}`;
+    const currentExt = path.extname(fileLocation);
+    let newExtension = "";
+    
+    if (this.options.esm) {
+      switch (currentExt) {
+        case '.ts':
+        default:
+          newExtension = '.js';
+        break;
+        case '.mts':
+          newExtension = '.mjs';
+        break;
+        case '.cts':
+          newExtension = '.cjs';
+        break;
+      }
+    }
+  
+    fileLocation = fileLocation.replace(currentExt, ''); // no ts extension in import
+    return `./${path.relative(this.options.routesDir, fileLocation).replace(/\\/g, '/')}${newExtension}`;
   }
 
   protected buildPropertySchema(source: Tsoa.Property): TsoaRoute.PropertySchema {

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -144,24 +144,24 @@ export abstract class AbstractRouteGenerator<Config extends ExtendedRoutesConfig
 
   protected getRelativeImportPath(fileLocation: string) {
     const currentExt = path.extname(fileLocation);
-    let newExtension = "";
-    
+    let newExtension = '';
+
     if (this.options.esm) {
       switch (currentExt) {
         case '.ts':
         default:
           newExtension = '.js';
-        break;
+          break;
         case '.mts':
           newExtension = '.mjs';
-        break;
+          break;
         case '.cts':
           newExtension = '.cjs';
-        break;
+          break;
       }
     }
-  
-    fileLocation = fileLocation.replace(currentExt, ''); // no ts extension in import
+
+    fileLocation = fileLocation.replace(/\.(ts|mts|cts)$/, ''); // no ts extension in import
     return `./${path.relative(this.options.routesDir, fileLocation).replace(/\\/g, '/')}${newExtension}`;
   }
 

--- a/tests/unit/templating/routeGenerator.spec.ts
+++ b/tests/unit/templating/routeGenerator.spec.ts
@@ -122,5 +122,57 @@ describe('RouteGenerator', () => {
 
       expect(models).to.equal('./controller.js');
     });
+
+    it('adds mjs for routes if esm is true and source is mts', () => {
+      const generator = new DefaultRouteGenerator(
+        {
+          controllers: [
+            {
+              location: 'controller.mts',
+              methods: [],
+              name: '',
+              path: '',
+            },
+          ],
+          referenceTypeMap: {},
+        },
+        {
+          entryFile: 'mockEntryFile',
+          routesDir: '.',
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          esm: true,
+        },
+      );
+
+      const models = generator.buildContent('{{#each controllers}}{{modulePath}}{{/each}}');
+
+      expect(models).to.equal('./controller.mjs');
+    });
+
+    it('adds cjs for routes if esm is true and source is cts', () => {
+      const generator = new DefaultRouteGenerator(
+        {
+          controllers: [
+            {
+              location: 'controller.cts',
+              methods: [],
+              name: '',
+              path: '',
+            },
+          ],
+          referenceTypeMap: {},
+        },
+        {
+          entryFile: 'mockEntryFile',
+          routesDir: '.',
+          noImplicitAdditionalProperties: 'silently-remove-extras',
+          esm: true,
+        },
+      );
+
+      const models = generator.buildContent('{{#each controllers}}{{modulePath}}{{/each}}');
+
+      expect(models).to.equal('./controller.cjs');
+    });
   });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue? #1307 

**Closing issues**
#1307 

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

Haven't had the ability to also test `.cts` files but I think this should be straight forward.

**Test plan**

I added two unit tests for the route generator method `getRelativeImportPath` that replaces the extension in controller files.