### PR TITLE
Correctly generate types for Record<string, T>

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -422,7 +422,7 @@ export class TypeResolver {
 
       if (typeReference.typeName.text === 'Record' && typeReference.typeArguments?.length === 2) {
         const indexType = new TypeResolver(typeReference.typeArguments[0], this.current, this.parentNode, this.context).resolve();
-        if (indexType.dataType === 'string') {
+        if (indexType.dataType === 'string' || indexType.dataType === 'integer' || indexType.dataType === 'double') {
           const valueType = new TypeResolver(typeReference.typeArguments[1], this.current, this.parentNode, this.context).resolve();
 
           const nestedObjectMetaType: Tsoa.NestedObjectLiteralType = {

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -420,6 +420,20 @@ export class TypeResolver {
         return stringMetaType;
       }
 
+      if (typeReference.typeName.text === 'Record' && typeReference.typeArguments?.length === 2) {
+        const indexType = new TypeResolver(typeReference.typeArguments[0], this.current, this.parentNode, this.context).resolve();
+        if (indexType.dataType === 'string') {
+          const valueType = new TypeResolver(typeReference.typeArguments[1], this.current, this.parentNode, this.context).resolve();
+
+          const nestedObjectMetaType: Tsoa.NestedObjectLiteralType = {
+            additionalProperties: valueType,
+            dataType: 'nestedObjectLiteral',
+            properties: [],
+          };
+          return nestedObjectMetaType;
+        }
+      }
+
       if (this.context[typeReference.typeName.text]) {
         return new TypeResolver(this.context[typeReference.typeName.text], this.current, this.parentNode, this.context).resolve();
       }
@@ -468,11 +482,11 @@ export class TypeResolver {
       return;
     }
 
-    const defaultNumberType = this.current.defaultNumberType
+    const defaultNumberType = this.current.defaultNumberType;
 
     if (resolution.resolvedType === 'number') {
       if (!parentNode) {
-        return { dataType: defaultNumberType};
+        return { dataType: defaultNumberType };
       }
 
       const tags = getJSDocTagNames(parentNode).filter(name => {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -78,7 +78,10 @@ export interface TestModel extends Model {
   parenthesizedIndexedValue?: ParenthesizedIndexedValue;
   indexedValueReference?: IndexedValueReference;
   indexedValueGeneric?: IndexedValueGeneric<IndexedValueTypeReference>;
-  record?: Record<'record-foo' | 'record-bar', { data: string }>;
+  stringUnionRecord?: Record<'record-foo' | 'record-bar', { data: string }>;
+  numberUnionRecord?: Record<1 | 2, { data: string }>;
+  stringRecord?: Record<string, { data: string }>;
+  numberRecord?: Record<number, { data: string }>;
   // modelsObjectDirect?: {[key: string]: TestSubModel2;};
   modelsObjectIndirect?: TestSubModelContainer;
   modelsObjectIndirectNS?: TestSubModelContainerNamespace.TestSubModelContainer;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -536,7 +536,7 @@ describe('Definition generation', () => {
           indexedValueGeneric: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/IndexedValueGeneric_IndexedValueTypeReference_');
           },
-          record: (propertyName, propertySchema) => {
+          stringUnionRecord: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/definitions/Record_record-foo-or-record-bar._data-string__');
             const schema = getValidatedDefinition('Record_record-foo-or-record-bar._data-string__', currentSpec);
             expect(schema).to.be.deep.eq({
@@ -569,6 +569,75 @@ describe('Definition generation', () => {
               example: undefined,
               format: undefined,
               description: 'Construct a type with a set of properties K of type T',
+            });
+          },
+          numberUnionRecord: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/Record_1-or-2._data-string__');
+            const schema = getValidatedDefinition('Record_1-or-2._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
+              properties: {
+                [1]: {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+                [2]: {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: 'Construct a type with a set of properties K of type T',
+            });
+          },
+          stringRecord: (propertyName, propertySchema) => {
+            expect(propertySchema).to.be.deep.eq({
+              properties: {},
+              additionalProperties: {
+                properties: {
+                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                },
+                required: ['data'],
+                type: 'object',
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: undefined,
+            });
+          },
+          numberRecord: (propertyName, propertySchema) => {
+            expect(propertySchema).to.be.deep.eq({
+              properties: {},
+              additionalProperties: {
+                properties: {
+                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                },
+                required: ['data'],
+                type: 'object',
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: undefined,
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1570,7 +1570,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               format: undefined,
             });
           },
-          record: (propertyName, propertySchema) => {
+          stringUnionRecord: (propertyName, propertySchema) => {
             expect(propertySchema.$ref).to.eq('#/components/schemas/Record_record-foo-or-record-bar._data-string__');
             const schema = getComponentSchema('Record_record-foo-or-record-bar._data-string__', currentSpec);
             expect(schema).to.be.deep.eq({
@@ -1603,6 +1603,75 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               example: undefined,
               format: undefined,
               description: 'Construct a type with a set of properties K of type T',
+            });
+          },
+          numberUnionRecord: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/Record_1-or-2._data-string__');
+            const schema = getComponentSchema('Record_1-or-2._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
+              properties: {
+                [1]: {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+                [2]: {
+                  properties: {
+                    data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  },
+                  required: ['data'],
+                  type: 'object',
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  default: undefined,
+                },
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: 'Construct a type with a set of properties K of type T',
+            });
+          },
+          stringRecord: (propertyName, propertySchema) => {
+            expect(propertySchema).to.be.deep.eq({
+              properties: {},
+              additionalProperties: {
+                properties: {
+                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                },
+                required: ['data'],
+                type: 'object',
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: undefined,
+            });
+          },
+          numberRecord: (propertyName, propertySchema) => {
+            expect(propertySchema).to.be.deep.eq({
+              properties: {},
+              additionalProperties: {
+                properties: {
+                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                },
+                required: ['data'],
+                type: 'object',
+              },
+              type: 'object',
+              default: undefined,
+              example: undefined,
+              format: undefined,
+              description: undefined,
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {


### PR DESCRIPTION
When encountering a Record whose key is string, tsoa would previously generate a blank object. This change allows the type resolver to recognize the record and generate its value type properly.

I would love guidance on where to add some tests for this PR! The test suite is a little opaque to me.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Closing issues**

Closes #1407

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
