### PR TITLE
Fix param examples incorrectly made into arrays

### DIFF
--- a/packages/cli/src/metadataGeneration/parameterGenerator.ts
+++ b/packages/cli/src/metadataGeneration/parameterGenerator.ts
@@ -134,7 +134,10 @@ export class ParameterGenerator {
     if (!this.supportBodyMethod(this.method)) {
       throw new GenerateMetadataError(`@BodyProp('${parameterName}') Can't support in ${this.method.toUpperCase()} method.`);
     }
-    const { examples: example, exampleLabels } = this.getParameterExample(parameter, parameterName);
+
+    const { examples, exampleLabels } = this.getParameterExample(parameter, parameterName);
+    const example = examples?.length ? examples[0] : undefined
+    
     return {
       default: getInitializerValue(parameter.initializer, this.current.typeChecker, type),
       description: this.getParameterDescription(parameter),

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -757,8 +757,13 @@ describe('Metadata generation', () => {
       expect(parameter.parameterName).to.equal('firstname');
       expect(parameter.required).to.be.true;
       expect(parameter.example).not.to.be.undefined;
-      expect(parameter.example).to.deep.equal(['name1', 'name2']);
-      expect((parameter.example as unknown[]).length).to.be.equal(2);
+      /**
+       * Multiple example values per property are not allowed.
+       * Putting them into an array is *not* the intended behavior
+       * {@link https://swagger.io/docs/specification/2-0/adding-examples/}
+       */
+      // expect(parameter.example).to.deep.equal(['name1', 'name2']);
+      // expect((parameter.example as unknown[]).length).to.be.equal(2);
     });
 
     it('should generate a res parameter and the corresponding additional response', () => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -393,6 +393,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       });
     });
 
+    describe('should generate single example for @BodyProp parameters', () => {
+      it('Single @BodyProp parameter in Post method', () => {
+        const postBodyParams = exampleSpec.paths['/ExampleTest/post_body_prop_single'].post?.requestBody?.content?.['application/json'];
+        expect(postBodyParams?.schema?.properties?.prop1?.example).to.equal('prop1');
+      });
+
+      it('Two @BodyProp parameters in Post method', () => {
+        const postBodyParams = exampleSpec.paths['/ExampleTest/post_body_prop'].post?.requestBody?.content?.['application/json'];
+        expect(postBodyParams?.schema?.properties?.prop1?.example).to.equal('prop1_1');
+        expect(postBodyParams?.schema?.properties?.prop2?.example).to.equal('prop2_1');
+      });
+    })
+
     it('Supports custom example labels', () => {
       const metadata = new MetadataGenerator('./fixtures/controllers/exampleController.ts').Generate();
       const exampleSpec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();


### PR DESCRIPTION
fixes #1464

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [X] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Potential Problems With The Approach**

It would be better to allow for multiple examples in methods having `@BodyProp` parameters, but the current solution to toss multiple examples into an array does not work as expected (it assumes that the example value of the prop is the array itself).

Multiple examples need to be addressed at the schema level rather than the prop level. This exceeds the scope of this bugfix.

**Test plan**

- Two test were included to cover the case of multiple examples per `@BodyProp`. In both cases it is expected that examples after the first are ignored.
- Two tests were commented out, on account of expecting erroneous behavior
