### PR TITLE
fix: Don't URI encode schema keys when using $ref

### DIFF
--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -44,7 +44,7 @@ export class MetadataGenerator {
   }
 
   private setProgramToDynamicControllersFiles(controllers: string[], esm: boolean) {
-    const allGlobFiles = importClassesFromDirectories(controllers, esm ? ['.mts', '.ts', '.cts']: ['.ts']);
+    const allGlobFiles = importClassesFromDirectories(controllers, esm ? ['.mts', '.ts', '.cts'] : ['.ts']);
     if (allGlobFiles.length === 0) {
       throw new GenerateMetadataError(`[${controllers.join(', ')}] globs found 0 controllers.`);
     }
@@ -216,7 +216,7 @@ export class MetadataGenerator {
     if (!referenceType.refName) {
       return;
     }
-    this.referenceTypeMap[referenceType.refName] = referenceType;
+    this.referenceTypeMap[decodeURIComponent(referenceType.refName)] = referenceType;
   }
 
   public GetReferenceType(refName: string) {

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -763,21 +763,19 @@ export class TypeResolver {
   }
 
   private getRefTypeName(name: string): string {
-    return encodeURIComponent(
-      name
-        .replace(/<|>/g, '_')
-        .replace(/\s+/g, '')
-        .replace(/,/g, '.')
-        .replace(/'([^']*)'/g, '$1')
-        .replace(/"([^"]*)"/g, '$1')
-        .replace(/&/g, '-and-')
-        .replace(/\|/g, '-or-')
-        .replace(/\[\]/g, '-Array')
-        .replace(/{|}/g, '_') // SuccessResponse_{indexesCreated-number}_ -> SuccessResponse__indexesCreated-number__
-        .replace(/([a-z]+):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
-        .replace(/;/g, '--')
-        .replace(/([a-z]+)\[([a-z]+)\]/gi, '$1-at-$2'), // Partial_SerializedDatasourceWithVersion[format]_ -> Partial_SerializedDatasourceWithVersion~format~_,
-    );
+    return name
+      .replace(/<|>/g, '_')
+      .replace(/\s+/g, '')
+      .replace(/,/g, '.')
+      .replace(/'([^']*)'/g, '$1')
+      .replace(/"([^"]*)"/g, '$1')
+      .replace(/&/g, '-and-')
+      .replace(/\|/g, '-or-')
+      .replace(/\[\]/g, '-Array')
+      .replace(/{|}/g, '_') // SuccessResponse_{indexesCreated-number}_ -> SuccessResponse__indexesCreated-number__
+      .replace(/([a-z]+):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
+      .replace(/;/g, '--')
+      .replace(/([a-z]+)\[([a-z]+)\]/gi, '$1-at-$2'); // Partial_SerializedDatasourceWithVersion[format]_ -> Partial_SerializedDatasourceWithVersion~format~_,
   }
 
   private attemptToResolveKindToPrimitive = (syntaxKind: ts.SyntaxKind): ResolvesToPrimitive | DoesNotResolveToPrimitive => {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -81,10 +81,9 @@ export class SpecGenerator2 extends SpecGenerator {
     const definitions: { [definitionsName: string]: Swagger.Schema2 } = {};
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
-      const decodedName = decodeURIComponent(referenceType.refName);
       if (referenceType.dataType === 'refObject') {
         const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
-        definitions[decodedName] = {
+        definitions[referenceType.refName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
           required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
@@ -92,7 +91,7 @@ export class SpecGenerator2 extends SpecGenerator {
         };
 
         if (referenceType.additionalProperties) {
-          definitions[decodedName].additionalProperties = this.buildAdditionalProperties(referenceType.additionalProperties);
+          definitions[referenceType.refName].additionalProperties = this.buildAdditionalProperties(referenceType.additionalProperties);
         } else {
           // Since additionalProperties was not explicitly set in the TypeScript interface for this model
           //      ...we need to make a decision

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -81,9 +81,10 @@ export class SpecGenerator2 extends SpecGenerator {
     const definitions: { [definitionsName: string]: Swagger.Schema2 } = {};
     Object.keys(this.metadata.referenceTypeMap).map(typeName => {
       const referenceType = this.metadata.referenceTypeMap[typeName];
+      const decodedName = decodeURIComponent(referenceType.refName);
       if (referenceType.dataType === 'refObject') {
         const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
-        definitions[referenceType.refName] = {
+        definitions[decodedName] = {
           description: referenceType.description,
           properties: this.buildProperties(referenceType.properties),
           required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
@@ -91,7 +92,7 @@ export class SpecGenerator2 extends SpecGenerator {
         };
 
         if (referenceType.additionalProperties) {
-          definitions[referenceType.refName].additionalProperties = this.buildAdditionalProperties(referenceType.additionalProperties);
+          definitions[decodedName].additionalProperties = this.buildAdditionalProperties(referenceType.additionalProperties);
         } else {
           // Since additionalProperties was not explicitly set in the TypeScript interface for this model
           //      ...we need to make a decision
@@ -478,7 +479,7 @@ export class SpecGenerator2 extends SpecGenerator {
   }
 
   protected getSwaggerTypeForReferenceType(referenceType: Tsoa.ReferenceType): Swagger.BaseSchema {
-    return { $ref: `#/definitions/${referenceType.refName}` };
+    return { $ref: `#/definitions/${encodeURIComponent(referenceType.refName)}` };
   }
 
   private decideEnumType(anEnum: Array<string | number>, nameOfEnum: string): 'string' | 'number' {

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -572,7 +572,7 @@ export class SpecGenerator3 extends SpecGenerator {
   }
 
   protected getSwaggerTypeForReferenceType(referenceType: Tsoa.ReferenceType): Swagger.BaseSchema {
-    return { $ref: `#/components/schemas/${referenceType.refName}` };
+    return { $ref: `#/components/schemas/${encodeURIComponent(referenceType.refName)}` };
   }
 
   protected getSwaggerTypeForPrimitiveType(dataType: Tsoa.PrimitiveTypeLiteral): Swagger.Schema {


### PR DESCRIPTION
This fixes an isssue where using `$` in type names leads to invalid OpenAPI specs. This would happen because the `refName` property that is used as the object key for refs and to create `$ref` attributes is URI encoded on creation, when it only needs to be URI encoded when used in a `$ref` attribute.

Fixes #1461

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Test plan**

I had a hard time configuring a unit test to check this behaviour, if anyone can provide some guidance on how to do it please let me know, as the test cases in this repo are hard to follow.
