### PR TITLE
Escape backtick and template variable from type name

### DIFF
--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -770,9 +770,11 @@ export class TypeResolver {
         .replace(/,/g, '.')
         .replace(/'([^']*)'/g, '$1')
         .replace(/"([^"]*)"/g, '$1')
+        .replace(/`([^`]*)`/g, '$1')
         .replace(/&/g, '-and-')
         .replace(/\|/g, '-or-')
         .replace(/\[\]/g, '-Array')
+        .replace(/\$\{([^}]+)\}/g, '_$1') // ${variable} -> _variable
         .replace(/{|}/g, '_') // SuccessResponse_{indexesCreated-number}_ -> SuccessResponse__indexesCreated-number__
         .replace(/([a-z]+):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
         .replace(/;/g, '--')

--- a/tests/fixtures/controllers/typeInferenceController.ts
+++ b/tests/fixtures/controllers/typeInferenceController.ts
@@ -53,4 +53,11 @@ export class TypeInferenceController {
       demo21: '',
     };
   }
+
+  @Get('escape-string-literal-type')
+  public escapeStringLiteralType(): Omit<TruncationTestModel, `demo${number}`> {
+    return {
+      d: '',
+    };
+  }
 }

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1006,6 +1006,22 @@ describe('Metadata generation', () => {
         'demo21',
       ]);
     });
+
+    it('should generate escapeStringLiteralType method', () => {
+      const method = controller.methods.find(method => method.name === 'escapeStringLiteralType');
+      if (!method) {
+        throw new Error('Method escapeStringLiteralType not defined!');
+      }
+
+      expect(method.method).to.equal('get');
+      expect(method.path).to.equal('escape-string-literal-type');
+      const [response] = method.responses;
+      expect(response.schema?.dataType).to.eq('refAlias');
+      expect((response.schema as Tsoa.RefAliasType)?.refName).to.equal('Omit_TruncationTestModel.demo_number_');
+      const properties = (((response.schema as Tsoa.RefAliasType).type as Tsoa.RefAliasType).type as Tsoa.NestedObjectLiteralType).properties;
+      expect(properties.length).to.equal(1);
+      expect(properties.map(prop => prop.name)).to.have.members(['d']);
+    });
   });
 
   describe('controllerWithJsDocResponseDescriptionGeneration', () => {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

---

This PR solve the issue with Swagger that can't handle `$` schema name.

My use case is the following:
```ts
type MyModel = {
  normalProp: string;
  [key: `variable${number}`]: string;
}
```

TSOA can't use the type `MyModal` which is understandable as one of the key is dynamic.
My approach what to create a TSOA specific type like this:
```ts
import { MyModal as SourceMyModel } from "./types";
type MyModel = Omit<SourceMyModel, `variable${number}`> & { variable1: string, variable2: string };
```
With this, TSOA is able to generate the OpenApi file,
but the generated schemas are:
```json
"Pick_SourceMyModel.Exclude_keyofSourceMyModel.%60variable%24_number_%60__": {
	"properties": {
		"normalProp": {
			"type": "string"
		}
	},
	"required": [
		"normalProp"
	],
	"type": "object",
	"description": "From T, pick a set of properties whose keys are in the union K"
},
"Omit_SourceMyModel.%60variable%24_number_%60_": {
	"$ref": "#/components/schemas/Pick_SourceMyModel.Exclude_keyofSourceMyModel.%60variable%24_number_%60__",
	"description": "Construct a type with the properties of T except for those in type K."
},
"MyModel": {
	"allOf": [
		{
			"$ref": "#/components/schemas/Omit_SourceMyModel.%60variable%24_number_%60_"
		},
		{
			"properties": {
				"variable2": {
					"type": "string"
				},
				"variable1": {
					"type": "string"
				}
			},
			"type": "object"
		}
	]
}
```

With my PR the output will be:
```json
"Pick_SourceMyModel.Exclude_keyofSourceMyModel.variable_number__": {
	"properties": {
		"normalProp": {
			"type": "string"
		}
	},
	"required": [
		"normalProp"
	],
	"type": "object",
	"description": "From T, pick a set of properties whose keys are in the union K"
},
"Omit_SourceMyModel.variable_number_": {
	"$ref": "#/components/schemas/Pick_SourceMyModel.Exclude_keyofSourceMyModel.variable_number__",
	"description": "Construct a type with the properties of T except for those in type K."
},
"MyModel": {
	"allOf": [
		{
			"$ref": "#/components/schemas/Omit_SourceMyModel.variable_number_"
		},
		{
			"properties": {
				"variable2": {
					"type": "string"
				},
				"variable1": {
					"type": "string"
				}
			},
			"type": "object"
		}
	]
}
```