### PR TITLE
Enhance Nullable Union Type Inference through Strict Mode

### DIFF
--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -24,7 +24,7 @@ export class MetadataGenerator {
     esm = false,
   ) {
     TypeResolver.clearCache();
-    this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers, esm) : createProgram([entryFile], compilerOptions || {});
+    this.program = controllers ? this.setProgramToDynamicControllersFiles(controllers, esm) : createProgram([entryFile], { strict: true, ...compilerOptions } || {});
     this.typeChecker = this.program.getTypeChecker();
   }
 
@@ -44,7 +44,7 @@ export class MetadataGenerator {
   }
 
   private setProgramToDynamicControllersFiles(controllers: string[], esm: boolean) {
-    const allGlobFiles = importClassesFromDirectories(controllers, esm ? ['.mts', '.ts', '.cts']: ['.ts']);
+    const allGlobFiles = importClassesFromDirectories(controllers, esm ? ['.mts', '.ts', '.cts'] : ['.ts']);
     if (allGlobFiles.length === 0) {
       throw new GenerateMetadataError(`[${controllers.join(', ')}] globs found 0 controllers.`);
     }

--- a/tests/fixtures/controllers/typeInferenceWithNullableValueController.ts
+++ b/tests/fixtures/controllers/typeInferenceWithNullableValueController.ts
@@ -1,0 +1,10 @@
+import { Get, Route } from '@tsoa/runtime';
+
+@Route('inference')
+export class TypeInferenceWithNullableValueController {
+  @Get('keys-inference-with-nullable')
+  public multiKeysInterfaceInferenceWithNullable() {
+    const maybeString: string | null = Math.random() > 0.5 ? 'foo' : null;
+    return maybeString;
+  }
+}

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1079,4 +1079,25 @@ describe('Metadata generation', () => {
       checkNumberType(getInteger, 'integer');
     });
   });
+  describe('TypeInferenceWithNullableValueController', () => {
+    const metadata = new MetadataGenerator('./fixtures/controllers/typeInferenceWithNullableValueController.ts', { strict: true }).Generate();
+    const controller = metadata.controllers.find(controller => controller.name === 'TypeInferenceWithNullableValueController');
+
+    if (!controller) {
+      throw new Error('TypeInferenceWithNullableValueController not defined!');
+    }
+
+    it('should generate multiKeysInterfaceInferenceWithNullable method', () => {
+      const method = controller.methods.find(method => method.name === 'multiKeysInterfaceInferenceWithNullable');
+
+      if (!method) {
+        throw new Error('Method multiKeysInterfaceInferenceWithNullable not defined!');
+      }
+
+      expect(method.method).to.equal('get');
+      expect(method.path).to.equal('keys-inference-with-nullable');
+      const [response] = method.responses;
+      expect(response.schema?.dataType).to.eq('union');
+    });
+  });
 });


### PR DESCRIPTION
#### Summary

This PR addresses issue #1474, aiming to improve the type inference mechanism for nullable union types in tsoa. By enabling TypeScript's strict mode, we significantly enhance the accuracy of type definitions and OpenAPI Schemas generated by the library.

#### Changes

- Modified TypeScript program's `compilerOptions` to include `strict: true`.
- Adjusted relevant unit tests to validate the improved type inference.

#### Impact

- This change may modify the output of existing API definitions. However, it enhances the schema's accuracy without limiting the current scope.
  
#### How to Test

1. Pull the changes and install updated dependencies.
2. Run the existing unit tests to validate that the change is working as expected.
3. Manually create a route using a nullable union type and confirm that the generated OpenAPI schema is accurate.

#### Context

- Library Version: 5.1.1
- Node Version: 18.12.0
- Package Manager: Yarn

---
