### PR TITLE
feat: added ability to pass multerInstance into RegisterRoutes

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -12,7 +12,7 @@ import { expressAuthentication } from '{{authenticationModule}}';
 {{/if}}
 {{#if iocModule}}
 import { iocContainer } from '{{iocModule}}';
-import type { IocContainer, IocContainerFactory } from '@tsoa/runtime';
+import type { IocContainer, IocContainerFactory, RegisterRoutesOptions } from '@tsoa/runtime';
 {{/if}}
 import type { RequestHandler, Router } from 'express';
 {{#if useFileUploads}}
@@ -21,7 +21,7 @@ import multer from 'multer';
 {{else}}
 const multer = require('multer');
 {{/if}}
-const upload = multer({{{json multerOpts}}});
+let upload = multer({{{json multerOpts}}});
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -54,11 +54,16 @@ const validationService = new ValidationService(models);
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-export function RegisterRoutes(app: Router) {
+export function RegisterRoutes(app: Router, registerOptions: RegisterRoutesOptions = {}) {
     // ###########################################################################################################
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
+    {{#if useFileUploads}}
+        if(registerOptions.multer){
+            upload = registerOptions.multer,
+        }
+    {{/if}}
     {{#each controllers}}
     {{#each actions}}
         app.{{method}}('{{fullPath}}',

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -21,7 +21,6 @@ import multer from 'multer';
 {{else}}
 const multer = require('multer');
 {{/if}}
-let upload = multer({{{json multerOpts}}});
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -55,15 +54,14 @@ const validationService = new ValidationService(models);
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 export function RegisterRoutes(app: Router, registerOptions: RegisterRoutesOptions = {}) {
+    {{#if useFileUploads}}
+    // NOTE: If registerOptions.multer is passed to this function, then it will override the multer options from `tsoa.json`
+    const upload = registerOptions.multer || multer({{{json multerOpts}}});
+    {{/if}}
     // ###########################################################################################################
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
     // ###########################################################################################################
-    {{#if useFileUploads}}
-        if(registerOptions.multer){
-            upload = registerOptions.multer,
-        }
-    {{/if}}
     {{#each controllers}}
     {{#each actions}}
         app.{{method}}('{{fullPath}}',

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -26,7 +26,6 @@ import multer from '@koa/multer';
 {{else}}
 const multer = require('@koa/multer');
 {{/if}}
-const upload = multer({{{json multerOpts}}});
 {{/if}}
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -59,7 +58,11 @@ const validationService = new ValidationService(models);
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
-export function RegisterRoutes(router: KoaRouter) {
+export function RegisterRoutes(app: Router, registerOptions: RegisterRoutesOptions = {}) {
+    {{#if useFileUploads}}
+    // NOTE: If registerOptions.multer is passed to this function, then it will override the multer options from `tsoa.json`
+    const upload = registerOptions.multer || multer({{{json multerOpts}}});
+    {{/if}}
     // ###########################################################################################################
     //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
     //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -1,3 +1,4 @@
+import multer from 'multer';
 import { ExtensionType } from '../decorators/extension';
 import type { Swagger } from '../swagger/swagger';
 import { Validator } from '..';
@@ -15,6 +16,10 @@ export namespace Tsoa {
     name: string;
     path: string;
     produces?: string[];
+  }
+
+  export interface RegisterRoutesOptions {
+    multer?: multer.Multer;
   }
 
   export interface Method {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

### If this is a new feature submission:

- [x] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project? - > see #1483 

- Added multer instance injection into `RegisterRoutes`.
- Created a new Type RegisterRoutesOptions which currently only has `{multer: multer.Multer}` as it's property this could be expanded as required in future.


