### PR TITLE
fix: Referencer, Name conflicts, Mapped unions, etc.

### DIFF
--- a/packages/cli/src/metadataGeneration/exceptions.ts
+++ b/packages/cli/src/metadataGeneration/exceptions.ts
@@ -11,7 +11,7 @@ export class GenerateMetadataError extends Error {
 }
 
 export class GenerateMetaDataWarning {
-  constructor(private message: string, private node: Node | TypeNode, private onlyCurrent = false) {}
+  constructor(private message: string, private node: Node | TypeNode, private onlyCurrent = false) { }
 
   toString() {
     return `Warning: ${this.message}\n${prettyLocationOfNode(this.node)}\n${prettyTroubleCause(this.node, this.onlyCurrent)}`;
@@ -20,19 +20,23 @@ export class GenerateMetaDataWarning {
 
 export function prettyLocationOfNode(node: Node | TypeNode) {
   const sourceFile = node.getSourceFile();
-  const token = node.getFirstToken() || node.parent.getFirstToken();
-  const start = token ? `:${sourceFile.getLineAndCharacterOfPosition(token.getStart()).line + 1}` : '';
-  const end = token ? `:${sourceFile.getLineAndCharacterOfPosition(token.getEnd()).line + 1}` : '';
-  const normalizedPath = normalize(`${sourceFile.fileName}${start}${end}`);
-  return `At: ${normalizedPath}.`;
+  if (sourceFile) {
+    const token = node.getFirstToken() || node.parent.getFirstToken();
+    const start = token ? `:${sourceFile.getLineAndCharacterOfPosition(token.getStart()).line + 1}` : '';
+    const end = token ? `:${sourceFile.getLineAndCharacterOfPosition(token.getEnd()).line + 1}` : '';
+    const normalizedPath = normalize(`${sourceFile.fileName}${start}${end}`);
+    return `At: ${normalizedPath}.`;
+  } else {
+    return `At unknown position...`;
+  }
 }
 
 export function prettyTroubleCause(node: Node | TypeNode, onlyCurrent = false) {
   let name: string;
   if (onlyCurrent || !node.parent) {
-    name = node.pos !== -1 ? node.getText() : (node as any).name.text;
+    name = node.pos !== -1 ? node.getText() : ((node as any).name?.text || '<unknown name>');
   } else {
-    name = node.parent.pos !== -1 ? node.parent.getText() : (node as any).parent.name.text;
+    name = node.parent.pos !== -1 ? node.parent.getText() : ((node as any).parent.name?.text || '<unknown name>');
   }
   return `This was caused by '${name}'`;
 }

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -12,7 +12,7 @@ export class MetadataGenerator {
   public readonly typeChecker: TypeChecker;
   private readonly program: Program;
   private referenceTypeMap: Tsoa.ReferenceTypeMap = {};
-  private modelDefinitionPosMap: { [name: string]: { fileName: string, pos: number }[] } = {};
+  private modelDefinitionPosMap: { [name: string]: Array<{ fileName: string; pos: number }> } = {};
   private expressionOrigNameMap: Record<string, string> = {};
 
   constructor(
@@ -223,12 +223,12 @@ export class MetadataGenerator {
     return this.referenceTypeMap[refName];
   }
 
-  public CheckModelUnicity(refName: string, positions: { fileName: string, pos: number }[]) {
+  public CheckModelUnicity(refName: string, positions: Array<{ fileName: string; pos: number }>) {
     if (!this.modelDefinitionPosMap[refName]) {
       this.modelDefinitionPosMap[refName] = positions;
     } else {
-      let origPositions = this.modelDefinitionPosMap[refName];
-      if (!(origPositions.length == positions.length && positions.every(pos => origPositions.find(origPos => pos.pos == origPos.pos && pos.fileName == origPos.fileName)))) {
+      const origPositions = this.modelDefinitionPosMap[refName];
+      if (!(origPositions.length === positions.length && positions.every(pos => origPositions.find(origPos => pos.pos === origPos.pos && pos.fileName === origPos.fileName)))) {
         throw new Error(`Found 2 different model definitions for model ${refName}: orig: ${JSON.stringify(origPositions)}, act: ${JSON.stringify(positions)}`);
       }
     }
@@ -238,7 +238,7 @@ export class MetadataGenerator {
     if (!this.expressionOrigNameMap[formattedRefName]) {
       this.expressionOrigNameMap[formattedRefName] = refName;
     } else {
-      if (this.expressionOrigNameMap[formattedRefName] != refName) {
+      if (this.expressionOrigNameMap[formattedRefName] !== refName) {
         throw new Error(`Found 2 different type expressions for formatted name "${formattedRefName}": orig: "${this.expressionOrigNameMap[formattedRefName]}", act: "${refName}"`);
       }
     }

--- a/packages/cli/src/metadataGeneration/metadataGenerator.ts
+++ b/packages/cli/src/metadataGeneration/metadataGenerator.ts
@@ -1,18 +1,19 @@
+import { Config, Tsoa } from '@tsoa/runtime';
 import { minimatch } from 'minimatch';
+import { createProgram, forEachChild, isClassDeclaration, type ClassDeclaration, type CompilerOptions, type Program, type TypeChecker } from 'typescript';
+import { getDecorators } from '../utils/decoratorUtils';
 import { importClassesFromDirectories } from '../utils/importClassesFromDirectories';
 import { ControllerGenerator } from './controllerGenerator';
 import { GenerateMetadataError } from './exceptions';
-import { Config, Tsoa } from '@tsoa/runtime';
 import { TypeResolver } from './typeResolver';
-import { getDecorators } from '../utils/decoratorUtils';
-import { type TypeChecker, type Program, type ClassDeclaration, type CompilerOptions, createProgram, forEachChild, isClassDeclaration } from 'typescript';
 
 export class MetadataGenerator {
   public readonly controllerNodes = new Array<ClassDeclaration>();
   public readonly typeChecker: TypeChecker;
   private readonly program: Program;
   private referenceTypeMap: Tsoa.ReferenceTypeMap = {};
-  private circularDependencyResolvers = new Array<(referenceTypes: Tsoa.ReferenceTypeMap) => void>();
+  private modelDefinitionPosMap: { [name: string]: { fileName: string, pos: number }[] } = {};
+  private expressionOrigNameMap: Record<string, string> = {};
 
   constructor(
     entryFile: string,
@@ -35,7 +36,6 @@ export class MetadataGenerator {
 
     this.checkForMethodSignatureDuplicates(controllers);
     this.checkForPathParamSignatureDuplicates(controllers);
-    this.circularDependencyResolvers.forEach(c => c(this.referenceTypeMap));
 
     return {
       controllers,
@@ -214,17 +214,34 @@ export class MetadataGenerator {
 
   public AddReferenceType(referenceType: Tsoa.ReferenceType) {
     if (!referenceType.refName) {
-      return;
+      throw new Error('no reference type name found');
     }
-    this.referenceTypeMap[decodeURIComponent(referenceType.refName)] = referenceType;
+    this.referenceTypeMap[referenceType.refName] = referenceType;
   }
 
   public GetReferenceType(refName: string) {
     return this.referenceTypeMap[refName];
   }
 
-  public OnFinish(callback: (referenceTypes: Tsoa.ReferenceTypeMap) => void) {
-    this.circularDependencyResolvers.push(callback);
+  public CheckModelUnicity(refName: string, positions: { fileName: string, pos: number }[]) {
+    if (!this.modelDefinitionPosMap[refName]) {
+      this.modelDefinitionPosMap[refName] = positions;
+    } else {
+      let origPositions = this.modelDefinitionPosMap[refName];
+      if (!(origPositions.length == positions.length && positions.every(pos => origPositions.find(origPos => pos.pos == origPos.pos && pos.fileName == origPos.fileName)))) {
+        throw new Error(`Found 2 different model definitions for model ${refName}: orig: ${JSON.stringify(origPositions)}, act: ${JSON.stringify(positions)}`);
+      }
+    }
+  }
+
+  public CheckExpressionUnicity(formattedRefName: string, refName: string) {
+    if (!this.expressionOrigNameMap[formattedRefName]) {
+      this.expressionOrigNameMap[formattedRefName] = refName;
+    } else {
+      if (this.expressionOrigNameMap[formattedRefName] != refName) {
+        throw new Error(`Found 2 different type expressions for formatted name "${formattedRefName}": orig: "${this.expressionOrigNameMap[formattedRefName]}", act: "${refName}"`);
+      }
+    }
   }
 
   private buildControllers() {

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -193,7 +193,7 @@ export class TypeResolver {
             .filter(property => isIgnored(property) === false)
             // Transform to property
             .map(property => {
-              const propertyType = this.current.typeChecker.getTypeOfSymbol(property);
+              const propertyType = this.current.typeChecker.getTypeOfSymbolAtLocation(property, this.typeNode);
 
               const typeNode = this.current.typeChecker.typeToTypeNode(propertyType, undefined, ts.NodeBuilderFlags.NoTruncation)!;
               const parent = getOneOrigDeclaration(property); //If there are more declarations, we need to get one of them, from where we want to recognize jsDoc

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -121,7 +121,7 @@ export class TypeResolver {
           description: this.getNodeDescription(propertySignature),
           format: this.getNodeFormat(propertySignature),
           name: (propertySignature.name as ts.Identifier).text,
-          required: !propertySignature.questionToken && def === undefined,
+          required: !propertySignature.questionToken,
           type,
           validators: getPropertyValidators(propertySignature) || {},
           deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
@@ -219,7 +219,7 @@ export class TypeResolver {
               // Push property
               return {
                 name: property.getName(),
-                required: required && def === undefined,
+                required,
                 deprecated: parent ? isExistJSDocTag(parent, tag => tag.tagName.text === 'deprecated') || isDecorator(parent, identifier => identifier.text === 'Deprecated') : false,
                 type,
                 default: def,
@@ -1272,7 +1272,7 @@ export class TypeResolver {
       example: this.getNodeExample(propertySignature),
       format: this.getNodeFormat(propertySignature),
       name: identifier.text,
-      required: required && def === undefined,
+      required,
       type: new TypeResolver(propertySignature.type, this.current, propertySignature.type.parent, this.context).resolve(),
       validators: getPropertyValidators(propertySignature) || {},
       deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
@@ -1311,7 +1311,7 @@ export class TypeResolver {
       example: this.getNodeExample(propertyDeclaration),
       format: this.getNodeFormat(propertyDeclaration),
       name: identifier.text,
-      required: required && def === undefined,
+      required,
       type,
       validators: getPropertyValidators(propertyDeclaration) || {},
       // class properties and constructor parameters may be deprecated either via jsdoc annotation or decorator

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -186,6 +186,15 @@ export class TypeResolver {
             dataType: 'union',
             types: resolvedTypes,
           };
+        } else if (type.flags & ts.TypeFlags.Undefined) {
+          return {
+            dataType: 'undefined',
+          };
+        } else if (type.flags & ts.TypeFlags.Null) {
+          return {
+            dataType: 'enum',
+            enums: [null],
+          };
         } else if (type.flags & ts.TypeFlags.Object) {
           const typeProperties: ts.Symbol[] = type.getProperties();
           const properties: Tsoa.Property[] = typeProperties

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -1103,13 +1103,13 @@ export class TypeResolver {
       .replace(/{|}/g, '_') // SuccessResponse_{indexesCreated-number}_ -> SuccessResponse__indexesCreated-number__
       .replace(/([a-z_0-9]+\??):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
       .replace(/;/g, '--')
-      .replace(/\r\n/g, '\n')
       .replace(/([a-z})\]])\[([a-z]+)\]/gi, '$1-at-$2'); // Partial_SerializedDatasourceWithVersion[format]_ -> Partial_SerializedDatasourceWithVersion~format~_,
 
     //Safety fixes to replace all characters which are not accepted by swagger ui
-    const formattedName = preformattedName.replace(/[^A-Za-z0-9\-._]/g, match => {
+    let formattedName = preformattedName.replace(/[^A-Za-z0-9\-._]/g, match => {
       return `_${match.charCodeAt(0)}_`;
     });
+    formattedName = formattedName.replace(/92_r_92_n/g, '92_n'); //Windows uses \r\n, but linux uses \n.
 
     return formattedName;
   }

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -1103,6 +1103,7 @@ export class TypeResolver {
       .replace(/{|}/g, '_') // SuccessResponse_{indexesCreated-number}_ -> SuccessResponse__indexesCreated-number__
       .replace(/([a-z_0-9]+\??):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
       .replace(/;/g, '--')
+      .replace(/\r\n/g, '\n')
       .replace(/([a-z})\]])\[([a-z]+)\]/gi, '$1-at-$2'); // Partial_SerializedDatasourceWithVersion[format]_ -> Partial_SerializedDatasourceWithVersion~format~_,
 
     //Safety fixes to replace all characters which are not accepted by swagger ui

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -1082,7 +1082,7 @@ export class TypeResolver {
   //Generates a name from the original type expression.
   //This function is not invertable, so it's possible, that 2 type expressions have the same refTypeName.
   private getRefTypeName(name: string): string {
-    return name
+    const preformattedName = name //Preformatted name handles most cases
       .replace(/<|>/g, '_')
       .replace(/\s+/g, '')
       .replace(/,/g, '.')
@@ -1095,6 +1095,13 @@ export class TypeResolver {
       .replace(/([a-z_0-9]+\??):([a-z]+)/gi, '$1-$2') // SuccessResponse_indexesCreated:number_ -> SuccessResponse_indexesCreated-number_
       .replace(/;/g, '--')
       .replace(/([a-z})\]])\[([a-z]+)\]/gi, '$1-at-$2'); // Partial_SerializedDatasourceWithVersion[format]_ -> Partial_SerializedDatasourceWithVersion~format~_,
+
+    //Safety fixes to replace all characters which are not accepted by swagger ui
+    const formattedName = preformattedName.replace(/[^A-Za-z0-9\-._]/g, match => {
+      return `_${match.charCodeAt(0)}_`;
+    });
+
+    return formattedName;
   }
 
   private attemptToResolveKindToPrimitive = (syntaxKind: ts.SyntaxKind): ResolvesToPrimitive | DoesNotResolveToPrimitive => {

--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -68,7 +68,7 @@ export abstract class AbstractRouteGenerator<Config extends ExtendedRoutesConfig
     return convertBracesPathParams(path);
   }
 
-  protected buildContext() {
+  protected buildContext(): any {
     const authenticationModule = this.options.authenticationModule ? this.getRelativeImportPath(this.options.authenticationModule) : undefined;
     const iocModule = this.options.iocModule ? this.getRelativeImportPath(this.options.iocModule) : undefined;
 

--- a/packages/cli/src/utils/validatorUtils.ts
+++ b/packages/cli/src/utils/validatorUtils.ts
@@ -1,7 +1,7 @@
-import validator from 'validator';
-import * as ts from 'typescript';
-import { GenerateMetadataError } from './../metadataGeneration/exceptions';
 import { Tsoa } from '@tsoa/runtime';
+import * as ts from 'typescript';
+import validator from 'validator';
+import { GenerateMetadataError } from './../metadataGeneration/exceptions';
 import { commentToString, getJSDocTags } from './jsDocUtils';
 
 export function getParameterValidators(parameter: ts.ParameterDeclaration, parameterName: string): Tsoa.Validators {
@@ -99,7 +99,7 @@ export function getParameterValidators(parameter: ts.ParameterDeclaration, param
   }, {} as Tsoa.Validators & { [unknown: string]: { errorMsg: string; value: undefined } });
 }
 
-export function getPropertyValidators(property: ts.PropertyDeclaration | ts.TypeAliasDeclaration | ts.PropertySignature | ts.ParameterDeclaration): Tsoa.Validators | undefined {
+export function getPropertyValidators(property: ts.Node): Tsoa.Validators | undefined {
   const tags = getJSDocTags(property, tag => {
     return getParameterTagSupport().some(value => value === tag.tagName.text);
   });

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -366,6 +366,9 @@ export interface TestModel extends Model {
     doubleIndexedIntersectionMap: Partial<{ [a: string]: string } & { [b: number]: number }>;
     parenthesizedMap: Partial<{ a: string } | ({ b: string } & { c: string })>;
     parenthesizedMap2: Partial<({ a: string } | { b: string }) & { c: string }>;
+
+    undefinedMap: Partial<undefined>;
+    nullMap: Partial<null>;
   };
 
   conditionals?: {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -209,6 +209,299 @@ export interface TestModel extends Model {
   extensionComment?: boolean;
 
   keyofLiteral?: keyof Items;
+
+  namespaces?: {
+    simple: NamespaceType;
+    inNamespace1: Namespace1.NamespaceType;
+    typeHolder1: Namespace1.TypeHolder;
+    inModule: Namespace2.Namespace2.NamespaceType;
+    typeHolder2: Namespace2.TypeHolder;
+  };
+
+  defaults?: {
+    basic: DefaultsClass;
+    replacedTypes: ReplaceTypes<DefaultsClass, boolean, string>;
+    /**
+     * @default undefined
+     */
+    defaultUndefined?: string,
+    /**
+     * @default null
+     */
+    defaultNull: string | null,
+    /**
+     * @default
+     * {
+     *   "a": "a",
+     *   "b": 2
+     * }
+     */
+    defaultObject: { a: string, b: number },
+  };
+
+  jsDocTypeNames?: {
+    simple: Partial<{ a: string }>;
+    commented: Partial<{
+      /** comment */
+      a: string
+    }>;
+    multilineCommented: Partial<{
+      /**
+       * multiline
+       * comment
+       */
+      a: string
+    }>;
+    defaultValue: Partial<{
+      /** @default "true" */
+      a: string
+    }>;
+    deprecated: Partial<{
+      /** @deprecated */
+      a: string
+    }>;
+    validators: Partial<{
+      /** @minLength 3 */
+      a: string
+    }>;
+    examples: Partial<{
+      /** @example "example" */
+      a: string
+    }>;
+    extensions: Partial<{
+      /** @extension {"x-key-1": "value-1"} */
+      a: string
+    }>;
+    ignored: Partial<{
+      /** @ignore */
+      a: string
+    }>;
+
+    indexedSimple: Partial<{ [a: string]: string }>;
+    indexedCommented: Partial<{
+      /** comment */
+      [a: string]: string
+    }>;
+    indexedMultilineCommented: Partial<{
+      /**
+       * multiline
+       * comment
+       */
+      [a: string]: string
+    }>;
+    indexedDefaultValue: Partial<{
+      /** @default "true" */
+      [a: string]: string
+    }>;
+    indexedDeprecated: Partial<{
+      /** @deprecated */
+      [a: string]: string
+    }>;
+    indexedValidators: Partial<{
+      /** @minLength 3 */
+      [a: string]: string
+    }>;
+    indexedExamples: Partial<{
+      /** @example "example" */
+      [a: string]: string
+    }>;
+    indexedExtensions: Partial<{
+      /** @extension {"x-key-1": "value-1"} */
+      [a: string]: string
+    }>;
+    indexedIgnored: Partial<{
+      /** @ignore */
+      [a: string]: string
+    }>;
+  };
+
+  jsdocMap?: {
+    omitted: Omit<JsDocced, 'notRelevant'>;
+    partial: Partial<JsDocced>;
+    replacedTypes: ReplaceStringAndNumberTypes<JsDocced>;
+    doubleReplacedTypes: ReplaceStringAndNumberTypes<ReplaceStringAndNumberTypes<JsDocced>>
+    postfixed: Postfixed<JsDocced, '_PostFix'>;
+    values: Values<JsDocced>;
+    typesValues: InternalTypes<Values<JsDocced>>;
+    onlyOneValue: JsDocced['numberValue'];
+    synonym: JsDoccedSynonym;
+    synonym2: JsDoccedSynonym2;
+  };
+
+  duplicatedDefinitions?: {
+    interfaces: DuplicatedInterface;
+    enums: DuplicatedEnum;
+    enumMember: DuplicatedEnum.C;
+    namespaceMember: DuplicatedEnum.D;
+  };
+
+  mappeds?: {
+    unionMap: Partial<{ a: string } | { b: number }>;
+    indexedUnionMap: Partial<{ a: string } | { [b: string]: number }>;
+    doubleIndexedUnionMap: Partial<{ [a: string]: string } | { [b: string]: number }>;
+
+    intersectionMap: Partial<{ a: string } & { b: number }>;
+    indexedIntersectionMap: Partial<{ a: string } & { [b: string]: number }>;
+    doubleIndexedIntersectionMap: Partial<{ [a: string]: string } & { [b: number]: number }>;
+    parenthesizedMap: Partial<{ a: string } | ({ b: string } & { c: string })>;
+    parenthesizedMap2: Partial<({ a: string } | { b: string }) & { c: string }>;
+  };
+
+  conditionals?: {
+    simpeConditional: string extends string ? number : boolean;
+    simpeFalseConditional: string extends number ? number : boolean;
+    typedConditional: Conditional<string, string, number, boolean>;
+    typedFalseConditional: Conditional<string, number, number, boolean>;
+    dummyConditional: Dummy<Conditional<string, string, number, boolean>>;
+    dummyFalseConditional: Dummy<Conditional<string, number, number, boolean>>;
+    mappedConditional: Partial<string extends string ? { a: number } : never>;
+    mappedTypedConditional: Partial<Conditional<string, string, { a: number }, never>>;
+  }
+
+  typeOperators?: {
+    keysOfAny: KeysMember;
+    keysOfInterface: KeysMember<NestedTypeLiteral>;
+    simple: keyof NestedTypeLiteral;
+    keyofItem: keyof NestedTypeLiteral['b'];
+    keyofAnyItem: keyof NestedTypeLiteral['e'];
+    keyofAny: keyof any;
+    stringLiterals: keyof Record<'A' | 'B' | 'C', string>;
+    stringAndNumberLiterals: keyof Record<'A' | 'B' | 3, string>;
+    keyofEnum: keyof typeof DuplicatedEnum;
+    numberAndStringKeys: keyof { [3]: string, [4]: string, a: string };
+    oneStringKeyInterface: keyof { a: string };
+    oneNumberKeyInterface: keyof { [3]: string };
+    indexStrings: keyof { [a: string]: string };
+    indexNumbers: keyof { [a: number]: string };
+  }
+
+  nestedTypes?: {
+    multiplePartial: Partial<Partial<{ a: string }>>;
+    separateField: Partial<SeparateField<Partial<{ a: string, b: string }>, 'a'>>;
+    separateField2: Partial<SeparateField<Partial<{ a: string, b: string }>, 'a' | 'b'>>;
+    separateField3: Partial<SeparateField<Partial<{ a: string, b: number }>, 'a' | 'b'>>;
+  }
+}
+
+type SeparateField<T, Field extends keyof T> = {
+  omitted: Omit<T, Field>,
+  field: T[Field];
+}
+
+type KeysMember<T = any> = {
+  keys: keyof T;
+}
+
+interface NestedTypeLiteral {
+  a: string;
+  b: {
+    c: string;
+    d: string;
+  },
+  e: any;
+}
+
+type Dummy<T> = T;
+
+type Conditional<T, CheckType, TrueType, FalseType> = T extends CheckType ? TrueType : FalseType;
+
+interface DuplicatedInterface {
+  a: string;
+}
+
+interface DuplicatedInterface {
+  a: string;
+  b: string;
+}
+
+class DuplicatedInterface {
+  a = 'defaultA';
+}
+
+enum DuplicatedEnum {
+  A = 'AA',
+  B = 'BB'
+}
+
+enum DuplicatedEnum {
+  C = 'CC'
+}
+
+namespace DuplicatedEnum {
+  export type D = 'DD';
+}
+
+interface JsDocced {
+  /**
+   * @maxLength 3
+   * @default "def"
+   */
+  stringValue: string;
+  /**
+   * @isInt
+   * @default 6
+   */
+  numberValue: number;
+}
+
+type JsDoccedKeys = keyof JsDocced;
+type JsDoccedSynonym = { [key in JsDoccedKeys]: JsDocced[key] };
+type JsDoccedSynonym2 = { [key in keyof JsDocced]: JsDocced[key] };
+type ReplaceTypes<T, Type1, Type2> = { [K in keyof T]: T[K] extends Type1 ? Type2 : Type1 };
+type ReplaceStringAndNumberTypes<T> = ReplaceTypes<T, string, number>;
+type Postfixed<T, Postfix extends string> = { [K in keyof T as `${K & string}${Postfix}`]: T[K] };
+type Values<T> = { [K in keyof T]: { value: T[K] } }
+type InternalTypes<T extends Record<any, { value: any }>> = { [K in keyof T]: T[K]['value'] };
+
+
+class DefaultsClass {
+  /**
+   * @default true
+   */
+  boolValue1?: boolean;
+  /**
+   * @default false
+   */
+  boolValue2?= true;
+  boolValue3?= false;
+  boolValue4?: boolean;
+}
+
+type NamespaceType = string;
+
+namespace Namespace1 {
+  export interface NamespaceType {
+    inFirstNamespace: string;
+  }
+
+  export interface TypeHolder {
+    inNamespace1_1: Namespace1.NamespaceType;
+    inNamespace1_2: NamespaceType;
+  }
+}
+
+namespace Namespace1 {
+  export interface NamespaceType {
+    inFirstNamespace2: string;
+  }
+}
+
+namespace Namespace2 {
+  interface NamespaceType {
+    inSecondNamespace: string;
+  }
+
+  export module Namespace2 {
+    export interface NamespaceType {
+      inModule: string;
+      other?: NamespaceType;
+    }
+  }
+
+  export interface TypeHolder {
+    inModule: Namespace2.NamespaceType;
+    inNamespace2: NamespaceType;
+  }
 }
 
 type Items = {
@@ -222,7 +515,7 @@ interface DeprecatedType {
 }
 
 @Deprecated()
-class DeprecatedClass {}
+class DeprecatedClass { }
 
 interface TypeWithDeprecatedProperty {
   ok: boolean;
@@ -268,7 +561,6 @@ const otherIndexedValue = {
 } as const;
 
 export type ForeignIndexedValue = (typeof indexedValue)[keyof typeof otherIndexedValue];
-
 type Maybe<T> = T | null;
 
 export interface TypeAliasModel1 {
@@ -415,14 +707,14 @@ export interface TestSubModel2 extends TestSubModel {
   testSubModel2: boolean;
 }
 
-export interface HeritageTestModel extends TypeAlias4, Partial<Omit<UserResponseModel, 'id'>> {}
+export interface HeritageTestModel extends TypeAlias4, Partial<Omit<UserResponseModel, 'id'>> { }
 
 export interface HeritageBaseModel {
   value: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface HeritageTestModel2 extends HeritageBaseModel {}
+export interface HeritageTestModel2 extends HeritageBaseModel { }
 
 export interface DefaultTestModel<T = Word, U = Omit<ErrorResponseModel, 'status'>> {
   t: GenericRequest<T>;
@@ -484,7 +776,7 @@ export class ParameterTestModel {
   public nicknames?: string[];
 }
 
-export class ValidateCustomErrorModel {}
+export class ValidateCustomErrorModel { }
 
 export class ValidateModel {
   /**
@@ -768,8 +1060,8 @@ const ClassIndexTest = {
 type Names = keyof typeof ClassIndexTest;
 type ResponseDistribute<T, U> = T extends Names
   ? {
-      [key in T]: Record<(typeof ClassIndexTest)[T][number], U>;
-    }
+    [key in T]: Record<(typeof ClassIndexTest)[T][number], U>;
+  }
   : never;
 type IndexRecordAlias<T> = ResponseDistribute<Names, T>;
 
@@ -940,3 +1232,4 @@ type OrderDirection = 'asc' | 'desc';
 type OrderOptions<E> = `${keyof E & string}:${OrderDirection}`;
 
 type TemplateLiteralString = OrderOptions<ParameterTestModel>;
+

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -224,11 +224,11 @@ export interface TestModel extends Model {
     /**
      * @default undefined
      */
-    defaultUndefined?: string,
+    defaultUndefined?: string;
     /**
      * @default null
      */
-    defaultNull: string | null,
+    defaultNull: string | null;
     /**
      * @default
      * {
@@ -236,82 +236,82 @@ export interface TestModel extends Model {
      *   "b": 2
      * }
      */
-    defaultObject: { a: string, b: number },
+    defaultObject: { a: string; b: number };
   };
 
   jsDocTypeNames?: {
     simple: Partial<{ a: string }>;
     commented: Partial<{
       /** comment */
-      a: string
+      a: string;
     }>;
     multilineCommented: Partial<{
       /**
        * multiline
        * comment
        */
-      a: string
+      a: string;
     }>;
     defaultValue: Partial<{
       /** @default "true" */
-      a: string
+      a: string;
     }>;
     deprecated: Partial<{
       /** @deprecated */
-      a: string
+      a: string;
     }>;
     validators: Partial<{
       /** @minLength 3 */
-      a: string
+      a: string;
     }>;
     examples: Partial<{
       /** @example "example" */
-      a: string
+      a: string;
     }>;
     extensions: Partial<{
       /** @extension {"x-key-1": "value-1"} */
-      a: string
+      a: string;
     }>;
     ignored: Partial<{
       /** @ignore */
-      a: string
+      a: string;
     }>;
 
     indexedSimple: Partial<{ [a: string]: string }>;
     indexedCommented: Partial<{
       /** comment */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedMultilineCommented: Partial<{
       /**
        * multiline
        * comment
        */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedDefaultValue: Partial<{
       /** @default "true" */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedDeprecated: Partial<{
       /** @deprecated */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedValidators: Partial<{
       /** @minLength 3 */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedExamples: Partial<{
       /** @example "example" */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedExtensions: Partial<{
       /** @extension {"x-key-1": "value-1"} */
-      [a: string]: string
+      [a: string]: string;
     }>;
     indexedIgnored: Partial<{
       /** @ignore */
-      [a: string]: string
+      [a: string]: string;
     }>;
   };
 
@@ -319,7 +319,7 @@ export interface TestModel extends Model {
     omitted: Omit<JsDocced, 'notRelevant'>;
     partial: Partial<JsDocced>;
     replacedTypes: ReplaceStringAndNumberTypes<JsDocced>;
-    doubleReplacedTypes: ReplaceStringAndNumberTypes<ReplaceStringAndNumberTypes<JsDocced>>
+    doubleReplacedTypes: ReplaceStringAndNumberTypes<ReplaceStringAndNumberTypes<JsDocced>>;
     postfixed: Postfixed<JsDocced, '_PostFix'>;
     values: Values<JsDocced>;
     typesValues: InternalTypes<Values<JsDocced>>;
@@ -356,7 +356,7 @@ export interface TestModel extends Model {
     dummyFalseConditional: Dummy<Conditional<string, number, number, boolean>>;
     mappedConditional: Partial<string extends string ? { a: number } : never>;
     mappedTypedConditional: Partial<Conditional<string, string, { a: number }, never>>;
-  }
+  };
 
   typeOperators?: {
     keysOfAny: KeysMember;
@@ -368,36 +368,36 @@ export interface TestModel extends Model {
     stringLiterals: keyof Record<'A' | 'B' | 'C', string>;
     stringAndNumberLiterals: keyof Record<'A' | 'B' | 3, string>;
     keyofEnum: keyof typeof DuplicatedEnum;
-    numberAndStringKeys: keyof { [3]: string, [4]: string, a: string };
+    numberAndStringKeys: keyof { [3]: string; [4]: string; a: string };
     oneStringKeyInterface: keyof { a: string };
     oneNumberKeyInterface: keyof { [3]: string };
     indexStrings: keyof { [a: string]: string };
     indexNumbers: keyof { [a: number]: string };
-  }
+  };
 
   nestedTypes?: {
     multiplePartial: Partial<Partial<{ a: string }>>;
-    separateField: Partial<SeparateField<Partial<{ a: string, b: string }>, 'a'>>;
-    separateField2: Partial<SeparateField<Partial<{ a: string, b: string }>, 'a' | 'b'>>;
-    separateField3: Partial<SeparateField<Partial<{ a: string, b: number }>, 'a' | 'b'>>;
-  }
+    separateField: Partial<SeparateField<Partial<{ a: string; b: string }>, 'a'>>;
+    separateField2: Partial<SeparateField<Partial<{ a: string; b: string }>, 'a' | 'b'>>;
+    separateField3: Partial<SeparateField<Partial<{ a: string; b: number }>, 'a' | 'b'>>;
+  };
 }
 
 type SeparateField<T, Field extends keyof T> = {
-  omitted: Omit<T, Field>,
+  omitted: Omit<T, Field>;
   field: T[Field];
-}
+};
 
 type KeysMember<T = any> = {
   keys: keyof T;
-}
+};
 
 interface NestedTypeLiteral {
   a: string;
   b: {
     c: string;
     d: string;
-  },
+  };
   e: any;
 }
 
@@ -420,13 +420,14 @@ class DuplicatedInterface {
 
 enum DuplicatedEnum {
   A = 'AA',
-  B = 'BB'
+  B = 'BB',
 }
 
 enum DuplicatedEnum {
-  C = 'CC'
+  C = 'CC',
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace DuplicatedEnum {
   export type D = 'DD';
 }
@@ -450,9 +451,8 @@ type JsDoccedSynonym2 = { [key in keyof JsDocced]: JsDocced[key] };
 type ReplaceTypes<T, Type1, Type2> = { [K in keyof T]: T[K] extends Type1 ? Type2 : Type1 };
 type ReplaceStringAndNumberTypes<T> = ReplaceTypes<T, string, number>;
 type Postfixed<T, Postfix extends string> = { [K in keyof T as `${K & string}${Postfix}`]: T[K] };
-type Values<T> = { [K in keyof T]: { value: T[K] } }
+type Values<T> = { [K in keyof T]: { value: T[K] } };
 type InternalTypes<T extends Record<any, { value: any }>> = { [K in keyof T]: T[K]['value'] };
-
 
 class DefaultsClass {
   /**
@@ -462,13 +462,14 @@ class DefaultsClass {
   /**
    * @default false
    */
-  boolValue2?= true;
-  boolValue3?= false;
+  boolValue2? = true;
+  boolValue3? = false;
   boolValue4?: boolean;
 }
 
 type NamespaceType = string;
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Namespace1 {
   export interface NamespaceType {
     inFirstNamespace: string;
@@ -480,17 +481,20 @@ namespace Namespace1 {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Namespace1 {
   export interface NamespaceType {
     inFirstNamespace2: string;
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Namespace2 {
   interface NamespaceType {
     inSecondNamespace: string;
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-namespace-keyword, @typescript-eslint/no-namespace
   export module Namespace2 {
     export interface NamespaceType {
       inModule: string;
@@ -515,7 +519,7 @@ interface DeprecatedType {
 }
 
 @Deprecated()
-class DeprecatedClass { }
+class DeprecatedClass {}
 
 interface TypeWithDeprecatedProperty {
   ok: boolean;
@@ -707,14 +711,14 @@ export interface TestSubModel2 extends TestSubModel {
   testSubModel2: boolean;
 }
 
-export interface HeritageTestModel extends TypeAlias4, Partial<Omit<UserResponseModel, 'id'>> { }
+export interface HeritageTestModel extends TypeAlias4, Partial<Omit<UserResponseModel, 'id'>> {}
 
 export interface HeritageBaseModel {
   value: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface HeritageTestModel2 extends HeritageBaseModel { }
+export interface HeritageTestModel2 extends HeritageBaseModel {}
 
 export interface DefaultTestModel<T = Word, U = Omit<ErrorResponseModel, 'status'>> {
   t: GenericRequest<T>;
@@ -776,7 +780,7 @@ export class ParameterTestModel {
   public nicknames?: string[];
 }
 
-export class ValidateCustomErrorModel { }
+export class ValidateCustomErrorModel {}
 
 export class ValidateModel {
   /**
@@ -1060,8 +1064,8 @@ const ClassIndexTest = {
 type Names = keyof typeof ClassIndexTest;
 type ResponseDistribute<T, U> = T extends Names
   ? {
-    [key in T]: Record<(typeof ClassIndexTest)[T][number], U>;
-  }
+      [key in T]: Record<(typeof ClassIndexTest)[T][number], U>;
+    }
   : never;
 type IndexRecordAlias<T> = ResponseDistribute<Names, T>;
 
@@ -1232,4 +1236,3 @@ type OrderDirection = 'asc' | 'desc';
 type OrderOptions<E> = `${keyof E & string}:${OrderDirection}`;
 
 type TemplateLiteralString = OrderOptions<ParameterTestModel>;
-

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -237,6 +237,27 @@ export interface TestModel extends Model {
      * }
      */
     defaultObject: { a: string; b: number };
+    /**
+     * @default `\`"'\"\'\n\t\r\b\f\v\0\g\x\\`//\0, \v is not supported...
+     *
+     */
+    stringEscapeCharacters: undefined; //type is not really interesting
+    /**
+     * @default //Comment1
+     * 4
+     * //Comment2
+     *
+     */
+    comments: undefined; //type is not really interesting
+    /**
+     * @default {
+     * //Alma
+     * `\\`: '\n'
+     *
+     * }
+     *
+     */
+    jsonCharacters: undefined; //type is not really interesting
   };
 
   jsDocTypeNames?: {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1892,7 +1892,7 @@ describe('Definition generation', () => {
                     format: undefined,
                   },
                 },
-                required: ['replacedTypes', 'basic'],
+                required: ['defaultNull', 'replacedTypes', 'basic'],
                 type: 'object',
               },
               `for property ${propertyName}`,

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -2604,8 +2604,10 @@ describe('Definition generation', () => {
             );
             expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_40__b-string_-and-_c-string__41__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/definitions/Partial__40__a-string_-or-_b-string__41_-and-_c-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.undefinedMap?.$ref).to.eq('#/definitions/Partial_undefined_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.nullMap?.$ref).to.eq('#/definitions/Partial_null_', `for property ${propertyName}`);
 
-            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
 
             const unionMapSchema = getValidatedDefinition('Partial__a-string_-or-_b-number__', currentSpec);
             expect(unionMapSchema).to.deep.eq(
@@ -2733,6 +2735,29 @@ describe('Definition generation', () => {
                 format: undefined,
               },
               `for property ${propertyName}.parenthesizedMap2`,
+            );
+            const undefinedMapSchema = getValidatedDefinition('Partial_undefined_', currentSpec);
+            expect(undefinedMapSchema).to.deep.eq(
+              {
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.undefinedMap`,
+            );
+            const nullMapSchema = getValidatedDefinition('Partial_null_', currentSpec);
+            expect(nullMapSchema).to.deep.eq(
+              {
+                enum: [null],
+                type: 'number',
+                'x-nullable': true,
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.nullMap`,
             );
           },
           conditionals: (propertyName, propertySchema) => {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1,12 +1,12 @@
-import { expect } from 'chai';
-import 'mocha';
+import { ExtendedSpecConfig } from '@tsoa/cli/cli';
 import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
 import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
 import { Swagger } from '@tsoa/runtime';
+import { expect } from 'chai';
+import 'mocha';
+import { versionMajorMinor } from 'typescript';
 import { getDefaultOptions } from '../../../fixtures/defaultOptions';
 import { TestModel } from '../../../fixtures/testModel';
-import { ExtendedSpecConfig } from '@tsoa/cli/cli';
-import { versionMajorMinor } from 'typescript';
 
 describe('Definition generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -131,7 +131,7 @@ describe('Definition generation', () => {
           'TestSubModelContainerNamespace.InnerNamespace.TestSubModelContainer2',
           'TestSubModel2',
           'TestSubModelNamespace.TestSubModelNS',
-          'TsoaTest.TestModel73',
+          'tsoaTest.TsoaTest.TestModel73',
         ];
         expectedModels.forEach(modelName => {
           getValidatedDefinition(modelName, currentSpec);
@@ -190,7 +190,7 @@ describe('Definition generation', () => {
 
     it('should generate a correct definition for models in namespaces in modules', () => {
       allSpecs.forEach(currentSpec => {
-        const namespaceInModule = getValidatedDefinition('TsoaTest.TestModel73', currentSpec);
+        const namespaceInModule = getValidatedDefinition('tsoaTest.TsoaTest.TestModel73', currentSpec);
 
         expect(namespaceInModule).to.deep.include({
           description: undefined,
@@ -282,7 +282,7 @@ describe('Definition generation', () => {
           },
           boolValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('boolean', `for property ${propertyName}.type`);
-            expect(propertySchema.default).to.eq('true', `for property ${propertyName}.default`);
+            expect(propertySchema.default).to.eq(true, `for property ${propertyName}.default`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           boolArray: (propertyName, propertySchema) => {
@@ -564,6 +564,7 @@ describe('Definition generation', () => {
                   default: undefined,
                 },
               },
+              required: ['record-foo', 'record-bar'],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -599,6 +600,7 @@ describe('Definition generation', () => {
                   default: undefined,
                 },
               },
+              required: ["1", "2"],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -607,37 +609,53 @@ describe('Definition generation', () => {
             });
           },
           stringRecord: (propertyName, propertySchema) => {
-            expect(propertySchema).to.be.deep.eq({
-              properties: {},
+            expect(propertySchema.$ref).to.eq('#/definitions/Record_string._data-string__');
+            const schema = getValidatedDefinition('Record_string._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
               additionalProperties: {
                 properties: {
-                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  data: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: "string"
+                  }
                 },
-                required: ['data'],
-                type: 'object',
+                required: ["data"],
+                type: "object"
               },
-              type: 'object',
               default: undefined,
+              description: "Construct a type with a set of properties K of type T",
               example: undefined,
               format: undefined,
-              description: undefined,
+              properties: {},
+              type: "object"
             });
           },
           numberRecord: (propertyName, propertySchema) => {
-            expect(propertySchema).to.be.deep.eq({
-              properties: {},
+            expect(propertySchema.$ref).to.eq('#/definitions/Record_number._data-string__');
+            const schema = getValidatedDefinition('Record_number._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
               additionalProperties: {
                 properties: {
-                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  data: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: "string"
+                  }
                 },
-                required: ['data'],
-                type: 'object',
+                required: ["data"],
+                type: "object"
               },
-              type: 'object',
               default: undefined,
+              description: "Construct a type with a set of properties K of type T",
               example: undefined,
               format: undefined,
-              description: undefined,
+              properties: {},
+              type: "object"
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
@@ -834,7 +852,7 @@ describe('Definition generation', () => {
               example: 42,
               minimum: 42,
               maximum: 42,
-              default: '42',
+              default: 42,
             });
 
             const dateAliasSchema = getValidatedDefinition('DateAlias', currentSpec);
@@ -1119,7 +1137,7 @@ describe('Definition generation', () => {
               {
                 properties: {
                   list: {
-                    items: { $ref: '#/definitions/ThingContainerWithTitle_string_' },
+                    items: { type: 'number', format: 'double' },
                     type: 'array',
                     default: undefined,
                     description: undefined,
@@ -1152,6 +1170,7 @@ describe('Definition generation', () => {
                   type: 'string',
                 },
               },
+              required: ['id'],
               type: 'object',
             });
 
@@ -1169,13 +1188,13 @@ describe('Definition generation', () => {
                     format: undefined,
                   },
                   indexedResponseObject: {
-                    $ref: '#/definitions/Record_id.any_',
+                    $ref: '#/definitions/Record_id._myProp1-string__',
                     description: undefined,
                     example: undefined,
                     format: undefined,
                   },
                   indexedType: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
-                  indexedTypeToAlias: { $ref: '#/definitions/IndexedInterfaceAlias', description: undefined, format: undefined, example: undefined },
+                  indexedTypeToAlias: { $ref: '#/definitions/IndexedInterface', description: undefined, format: undefined, example: undefined },
                   indexedTypeToClass: { $ref: '#/definitions/IndexedClass', description: undefined, format: undefined, example: undefined },
                   indexedTypeToInterface: { $ref: '#/definitions/IndexedInterface', description: undefined, format: undefined, example: undefined },
                   keyInterface: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined, 'x-nullable': false, enum: ['id'] },
@@ -1543,6 +1562,21 @@ describe('Definition generation', () => {
                     default: undefined,
                   },
                 },
+                required: [
+                  'lastname:asc',
+                  'age:asc',
+                  'weight:asc',
+                  'human:asc',
+                  'gender:asc',
+                  'nicknames:asc',
+                  'firstname:desc',
+                  'lastname:desc',
+                  'age:desc',
+                  'weight:desc',
+                  'human:desc',
+                  'gender:desc',
+                  'nicknames:desc'
+                ],
                 type: 'object',
                 description: undefined,
                 example: undefined,
@@ -1596,6 +1630,1474 @@ describe('Definition generation', () => {
               `for property ${propertyName}`,
             );
           },
+          namespaces: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq(
+              {
+                properties: {
+                  typeHolder2: {
+                    $ref: "#/definitions/Namespace2.TypeHolder",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inModule: {
+                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  typeHolder1: {
+                    $ref: "#/definitions/Namespace1.TypeHolder",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace1: {
+                    $ref: "#/definitions/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  simple: {
+                    $ref: "#/definitions/NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: [
+                  "typeHolder2",
+                  "inModule",
+                  "typeHolder1",
+                  "inNamespace1",
+                  "simple"
+                ],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}`
+            );
+
+            const typeHolder2Schema = getValidatedDefinition('Namespace2.TypeHolder', currentSpec);
+            expect(typeHolder2Schema).to.deep.eq(
+              {
+                properties: {
+                  inModule: {
+                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace2: {
+                    $ref: "#/definitions/Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inModule",
+                  "inNamespace2"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
+                description: undefined
+              },
+              `for property ${propertyName}.typeHolder2`
+            );
+
+            const namespace2_namespace2_namespaceTypeSchema = getValidatedDefinition('Namespace2.Namespace2.NamespaceType', currentSpec);
+            expect(namespace2_namespace2_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inModule: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  other: {
+                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inModule"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+              },
+              `for property ${propertyName}.typeHolder2.inModule`
+            );
+
+            const typeHolderSchema = getValidatedDefinition('Namespace1.TypeHolder', currentSpec);
+            expect(typeHolderSchema).to.deep.eq(
+              {
+                properties: {
+                  inNamespace1_1:
+                  {
+                    $ref: "#/definitions/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace1_2: {
+                    $ref: "#/definitions/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inNamespace1_1", "inNamespace1_2"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
+                description: undefined
+              },
+              `for property ${propertyName}.typeHolder1`
+            );
+
+            const namespace1_namespaceTypeSchema = getValidatedDefinition('Namespace1.NamespaceType', currentSpec);
+            expect(namespace1_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inFirstNamespace: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inFirstNamespace2: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inFirstNamespace", "inFirstNamespace2"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+              },
+              `for property ${propertyName}.typeHolder1.inNamespace1_1`
+            );
+
+            const namespace2_namespaceTypeSchema = getValidatedDefinition('Namespace2.NamespaceType', currentSpec);
+            expect(namespace2_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inSecondNamespace: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                },
+                required: ["inSecondNamespace"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+              },
+              `for property ${propertyName}.typeHolder2.inNamespace2`
+            );
+
+            const namespaceTypeSchema = getValidatedDefinition('NamespaceType', currentSpec);
+            expect(namespaceTypeSchema).to.deep.eq(
+              {
+                type: "string",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.simple`
+            );
+          },
+          defaults: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq({
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              properties: {
+                basic: {
+                  $ref: "#/definitions/DefaultsClass",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                defaultNull: {
+                  default: null,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  type: "string",
+                  "x-nullable": true
+                },
+                defaultObject: {
+                  default: {
+                    a: "a",
+                    b: 2
+                  },
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  properties: {
+                    a: {
+                      default: undefined,
+                      description: undefined,
+                      example: undefined,
+                      format: undefined,
+                      type: "string"
+                    },
+                    b: {
+                      default: undefined,
+                      description: undefined,
+                      example: undefined,
+                      format: "double",
+                      type: "number"
+                    }
+                  },
+                  required: ["b", "a"],
+                  type: "object"
+                },
+                defaultUndefined: {
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  type: "string"
+                },
+                replacedTypes: {
+                  $ref: "#/definitions/ReplaceTypes_DefaultsClass.boolean.string_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              required: ["replacedTypes", "basic"],
+              type: "object"
+            },
+              `for property ${propertyName}`
+            );
+
+            const basicSchema = getValidatedDefinition('DefaultsClass', currentSpec);
+            expect(basicSchema).to.deep.eq(
+              {
+                properties: {
+                  boolValue1: {
+                    type: "boolean",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue2: {
+                    type: "boolean",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue3: {
+                    type: "boolean",
+                    default: false,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue4: {
+                    type: "boolean",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                required: undefined,
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+              },
+              `for property ${propertyName}.basic`
+            );
+            const replacedTypesSchema = getValidatedDefinition('ReplaceTypes_DefaultsClass.boolean.string_', currentSpec);
+            expect(replacedTypesSchema).to.deep.eq(
+              {
+                properties: {
+                  boolValue1: {
+                    type: "string",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue2: {
+                    type: "string",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue3: {
+                    type: "string",
+                    default: false,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue4: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: undefined,
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.replacedTypes`
+            );
+          },
+          jsDocTypeNames: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.simple?.$ref).to.eq("#/definitions/Partial__a-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.commented?.$ref).to.eq("#/definitions/Partial__a_description-comment_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq("#/definitions/Partial__a_description-multiline%5Cncomment_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq("#/definitions/Partial__a_default-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.deprecated?.$ref).to.eq("#/definitions/Partial__a_deprecated-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq("#/definitions/Partial__a_validators%3A_minLength%3A_value%3A3___-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.examples?.$ref).to.eq("#/definitions/Partial__a_example-example_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq("#/definitions/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.ignored?.$ref).to.eq("#/definitions/Partial__a_ignored-true_-string__", `for property ${propertyName}`);
+
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
+
+            const simpleSchema = getValidatedDefinition('Partial__a-string__', currentSpec);
+            expect(simpleSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.simple`
+            );
+            const commentedSchema = getValidatedDefinition('Partial__a_description-comment_-string__', currentSpec);
+            expect(commentedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    description: "comment",
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.commented`
+            );
+            const multilineCommentedSchema = getValidatedDefinition('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
+            expect(multilineCommentedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    description: "multiline\ncomment",
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.multilineCommented`
+            );
+            const defaultValueSchema = getValidatedDefinition('Partial__a_default-true_-string__', currentSpec);
+            expect(defaultValueSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: "true",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.defaultValue`
+            );
+            const deprecatedSchema = getValidatedDefinition('Partial__a_deprecated-true_-string__', currentSpec);
+            expect(deprecatedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    "x-deprecated": true,
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.deprecated`
+            );
+            const validatorsSchema = getValidatedDefinition('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
+            expect(validatorsSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    minLength: 3,
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.validators`
+            );
+            const examplesSchema = getValidatedDefinition('Partial__a_example-example_-string__', currentSpec);
+            expect(examplesSchema).to.deep.eq({
+              default: undefined,
+              description: "Make all properties in T optional",
+              example: undefined,
+              format: undefined,
+              properties: {
+                a: {
+                  default: undefined,
+                  description: undefined,
+                  example: "example",
+                  format: undefined,
+                  type: "string"
+                }
+              },
+              type: "object"
+            },
+              `for property ${propertyName}.examples`
+            );
+            const extensionsSchema = getValidatedDefinition('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
+            expect(extensionsSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    "x-key-1": "value-1",
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.extensions`
+            );
+            const ignoredSchema = getValidatedDefinition('Partial__a_ignored-true_-string__', currentSpec);
+            expect(ignoredSchema).to.deep.eq(
+              {
+                properties: {
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.ignored`
+            );
+            const indexedSchema = getValidatedDefinition('Partial__[a-string]:string__', currentSpec);
+            expect(indexedSchema).to.deep.eq(
+              {
+                properties: {
+                },
+                additionalProperties: {
+                  type: "string"
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.indexedSimple`
+            );
+          },
+          jsdocMap: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.omitted?.$ref).to.eq("#/definitions/Omit_JsDocced.notRelevant_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.partial?.$ref).to.eq("#/definitions/Partial_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq("#/definitions/ReplaceStringAndNumberTypes_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq("#/definitions/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.postfixed?.$ref).to.eq("#/definitions/Postfixed_JsDocced._PostFix_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.values?.$ref).to.eq("#/definitions/Values_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typesValues?.$ref).to.eq("#/definitions/InternalTypes_Values_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.onlyOneValue).to.deep.eq(
+              {
+                type: "number",
+                format: "double",
+                default: undefined,
+                description: undefined,
+                example: undefined
+              },
+              `for property ${propertyName}.onlyOneValue`
+            );
+            expect(propertySchema?.properties?.synonym?.$ref).to.eq("#/definitions/JsDoccedSynonym", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym2?.$ref).to.eq("#/definitions/JsDoccedSynonym2", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
+
+            const omittedSchema = getValidatedDefinition('Omit_JsDocced.notRelevant_', currentSpec);
+            expect(omittedSchema).to.deep.eq(
+              {
+                $ref: "#/definitions/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__",
+                description: "Construct a type with the properties of T except for those in type K.",
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.omitted`
+            );
+            const omittedSchema2 = getValidatedDefinition('Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__', currentSpec);
+            expect(omittedSchema2).to.deep.eq({
+              properties: {
+                stringValue: {
+                  type: "string",
+                  default: "def",
+                  maxLength: 3,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                },
+                numberValue: {
+                  type: "integer",
+                  format: "int32",
+                  default: 6,
+                  description: undefined,
+                  example: undefined
+                }
+              },
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.omitted`
+            );
+            const partialSchema = getValidatedDefinition('Partial_JsDocced_', currentSpec);
+            expect(partialSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    format: undefined,
+                    example: undefined,
+                    description: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    example: undefined,
+                    description: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.partial`
+            );
+            const replacedTypesSchema = getValidatedDefinition('ReplaceStringAndNumberTypes_JsDocced_', currentSpec);
+            expect(replacedTypesSchema).to.deep.eq(
+              {
+                $ref: "#/definitions/ReplaceTypes_JsDocced.string.number_",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.replacedTypes`
+            );
+            const replacedTypes2Schema = getValidatedDefinition('ReplaceTypes_JsDocced.string.number_', currentSpec);
+            expect(replacedTypes2Schema).to.deep.eq({
+              properties: {
+                stringValue: {
+                  type: "number",
+                  format: "double",
+                  default: "def",
+                  maxLength: 3,
+                  description: undefined,
+                  example: undefined,
+                },
+                numberValue: {
+                  type: "string",
+                  default: 6,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.replacedTypes`
+            );
+            const doubleReplacedTypesSchema = getValidatedDefinition('ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__', currentSpec);
+            expect(doubleReplacedTypesSchema).to.deep.eq(
+              {
+                $ref: "#/definitions/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleReplacedTypes`
+            );
+            const doubleReplacedTypes2Schema = getValidatedDefinition('ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_', currentSpec);
+            expect(doubleReplacedTypes2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  },
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleReplacedTypes`
+            );
+            const postfixedSchema = getValidatedDefinition('Postfixed_JsDocced._PostFix_', currentSpec);
+            expect(postfixedSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue_PostFix: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue_PostFix: {
+                    type: "number",
+                    format: "double",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined
+                  }
+                },
+                required: [
+                  "stringValue_PostFix", "numberValue_PostFix"
+                ],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.postfixed`
+            );
+            const valuesSchema = getValidatedDefinition('Values_JsDocced_', currentSpec);
+            expect(valuesSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    properties: {
+                      value: {
+                        type: "string",
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: undefined
+                      }
+                    },
+                    required: ["value"],
+                    type: "object",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    properties: {
+                      value: {
+                        type: "number",
+                        format: "double",
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                      }
+                    },
+                    required: ["value"],
+                    type: "object",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.values`
+            );
+            const typesValuesSchema = getValidatedDefinition('InternalTypes_Values_JsDocced__', currentSpec);
+            expect(typesValuesSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.typesValues`
+            );
+
+            const synonymSchema = getValidatedDefinition('JsDoccedSynonym', currentSpec);
+            expect(synonymSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "number",
+                    format: "double",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  }
+                },
+                required: ["stringValue", "numberValue"],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.synonym`
+            );
+            const synonym2Schema = getValidatedDefinition('JsDoccedSynonym2', currentSpec);
+            expect(synonym2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.synonym2`
+            );
+          },
+          duplicatedDefinitions: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.interfaces?.$ref).to.eq("#/definitions/DuplicatedInterface", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enums?.$ref).to.eq("#/definitions/DuplicatedEnum", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enumMember?.$ref).to.eq("#/definitions/DuplicatedEnum.C", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq("#/definitions/DuplicatedEnum.D", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
+
+            const interfacesSchema = getValidatedDefinition('DuplicatedInterface', currentSpec);
+            expect(interfacesSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  b: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["a", "b"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
+                description: undefined,
+
+              },
+              `for property ${propertyName}.interfaces`
+            );
+            const enumsSchema = getValidatedDefinition('DuplicatedEnum', currentSpec);
+            expect(enumsSchema).to.deep.eq(
+              {
+                enum: ["AA", "BB", "CC"],
+                type: "string",
+                description: undefined
+              },
+              `for property ${propertyName}.enums`
+            );
+            const enumMemberSchema = getValidatedDefinition('DuplicatedEnum.C', currentSpec);
+            expect(enumMemberSchema).to.deep.eq(
+              {
+                enum: ["CC"],
+                type: "string",
+                description: undefined
+              },
+              `for property ${propertyName}.enumMember`
+            );
+            const namespaceMemberSchema = getValidatedDefinition('DuplicatedEnum.D', currentSpec);
+            expect(namespaceMemberSchema).to.deep.eq(
+              {
+                enum: ["DD"],
+                type: "string",
+                "x-nullable": false,
+                description: undefined,
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.namespaceMember`
+            );
+          },
+          mappeds: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.unionMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-_b-number__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq("#/definitions/Partial__a-string_-and-_b-number__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq("#/definitions/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-(_b-string_-and-_c-string_)_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq("#/definitions/Partial_(_a-string_-or-_b-string_)-and-_c-string__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+
+            const unionMapSchema = getValidatedDefinition('Partial__a-string_-or-_b-number__', currentSpec);
+            expect(unionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+              {
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.unionMap`
+            );
+            const indexedUnionMapSchema = getValidatedDefinition('Partial__a-string_-or-_[b-string]:number__', currentSpec);
+            expect(indexedUnionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+              {
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.indexedUnionMap`
+            );
+            const doubleIndexedUnionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
+            expect(doubleIndexedUnionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+              {
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleIndexedUnionMap`
+            );
+            const intersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-_b-number__', currentSpec);
+            expect(intersectionMapSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                b: {
+                  type: "number",
+                  format: "double",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.intersectionMap`
+            );
+            const indexedIntersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-_[b-string]:number__', currentSpec);
+            expect(indexedIntersectionMapSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              additionalProperties: {
+                type: "number",
+                format: "double"
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.indexedIntersectionMap`
+            );
+            const doubleIndexedIntersectionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
+            expect(doubleIndexedIntersectionMapSchema).to.deep.eq({ //Unions are not supported in OpenAPI 2
+              properties: {},
+              additionalProperties: {
+                type: "object"
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.doubleIndexedIntersectionMap`
+            );
+            const parenthesizedMapSchema = getValidatedDefinition('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
+            expect(parenthesizedMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+              {
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.parenthesizedMap`
+            );
+            const parenthesizedMap2Schema = getValidatedDefinition('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
+            expect(parenthesizedMap2Schema).to.deep.eq( //Unions are not supported in OpenAPI 2
+              {
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.parenthesizedMap2`
+            );
+          },
+          conditionals: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.simpeConditional).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq({
+              type: "boolean",
+              format: undefined,
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq("#/definitions/Conditional_string.string.number.boolean_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq("#/definitions/Conditional_string.number.number.boolean_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq("#/definitions/Dummy_Conditional_string.string.number.boolean__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq("#/definitions/Dummy_Conditional_string.number.number.boolean__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq("#/definitions/Partial_stringextendsstring%3F_a-number_-never_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq("#/definitions/Partial_Conditional_string.string._a-number_.never__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+
+            const typedConditionalSchema = getValidatedDefinition('Conditional_string.string.number.boolean_', currentSpec);
+            expect(typedConditionalSchema).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+            },
+              `for property ${propertyName}.typedConditional`);
+            const typedFalseConditionalSchema = getValidatedDefinition('Conditional_string.number.number.boolean_', currentSpec);
+            expect(typedFalseConditionalSchema).to.deep.eq({
+              type: "boolean",
+              format: undefined,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+            },
+              `for property ${propertyName}.typedFalseConditional`);
+            const dummyConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.string.number.boolean__', currentSpec);
+            expect(dummyConditionalSchema?.$ref).to.eq("#/definitions/Conditional_string.string.number.boolean_", `for property ${propertyName}.dummyConditional`);
+            const dummyFalseConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.number.number.boolean__', currentSpec);
+            expect(dummyFalseConditionalSchema?.$ref).to.eq("#/definitions/Conditional_string.number.number.boolean_", `for property ${propertyName}.dummyFalseConditional`);
+            const mappedConditionalSchema = getValidatedDefinition('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            expect(mappedConditionalSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "number",
+                  format: "double",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              example: undefined,
+              default: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.mappedConditional`);
+            const mappedTypedConditionalSchema = getValidatedDefinition('Partial_Conditional_string.string._a-number_.never__', currentSpec);
+            expect(mappedTypedConditionalSchema).to.deep.eq(mappedConditionalSchema, `for property ${propertyName}.mappedTypedConditional`);
+          },
+          typeOperators: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq("#/definitions/KeysMember", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq("#/definitions/KeysMember_NestedTypeLiteral_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple).to.deep.eq({
+              type: "string",
+              enum: ["a", "b", "e"],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.simple`);
+            expect(propertySchema?.properties?.keyofItem).to.deep.eq({
+              type: "string",
+              enum: ["c", "d"],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.keyofItem`);
+            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq({ //Unions are not supported in OpenAPI 2 (string | number)
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              type: "object"
+            },
+              `for property ${propertyName}.keyofAnyItem`);
+            expect(propertySchema?.properties?.keyofAny).to.deep.eq({ //Unions are not supported in OpenAPI 2 (string | number)
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              type: "object"
+            },
+              `for property ${propertyName}.keyofAny`);
+            expect(propertySchema?.properties?.stringLiterals).to.deep.eq({
+              type: "string",
+              enum: ["A", "B", "C"],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.stringLiterals`);
+            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq({ //Unions are not perfectly supported in OpenAPI 2 (string | number)
+              enum: ["A", "B", "3"],
+              type: "string",
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.stringAndNumberLiterals`);
+            expect(propertySchema?.properties?.keyofEnum).to.deep.eq({
+              type: "string",
+              enum: ["A", "B", "C"],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keyofEnum`);
+            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq({ //Unions are not perfectly supported in OpenAPI 2 (string | number)
+              enum: ["a", "3", "4"],
+              type: "string",
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.numberAndStringKeys`);
+            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq({
+              type: "string",
+              enum: ["a"],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.oneStringKeyInterface`);
+            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq({
+              type: "number",
+              enum: [3],
+              "x-nullable": false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.oneNumberKeyInterface`);
+            expect(propertySchema?.properties?.indexStrings).to.deep.eq({  //Unions are not perfectly supported in OpenAPI 2 (string | number)
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.indexStrings`);
+            expect(propertySchema?.properties?.indexNumbers).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}.indexNumbers`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(14, `for property ${propertyName}`);
+
+            const keysOfAnySchema = getValidatedDefinition('KeysMember', currentSpec);
+            expect(keysOfAnySchema).to.deep.eq({  //Unions are not perfectly supported in OpenAPI 2 (string | number)
+              properties: {
+                keys: {
+                  type: "object",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                }
+              },
+              required: ["keys"],
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keysOfAny`);
+
+            const keysOfInterfaceSchema = getValidatedDefinition('KeysMember_NestedTypeLiteral_', currentSpec);
+            expect(keysOfInterfaceSchema).to.deep.eq({
+              properties: {
+                keys: {
+                  type: "string",
+                  enum: ["a", "b", "e"],
+                  "x-nullable": false,
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                }
+              },
+              required: ["keys"],
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keysOfInterface`);
+          },
+          nestedTypes: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq("#/definitions/Partial_Partial__a-string___", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField2?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField3?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
+
+            const multiplePartialSchema = getValidatedDefinition('Partial_Partial__a-string___', currentSpec);
+            expect(multiplePartialSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.multiplePartial`);
+            const separateFieldSchema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldSchema).to.deep.eq({
+              properties: {
+                omitted: {
+                  $ref: "#/definitions/Omit_Partial__a-string--b-string__.a_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                },
+                field: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField`);
+            const separateFieldInternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-string__.a_', currentSpec);
+            expect(separateFieldInternalSchema).to.deep.eq({
+              $ref: "#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__",
+              description: "Construct a type with the properties of T except for those in type K.",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField.omitted`);
+
+            const separateFieldInternal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldInternal2Schema).to.deep.eq({
+              properties: {
+                b: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField.omitted`);
+
+            const separateField2Schema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', currentSpec);
+            expect(separateField2Schema).to.deep.eq({
+              properties: {
+                omitted: {
+                  $ref: "#/definitions/Omit_Partial__a-string--b-string__.a-or-b_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                field: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField2`);
+            const separateField2InternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-string__.a-or-b_', currentSpec);
+            expect(separateField2InternalSchema?.$ref).to.eq("#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__",
+              `for property ${propertyName}.separateField2.omitted`
+            );
+            const separateField2Internal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__', currentSpec);
+            expect(separateField2Internal2Schema).to.deep.eq({
+              properties: {},
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField2.omitted`);
+
+            const separateField3Schema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', currentSpec);
+            expect(separateField3Schema).to.deep.eq({ //Unions are not supported in OpenAPI 2
+              properties:
+              {
+                omitted: {
+                  $ref: "#/definitions/Omit_Partial__a-string--b-number__.a-or-b_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                field: {
+                  type: "object",
+                  description: undefined,
+                  default: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField3`);
+            const separateField3InternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-number__.a-or-b_', currentSpec);
+            expect(separateField3InternalSchema?.$ref).to.eq("#/definitions/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__",
+              `for property ${propertyName}.separateField3.omitted`
+            );
+            const separateField3Internal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__', currentSpec);
+            expect(separateField3Internal2Schema).to.deep.eq({
+              properties: {},
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField3.omitted`);
+          }
         };
 
         Object.keys(assertionsPerProperty).forEach(aPropertyName => {
@@ -1659,7 +3161,7 @@ describe('Definition generation', () => {
             throw new Error('No definition properties.');
           }
 
-          expect(definition.properties.boolValue.default).to.equal('true');
+          expect(definition.properties.boolValue.default).to.equal(true);
         });
       });
     });
@@ -2005,3 +3507,7 @@ describe('Definition generation', () => {
     });
   });
 });
+
+
+
+

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -600,7 +600,7 @@ describe('Definition generation', () => {
                   default: undefined,
                 },
               },
-              required: ["1", "2"],
+              required: ['1', '2'],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -619,18 +619,18 @@ describe('Definition generation', () => {
                     description: undefined,
                     example: undefined,
                     format: undefined,
-                    type: "string"
-                  }
+                    type: 'string',
+                  },
                 },
-                required: ["data"],
-                type: "object"
+                required: ['data'],
+                type: 'object',
               },
               default: undefined,
-              description: "Construct a type with a set of properties K of type T",
+              description: 'Construct a type with a set of properties K of type T',
               example: undefined,
               format: undefined,
               properties: {},
-              type: "object"
+              type: 'object',
             });
           },
           numberRecord: (propertyName, propertySchema) => {
@@ -644,18 +644,18 @@ describe('Definition generation', () => {
                     description: undefined,
                     example: undefined,
                     format: undefined,
-                    type: "string"
-                  }
+                    type: 'string',
+                  },
                 },
-                required: ["data"],
-                type: "object"
+                required: ['data'],
+                type: 'object',
               },
               default: undefined,
-              description: "Construct a type with a set of properties K of type T",
+              description: 'Construct a type with a set of properties K of type T',
               example: undefined,
               format: undefined,
               properties: {},
-              type: "object"
+              type: 'object',
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
@@ -1575,7 +1575,7 @@ describe('Definition generation', () => {
                   'weight:desc',
                   'human:desc',
                   'gender:desc',
-                  'nicknames:desc'
+                  'nicknames:desc',
                 ],
                 type: 'object',
                 description: undefined,
@@ -1635,50 +1635,44 @@ describe('Definition generation', () => {
               {
                 properties: {
                   typeHolder2: {
-                    $ref: "#/definitions/Namespace2.TypeHolder",
+                    $ref: '#/definitions/Namespace2.TypeHolder',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inModule: {
-                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/definitions/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   typeHolder1: {
-                    $ref: "#/definitions/Namespace1.TypeHolder",
+                    $ref: '#/definitions/Namespace1.TypeHolder',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace1: {
-                    $ref: "#/definitions/Namespace1.NamespaceType",
+                    $ref: '#/definitions/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   simple: {
-                    $ref: "#/definitions/NamespaceType",
+                    $ref: '#/definitions/NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: [
-                  "typeHolder2",
-                  "inModule",
-                  "typeHolder1",
-                  "inNamespace1",
-                  "simple"
-                ],
-                type: "object",
+                required: ['typeHolder2', 'inModule', 'typeHolder1', 'inNamespace1', 'simple'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}`
+              `for property ${propertyName}`,
             );
 
             const typeHolder2Schema = getValidatedDefinition('Namespace2.TypeHolder', currentSpec);
@@ -1686,25 +1680,24 @@ describe('Definition generation', () => {
               {
                 properties: {
                   inModule: {
-                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/definitions/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace2: {
-                    $ref: "#/definitions/Namespace2.NamespaceType",
+                    $ref: '#/definitions/Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inModule",
-                  "inNamespace2"],
-                type: "object",
+                required: ['inModule', 'inNamespace2'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
-                description: undefined
+                description: undefined,
               },
-              `for property ${propertyName}.typeHolder2`
+              `for property ${propertyName}.typeHolder2`,
             );
 
             const namespace2_namespace2_namespaceTypeSchema = getValidatedDefinition('Namespace2.Namespace2.NamespaceType', currentSpec);
@@ -1712,51 +1705,50 @@ describe('Definition generation', () => {
               {
                 properties: {
                   inModule: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   other: {
-                    $ref: "#/definitions/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/definitions/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inModule"],
-                type: "object",
+                required: ['inModule'],
+                type: 'object',
                 description: undefined,
-                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder2.inModule`
+              `for property ${propertyName}.typeHolder2.inModule`,
             );
 
             const typeHolderSchema = getValidatedDefinition('Namespace1.TypeHolder', currentSpec);
             expect(typeHolderSchema).to.deep.eq(
               {
                 properties: {
-                  inNamespace1_1:
-                  {
-                    $ref: "#/definitions/Namespace1.NamespaceType",
+                  inNamespace1_1: {
+                    $ref: '#/definitions/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace1_2: {
-                    $ref: "#/definitions/Namespace1.NamespaceType",
+                    $ref: '#/definitions/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inNamespace1_1", "inNamespace1_2"],
-                type: "object",
+                required: ['inNamespace1_1', 'inNamespace1_2'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
-                description: undefined
+                description: undefined,
               },
-              `for property ${propertyName}.typeHolder1`
+              `for property ${propertyName}.typeHolder1`,
             );
 
             const namespace1_namespaceTypeSchema = getValidatedDefinition('Namespace1.NamespaceType', currentSpec);
@@ -1764,26 +1756,26 @@ describe('Definition generation', () => {
               {
                 properties: {
                   inFirstNamespace: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inFirstNamespace2: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inFirstNamespace", "inFirstNamespace2"],
-                type: "object",
+                required: ['inFirstNamespace', 'inFirstNamespace2'],
+                type: 'object',
                 description: undefined,
-                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder1.inNamespace1_1`
+              `for property ${propertyName}.typeHolder1.inNamespace1_1`,
             );
 
             const namespace2_namespaceTypeSchema = getValidatedDefinition('Namespace2.NamespaceType', currentSpec);
@@ -1791,99 +1783,118 @@ describe('Definition generation', () => {
               {
                 properties: {
                   inSecondNamespace: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                 },
-                required: ["inSecondNamespace"],
-                type: "object",
+                required: ['inSecondNamespace'],
+                type: 'object',
                 description: undefined,
-                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder2.inNamespace2`
+              `for property ${propertyName}.typeHolder2.inNamespace2`,
             );
 
             const namespaceTypeSchema = getValidatedDefinition('NamespaceType', currentSpec);
             expect(namespaceTypeSchema).to.deep.eq(
               {
-                type: "string",
+                type: 'string',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.simple`
+              `for property ${propertyName}.simple`,
             );
           },
           defaults: (propertyName, propertySchema) => {
-            expect(propertySchema).to.deep.eq({
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-              properties: {
-                basic: {
-                  $ref: "#/definitions/DefaultsClass",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                },
-                defaultNull: {
-                  default: null,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  type: "string",
-                  "x-nullable": true
-                },
-                defaultObject: {
-                  default: {
-                    a: "a",
-                    b: 2
+            expect(propertySchema).to.deep.eq(
+              {
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+                properties: {
+                  basic: {
+                    $ref: '#/definitions/DefaultsClass',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
                   },
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  properties: {
-                    a: {
-                      default: undefined,
-                      description: undefined,
-                      example: undefined,
-                      format: undefined,
-                      type: "string"
+                  defaultNull: {
+                    default: null,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: 'string',
+                    'x-nullable': true,
+                  },
+                  defaultObject: {
+                    default: {
+                      a: 'a',
+                      b: 2,
                     },
-                    b: {
-                      default: undefined,
-                      description: undefined,
-                      example: undefined,
-                      format: "double",
-                      type: "number"
-                    }
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    properties: {
+                      a: {
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: undefined,
+                        type: 'string',
+                      },
+                      b: {
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: 'double',
+                        type: 'number',
+                      },
+                    },
+                    required: ['b', 'a'],
+                    type: 'object',
                   },
-                  required: ["b", "a"],
-                  type: "object"
+                  defaultUndefined: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: 'string',
+                  },
+                  replacedTypes: {
+                    $ref: '#/definitions/ReplaceTypes_DefaultsClass.boolean.string_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  comments: {
+                    default: 4,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  jsonCharacters: {
+                    default: { '\\': '\n' },
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  stringEscapeCharacters: {
+                    default: '`"\'"\'\n\t\r\b\fgx\\',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                defaultUndefined: {
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  type: "string"
-                },
-                replacedTypes: {
-                  $ref: "#/definitions/ReplaceTypes_DefaultsClass.boolean.string_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                required: ['replacedTypes', 'basic'],
+                type: 'object',
               },
-              required: ["replacedTypes", "basic"],
-              type: "object"
-            },
-              `for property ${propertyName}`
+              `for property ${propertyName}`,
             );
 
             const basicSchema = getValidatedDefinition('DefaultsClass', currentSpec);
@@ -1891,103 +1902,103 @@ describe('Definition generation', () => {
               {
                 properties: {
                   boolValue1: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue2: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue3: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: false,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue4: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 required: undefined,
                 description: undefined,
-                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.basic`
+              `for property ${propertyName}.basic`,
             );
             const replacedTypesSchema = getValidatedDefinition('ReplaceTypes_DefaultsClass.boolean.string_', currentSpec);
             expect(replacedTypesSchema).to.deep.eq(
               {
                 properties: {
                   boolValue1: {
-                    type: "string",
+                    type: 'string',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue2: {
-                    type: "string",
+                    type: 'string',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue3: {
-                    type: "string",
+                    type: 'string',
                     default: false,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue4: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 description: undefined,
                 default: undefined,
                 example: undefined,
                 format: undefined,
               },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
           },
           jsDocTypeNames: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.simple?.$ref).to.eq("#/definitions/Partial__a-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.commented?.$ref).to.eq("#/definitions/Partial__a_description-comment_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq("#/definitions/Partial__a_description-multiline%5Cncomment_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq("#/definitions/Partial__a_default-true_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.deprecated?.$ref).to.eq("#/definitions/Partial__a_deprecated-true_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.validators?.$ref).to.eq("#/definitions/Partial__a_validators%3A_minLength%3A_value%3A3___-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.examples?.$ref).to.eq("#/definitions/Partial__a_example-example_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.extensions?.$ref).to.eq("#/definitions/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.ignored?.$ref).to.eq("#/definitions/Partial__a_ignored-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple?.$ref).to.eq('#/definitions/Partial__a-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.commented?.$ref).to.eq('#/definitions/Partial__a_description-comment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/definitions/Partial__a_description-multiline%5Cncomment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq('#/definitions/Partial__a_default-true_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.deprecated?.$ref).to.eq('#/definitions/Partial__a_deprecated-true_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/definitions/Partial__a_validators%3A_minLength%3A_value%3A3___-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.examples?.$ref).to.eq('#/definitions/Partial__a_example-example_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/definitions/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.ignored?.$ref).to.eq('#/definitions/Partial__a_ignored-true_-string__', `for property ${propertyName}`);
 
-            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
 
@@ -1996,388 +2007,387 @@ describe('Definition generation', () => {
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.simple`
+              `for property ${propertyName}.simple`,
             );
             const commentedSchema = getValidatedDefinition('Partial__a_description-comment_-string__', currentSpec);
             expect(commentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    description: "comment",
+                    type: 'string',
+                    description: 'comment',
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.commented`
+              `for property ${propertyName}.commented`,
             );
             const multilineCommentedSchema = getValidatedDefinition('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    description: "multiline\ncomment",
+                    type: 'string',
+                    description: 'multiline\ncomment',
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.multilineCommented`
+              `for property ${propertyName}.multilineCommented`,
             );
             const defaultValueSchema = getValidatedDefinition('Partial__a_default-true_-string__', currentSpec);
             expect(defaultValueSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    default: "true",
+                    type: 'string',
+                    default: 'true',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.defaultValue`
+              `for property ${propertyName}.defaultValue`,
             );
             const deprecatedSchema = getValidatedDefinition('Partial__a_deprecated-true_-string__', currentSpec);
             expect(deprecatedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    "x-deprecated": true,
+                    type: 'string',
+                    'x-deprecated': true,
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.deprecated`
+              `for property ${propertyName}.deprecated`,
             );
             const validatorsSchema = getValidatedDefinition('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
             expect(validatorsSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     minLength: 3,
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.validators`
+              `for property ${propertyName}.validators`,
             );
             const examplesSchema = getValidatedDefinition('Partial__a_example-example_-string__', currentSpec);
-            expect(examplesSchema).to.deep.eq({
-              default: undefined,
-              description: "Make all properties in T optional",
-              example: undefined,
-              format: undefined,
-              properties: {
-                a: {
-                  default: undefined,
-                  description: undefined,
-                  example: "example",
-                  format: undefined,
-                  type: "string"
-                }
+            expect(examplesSchema).to.deep.eq(
+              {
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+                properties: {
+                  a: {
+                    default: undefined,
+                    description: undefined,
+                    example: 'example',
+                    format: undefined,
+                    type: 'string',
+                  },
+                },
+                type: 'object',
               },
-              type: "object"
-            },
-              `for property ${propertyName}.examples`
+              `for property ${propertyName}.examples`,
             );
             const extensionsSchema = getValidatedDefinition('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
             expect(extensionsSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    "x-key-1": "value-1",
+                    type: 'string',
+                    'x-key-1': 'value-1',
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.extensions`
+              `for property ${propertyName}.extensions`,
             );
             const ignoredSchema = getValidatedDefinition('Partial__a_ignored-true_-string__', currentSpec);
             expect(ignoredSchema).to.deep.eq(
               {
-                properties: {
-                },
-                type: "object",
-                description: "Make all properties in T optional",
+                properties: {},
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.ignored`
+              `for property ${propertyName}.ignored`,
             );
             const indexedSchema = getValidatedDefinition('Partial__[a-string]:string__', currentSpec);
             expect(indexedSchema).to.deep.eq(
               {
-                properties: {
-                },
+                properties: {},
                 additionalProperties: {
-                  type: "string"
+                  type: 'string',
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.indexedSimple`
+              `for property ${propertyName}.indexedSimple`,
             );
           },
           jsdocMap: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.omitted?.$ref).to.eq("#/definitions/Omit_JsDocced.notRelevant_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.partial?.$ref).to.eq("#/definitions/Partial_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq("#/definitions/ReplaceStringAndNumberTypes_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq("#/definitions/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.postfixed?.$ref).to.eq("#/definitions/Postfixed_JsDocced._PostFix_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.values?.$ref).to.eq("#/definitions/Values_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typesValues?.$ref).to.eq("#/definitions/InternalTypes_Values_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.omitted?.$ref).to.eq('#/definitions/Omit_JsDocced.notRelevant_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.partial?.$ref).to.eq('#/definitions/Partial_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq('#/definitions/ReplaceStringAndNumberTypes_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq('#/definitions/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.postfixed?.$ref).to.eq('#/definitions/Postfixed_JsDocced._PostFix_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.values?.$ref).to.eq('#/definitions/Values_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typesValues?.$ref).to.eq('#/definitions/InternalTypes_Values_JsDocced__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.onlyOneValue).to.deep.eq(
               {
-                type: "number",
-                format: "double",
+                type: 'number',
+                format: 'double',
                 default: undefined,
                 description: undefined,
-                example: undefined
+                example: undefined,
               },
-              `for property ${propertyName}.onlyOneValue`
+              `for property ${propertyName}.onlyOneValue`,
             );
-            expect(propertySchema?.properties?.synonym?.$ref).to.eq("#/definitions/JsDoccedSynonym", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.synonym2?.$ref).to.eq("#/definitions/JsDoccedSynonym2", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym?.$ref).to.eq('#/definitions/JsDoccedSynonym', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym2?.$ref).to.eq('#/definitions/JsDoccedSynonym2', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
 
             const omittedSchema = getValidatedDefinition('Omit_JsDocced.notRelevant_', currentSpec);
             expect(omittedSchema).to.deep.eq(
               {
-                $ref: "#/definitions/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__",
-                description: "Construct a type with the properties of T except for those in type K.",
+                $ref: '#/definitions/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__',
+                description: 'Construct a type with the properties of T except for those in type K.',
                 default: undefined,
                 example: undefined,
                 format: undefined,
               },
-              `for property ${propertyName}.omitted`
+              `for property ${propertyName}.omitted`,
             );
             const omittedSchema2 = getValidatedDefinition('Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__', currentSpec);
-            expect(omittedSchema2).to.deep.eq({
-              properties: {
-                stringValue: {
-                  type: "string",
-                  default: "def",
-                  maxLength: 3,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
+            expect(omittedSchema2).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: 'string',
+                    default: 'def',
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  numberValue: {
+                    type: 'integer',
+                    format: 'int32',
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  },
                 },
-                numberValue: {
-                  type: "integer",
-                  format: "int32",
-                  default: 6,
-                  description: undefined,
-                  example: undefined
-                }
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.omitted`
+              `for property ${propertyName}.omitted`,
             );
             const partialSchema = getValidatedDefinition('Partial_JsDocced_', currentSpec);
             expect(partialSchema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     format: undefined,
                     example: undefined,
-                    description: undefined
+                    description: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     example: undefined,
-                    description: undefined
-                  }
+                    description: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.partial`
+              `for property ${propertyName}.partial`,
             );
             const replacedTypesSchema = getValidatedDefinition('ReplaceStringAndNumberTypes_JsDocced_', currentSpec);
             expect(replacedTypesSchema).to.deep.eq(
               {
-                $ref: "#/definitions/ReplaceTypes_JsDocced.string.number_",
+                $ref: '#/definitions/ReplaceTypes_JsDocced.string.number_',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
             const replacedTypes2Schema = getValidatedDefinition('ReplaceTypes_JsDocced.string.number_', currentSpec);
-            expect(replacedTypes2Schema).to.deep.eq({
-              properties: {
-                stringValue: {
-                  type: "number",
-                  format: "double",
-                  default: "def",
-                  maxLength: 3,
-                  description: undefined,
-                  example: undefined,
+            expect(replacedTypes2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: 'number',
+                    format: 'double',
+                    default: 'def',
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                  },
+                  numberValue: {
+                    type: 'string',
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                numberValue: {
-                  type: "string",
-                  default: 6,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
             const doubleReplacedTypesSchema = getValidatedDefinition('ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__', currentSpec);
             expect(doubleReplacedTypesSchema).to.deep.eq(
               {
-                $ref: "#/definitions/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_",
+                $ref: '#/definitions/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleReplacedTypes`
+              `for property ${propertyName}.doubleReplacedTypes`,
             );
             const doubleReplacedTypes2Schema = getValidatedDefinition('ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_', currentSpec);
             expect(doubleReplacedTypes2Schema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
                     example: undefined,
                   },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleReplacedTypes`
+              `for property ${propertyName}.doubleReplacedTypes`,
             );
             const postfixedSchema = getValidatedDefinition('Postfixed_JsDocced._PostFix_', currentSpec);
             expect(postfixedSchema).to.deep.eq(
               {
                 properties: {
                   stringValue_PostFix: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue_PostFix: {
-                    type: "number",
-                    format: "double",
+                    type: 'number',
+                    format: 'double',
                     default: undefined,
                     description: undefined,
-                    example: undefined
-                  }
+                    example: undefined,
+                  },
                 },
-                required: [
-                  "stringValue_PostFix", "numberValue_PostFix"
-                ],
-                type: "object",
+                required: ['stringValue_PostFix', 'numberValue_PostFix'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.postfixed`
+              `for property ${propertyName}.postfixed`,
             );
             const valuesSchema = getValidatedDefinition('Values_JsDocced_', currentSpec);
             expect(valuesSchema).to.deep.eq(
@@ -2386,74 +2396,74 @@ describe('Definition generation', () => {
                   stringValue: {
                     properties: {
                       value: {
-                        type: "string",
+                        type: 'string',
                         default: undefined,
                         description: undefined,
                         example: undefined,
-                        format: undefined
-                      }
+                        format: undefined,
+                      },
                     },
-                    required: ["value"],
-                    type: "object",
-                    default: "def",
+                    required: ['value'],
+                    type: 'object',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
                     properties: {
                       value: {
-                        type: "number",
-                        format: "double",
+                        type: 'number',
+                        format: 'double',
                         default: undefined,
                         description: undefined,
                         example: undefined,
-                      }
+                      },
                     },
-                    required: ["value"],
-                    type: "object",
+                    required: ['value'],
+                    type: 'object',
                     default: 6,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.values`
+              `for property ${propertyName}.values`,
             );
             const typesValuesSchema = getValidatedDefinition('InternalTypes_Values_JsDocced__', currentSpec);
             expect(typesValuesSchema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
                     example: undefined,
-                  }
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.typesValues`
+              `for property ${propertyName}.typesValues`,
             );
 
             const synonymSchema = getValidatedDefinition('JsDoccedSynonym', currentSpec);
@@ -2461,63 +2471,63 @@ describe('Definition generation', () => {
               {
                 properties: {
                   stringValue: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "number",
-                    format: "double",
+                    type: 'number',
+                    format: 'double',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                  }
+                  },
                 },
-                required: ["stringValue", "numberValue"],
-                type: "object",
+                required: ['stringValue', 'numberValue'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.synonym`
+              `for property ${propertyName}.synonym`,
             );
             const synonym2Schema = getValidatedDefinition('JsDoccedSynonym2', currentSpec);
             expect(synonym2Schema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
-                    example: undefined
-                  }
+                    example: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.synonym2`
+              `for property ${propertyName}.synonym2`,
             );
           },
           duplicatedDefinitions: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.interfaces?.$ref).to.eq("#/definitions/DuplicatedInterface", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.enums?.$ref).to.eq("#/definitions/DuplicatedEnum", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.enumMember?.$ref).to.eq("#/definitions/DuplicatedEnum.C", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq("#/definitions/DuplicatedEnum.D", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.interfaces?.$ref).to.eq('#/definitions/DuplicatedInterface', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enums?.$ref).to.eq('#/definitions/DuplicatedEnum', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enumMember?.$ref).to.eq('#/definitions/DuplicatedEnum.C', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq('#/definitions/DuplicatedEnum.D', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
 
@@ -2526,578 +2536,651 @@ describe('Definition generation', () => {
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   b: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["a", "b"],
-                type: "object",
+                required: ['a', 'b'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' || currentSpec.specName === 'dynamicSpecWithNoImplicitExtras' ? false : true,
                 description: undefined,
-
               },
-              `for property ${propertyName}.interfaces`
+              `for property ${propertyName}.interfaces`,
             );
             const enumsSchema = getValidatedDefinition('DuplicatedEnum', currentSpec);
             expect(enumsSchema).to.deep.eq(
               {
-                enum: ["AA", "BB", "CC"],
-                type: "string",
-                description: undefined
+                enum: ['AA', 'BB', 'CC'],
+                type: 'string',
+                description: undefined,
               },
-              `for property ${propertyName}.enums`
+              `for property ${propertyName}.enums`,
             );
             const enumMemberSchema = getValidatedDefinition('DuplicatedEnum.C', currentSpec);
             expect(enumMemberSchema).to.deep.eq(
               {
-                enum: ["CC"],
-                type: "string",
-                description: undefined
+                enum: ['CC'],
+                type: 'string',
+                description: undefined,
               },
-              `for property ${propertyName}.enumMember`
+              `for property ${propertyName}.enumMember`,
             );
             const namespaceMemberSchema = getValidatedDefinition('DuplicatedEnum.D', currentSpec);
             expect(namespaceMemberSchema).to.deep.eq(
               {
-                enum: ["DD"],
-                type: "string",
-                "x-nullable": false,
+                enum: ['DD'],
+                type: 'string',
+                'x-nullable': false,
                 description: undefined,
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.namespaceMember`
+              `for property ${propertyName}.namespaceMember`,
             );
           },
           mappeds: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.unionMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-_b-number__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq("#/definitions/Partial__a-string_-and-_b-number__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq("#/definitions/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq("#/definitions/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq("#/definitions/Partial__a-string_-or-(_b-string_-and-_c-string_)_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq("#/definitions/Partial_(_a-string_-or-_b-string_)-and-_c-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.unionMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_b-number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-_b-number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq(
+              '#/definitions/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__',
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-(_b-string_-and-_c-string_)_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/definitions/Partial_(_a-string_-or-_b-string_)-and-_c-string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
             const unionMapSchema = getValidatedDefinition('Partial__a-string_-or-_b-number__', currentSpec);
-            expect(unionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+            expect(unionMapSchema).to.deep.eq(
+              //Unions are not supported in OpenAPI 2
               {
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.unionMap`
+              `for property ${propertyName}.unionMap`,
             );
             const indexedUnionMapSchema = getValidatedDefinition('Partial__a-string_-or-_[b-string]:number__', currentSpec);
-            expect(indexedUnionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+            expect(indexedUnionMapSchema).to.deep.eq(
+              //Unions are not supported in OpenAPI 2
               {
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.indexedUnionMap`
+              `for property ${propertyName}.indexedUnionMap`,
             );
             const doubleIndexedUnionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
-            expect(doubleIndexedUnionMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+            expect(doubleIndexedUnionMapSchema).to.deep.eq(
+              //Unions are not supported in OpenAPI 2
               {
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleIndexedUnionMap`
+              `for property ${propertyName}.doubleIndexedUnionMap`,
             );
             const intersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-_b-number__', currentSpec);
-            expect(intersectionMapSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+            expect(intersectionMapSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  b: {
+                    type: 'number',
+                    format: 'double',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  },
                 },
-                b: {
-                  type: "number",
-                  format: "double",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.intersectionMap`
+              `for property ${propertyName}.intersectionMap`,
             );
             const indexedIntersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-_[b-string]:number__', currentSpec);
-            expect(indexedIntersectionMapSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+            expect(indexedIntersectionMapSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                additionalProperties: {
+                  type: 'number',
+                  format: 'double',
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              additionalProperties: {
-                type: "number",
-                format: "double"
-              },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.indexedIntersectionMap`
+              `for property ${propertyName}.indexedIntersectionMap`,
             );
             const doubleIndexedIntersectionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
-            expect(doubleIndexedIntersectionMapSchema).to.deep.eq({ //Unions are not supported in OpenAPI 2
-              properties: {},
-              additionalProperties: {
-                type: "object"
+            expect(doubleIndexedIntersectionMapSchema).to.deep.eq(
+              {
+                //Unions are not supported in OpenAPI 2
+                properties: {},
+                additionalProperties: {
+                  type: 'object',
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.doubleIndexedIntersectionMap`
+              `for property ${propertyName}.doubleIndexedIntersectionMap`,
             );
             const parenthesizedMapSchema = getValidatedDefinition('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
-            expect(parenthesizedMapSchema).to.deep.eq( //Unions are not supported in OpenAPI 2
+            expect(parenthesizedMapSchema).to.deep.eq(
+              //Unions are not supported in OpenAPI 2
               {
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.parenthesizedMap`
+              `for property ${propertyName}.parenthesizedMap`,
             );
             const parenthesizedMap2Schema = getValidatedDefinition('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
-            expect(parenthesizedMap2Schema).to.deep.eq( //Unions are not supported in OpenAPI 2
+            expect(parenthesizedMap2Schema).to.deep.eq(
+              //Unions are not supported in OpenAPI 2
               {
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.parenthesizedMap2`
+              `for property ${propertyName}.parenthesizedMap2`,
             );
           },
           conditionals: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.simpeConditional).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}`);
-            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq({
-              type: "boolean",
-              format: undefined,
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq("#/definitions/Conditional_string.string.number.boolean_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq("#/definitions/Conditional_string.number.number.boolean_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq("#/definitions/Dummy_Conditional_string.string.number.boolean__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq("#/definitions/Dummy_Conditional_string.number.number.boolean__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq("#/definitions/Partial_stringextendsstring%3F_a-number_-never_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq("#/definitions/Partial_Conditional_string.string._a-number_.never__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simpeConditional).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq(
+              {
+                type: 'boolean',
+                format: undefined,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq('#/definitions/Conditional_string.string.number.boolean_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq('#/definitions/Conditional_string.number.number.boolean_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq('#/definitions/Dummy_Conditional_string.string.number.boolean__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq('#/definitions/Dummy_Conditional_string.number.number.boolean__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/definitions/Partial_stringextendsstring%3F_a-number_-never_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq('#/definitions/Partial_Conditional_string.string._a-number_.never__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
             const typedConditionalSchema = getValidatedDefinition('Conditional_string.string.number.boolean_', currentSpec);
-            expect(typedConditionalSchema).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-            },
-              `for property ${propertyName}.typedConditional`);
-            const typedFalseConditionalSchema = getValidatedDefinition('Conditional_string.number.number.boolean_', currentSpec);
-            expect(typedFalseConditionalSchema).to.deep.eq({
-              type: "boolean",
-              format: undefined,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-            },
-              `for property ${propertyName}.typedFalseConditional`);
-            const dummyConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.string.number.boolean__', currentSpec);
-            expect(dummyConditionalSchema?.$ref).to.eq("#/definitions/Conditional_string.string.number.boolean_", `for property ${propertyName}.dummyConditional`);
-            const dummyFalseConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.number.number.boolean__', currentSpec);
-            expect(dummyFalseConditionalSchema?.$ref).to.eq("#/definitions/Conditional_string.number.number.boolean_", `for property ${propertyName}.dummyFalseConditional`);
-            const mappedConditionalSchema = getValidatedDefinition('Partial_stringextendsstring?_a-number_-never_', currentSpec);
-            expect(mappedConditionalSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "number",
-                  format: "double",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                }
+            expect(typedConditionalSchema).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              example: undefined,
-              default: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.mappedConditional`);
+              `for property ${propertyName}.typedConditional`,
+            );
+            const typedFalseConditionalSchema = getValidatedDefinition('Conditional_string.number.number.boolean_', currentSpec);
+            expect(typedFalseConditionalSchema).to.deep.eq(
+              {
+                type: 'boolean',
+                format: undefined,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}.typedFalseConditional`,
+            );
+            const dummyConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.string.number.boolean__', currentSpec);
+            expect(dummyConditionalSchema?.$ref).to.eq('#/definitions/Conditional_string.string.number.boolean_', `for property ${propertyName}.dummyConditional`);
+            const dummyFalseConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.number.number.boolean__', currentSpec);
+            expect(dummyFalseConditionalSchema?.$ref).to.eq('#/definitions/Conditional_string.number.number.boolean_', `for property ${propertyName}.dummyFalseConditional`);
+            const mappedConditionalSchema = getValidatedDefinition('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            expect(mappedConditionalSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'number',
+                    format: 'double',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                example: undefined,
+                default: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.mappedConditional`,
+            );
             const mappedTypedConditionalSchema = getValidatedDefinition('Partial_Conditional_string.string._a-number_.never__', currentSpec);
             expect(mappedTypedConditionalSchema).to.deep.eq(mappedConditionalSchema, `for property ${propertyName}.mappedTypedConditional`);
           },
           typeOperators: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq("#/definitions/KeysMember", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq("#/definitions/KeysMember_NestedTypeLiteral_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.simple).to.deep.eq({
-              type: "string",
-              enum: ["a", "b", "e"],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.simple`);
-            expect(propertySchema?.properties?.keyofItem).to.deep.eq({
-              type: "string",
-              enum: ["c", "d"],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.keyofItem`);
-            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq({ //Unions are not supported in OpenAPI 2 (string | number)
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-              type: "object"
-            },
-              `for property ${propertyName}.keyofAnyItem`);
-            expect(propertySchema?.properties?.keyofAny).to.deep.eq({ //Unions are not supported in OpenAPI 2 (string | number)
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-              type: "object"
-            },
-              `for property ${propertyName}.keyofAny`);
-            expect(propertySchema?.properties?.stringLiterals).to.deep.eq({
-              type: "string",
-              enum: ["A", "B", "C"],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.stringLiterals`);
-            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq({ //Unions are not perfectly supported in OpenAPI 2 (string | number)
-              enum: ["A", "B", "3"],
-              type: "string",
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.stringAndNumberLiterals`);
-            expect(propertySchema?.properties?.keyofEnum).to.deep.eq({
-              type: "string",
-              enum: ["A", "B", "C"],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keyofEnum`);
-            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq({ //Unions are not perfectly supported in OpenAPI 2 (string | number)
-              enum: ["a", "3", "4"],
-              type: "string",
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.numberAndStringKeys`);
-            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq({
-              type: "string",
-              enum: ["a"],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.oneStringKeyInterface`);
-            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq({
-              type: "number",
-              enum: [3],
-              "x-nullable": false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.oneNumberKeyInterface`);
-            expect(propertySchema?.properties?.indexStrings).to.deep.eq({  //Unions are not perfectly supported in OpenAPI 2 (string | number)
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.indexStrings`);
-            expect(propertySchema?.properties?.indexNumbers).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}.indexNumbers`);
+            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq('#/definitions/KeysMember', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq('#/definitions/KeysMember_NestedTypeLiteral_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['a', 'b', 'e'],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.simple`,
+            );
+            expect(propertySchema?.properties?.keyofItem).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['c', 'd'],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.keyofItem`,
+            );
+            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq(
+              {
+                //Unions are not supported in OpenAPI 2 (string | number)
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+                type: 'object',
+              },
+              `for property ${propertyName}.keyofAnyItem`,
+            );
+            expect(propertySchema?.properties?.keyofAny).to.deep.eq(
+              {
+                //Unions are not supported in OpenAPI 2 (string | number)
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+                type: 'object',
+              },
+              `for property ${propertyName}.keyofAny`,
+            );
+            expect(propertySchema?.properties?.stringLiterals).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['A', 'B', 'C'],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.stringLiterals`,
+            );
+            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq(
+              {
+                //Unions are not perfectly supported in OpenAPI 2 (string | number)
+                enum: ['A', 'B', '3'],
+                type: 'string',
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.stringAndNumberLiterals`,
+            );
+            expect(propertySchema?.properties?.keyofEnum).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['A', 'B', 'C'],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.keyofEnum`,
+            );
+            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq(
+              {
+                //Unions are not perfectly supported in OpenAPI 2 (string | number)
+                enum: ['a', '3', '4'],
+                type: 'string',
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.numberAndStringKeys`,
+            );
+            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['a'],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.oneStringKeyInterface`,
+            );
+            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq(
+              {
+                type: 'number',
+                enum: [3],
+                'x-nullable': false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.oneNumberKeyInterface`,
+            );
+            expect(propertySchema?.properties?.indexStrings).to.deep.eq(
+              {
+                //Unions are not perfectly supported in OpenAPI 2 (string | number)
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.indexStrings`,
+            );
+            expect(propertySchema?.properties?.indexNumbers).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}.indexNumbers`,
+            );
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(14, `for property ${propertyName}`);
 
             const keysOfAnySchema = getValidatedDefinition('KeysMember', currentSpec);
-            expect(keysOfAnySchema).to.deep.eq({  //Unions are not perfectly supported in OpenAPI 2 (string | number)
-              properties: {
-                keys: {
-                  type: "object",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                }
+            expect(keysOfAnySchema).to.deep.eq(
+              {
+                //Unions are not perfectly supported in OpenAPI 2 (string | number)
+                properties: {
+                  keys: {
+                    type: 'object',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                required: ['keys'],
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              required: ["keys"],
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keysOfAny`);
+              `for property ${propertyName}.keysOfAny`,
+            );
 
             const keysOfInterfaceSchema = getValidatedDefinition('KeysMember_NestedTypeLiteral_', currentSpec);
-            expect(keysOfInterfaceSchema).to.deep.eq({
-              properties: {
-                keys: {
-                  type: "string",
-                  enum: ["a", "b", "e"],
-                  "x-nullable": false,
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                }
+            expect(keysOfInterfaceSchema).to.deep.eq(
+              {
+                properties: {
+                  keys: {
+                    type: 'string',
+                    enum: ['a', 'b', 'e'],
+                    'x-nullable': false,
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                required: ['keys'],
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              required: ["keys"],
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keysOfInterface`);
+              `for property ${propertyName}.keysOfInterface`,
+            );
           },
           nestedTypes: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq("#/definitions/Partial_Partial__a-string___", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField2?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField3?.$ref).to.eq("#/definitions/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq('#/definitions/Partial_Partial__a-string___', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField?.$ref).to.eq('#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField2?.$ref).to.eq('#/definitions/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField3?.$ref).to.eq('#/definitions/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
 
             const multiplePartialSchema = getValidatedDefinition('Partial_Partial__a-string___', currentSpec);
-            expect(multiplePartialSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
-              },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.multiplePartial`);
-            const separateFieldSchema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
-            expect(separateFieldSchema).to.deep.eq({
-              properties: {
-                omitted: {
-                  $ref: "#/definitions/Omit_Partial__a-string--b-string__.a_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
+            expect(multiplePartialSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField`);
+              `for property ${propertyName}.multiplePartial`,
+            );
+            const separateFieldSchema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldSchema).to.deep.eq(
+              {
+                properties: {
+                  omitted: {
+                    $ref: '#/definitions/Omit_Partial__a-string--b-string__.a_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField`,
+            );
             const separateFieldInternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-string__.a_', currentSpec);
-            expect(separateFieldInternalSchema).to.deep.eq({
-              $ref: "#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__",
-              description: "Construct a type with the properties of T except for those in type K.",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField.omitted`);
+            expect(separateFieldInternalSchema).to.deep.eq(
+              {
+                $ref: '#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__',
+                description: 'Construct a type with the properties of T except for those in type K.',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField.omitted`,
+            );
 
             const separateFieldInternal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__', currentSpec);
-            expect(separateFieldInternal2Schema).to.deep.eq({
-              properties: {
-                b: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+            expect(separateFieldInternal2Schema).to.deep.eq(
+              {
+                properties: {
+                  b: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField.omitted`);
+              `for property ${propertyName}.separateField.omitted`,
+            );
 
             const separateField2Schema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', currentSpec);
-            expect(separateField2Schema).to.deep.eq({
-              properties: {
-                omitted: {
-                  $ref: "#/definitions/Omit_Partial__a-string--b-string__.a-or-b_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+            expect(separateField2Schema).to.deep.eq(
+              {
+                properties: {
+                  omitted: {
+                    $ref: '#/definitions/Omit_Partial__a-string--b-string__.a-or-b_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField2`);
+              `for property ${propertyName}.separateField2`,
+            );
             const separateField2InternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-string__.a-or-b_', currentSpec);
-            expect(separateField2InternalSchema?.$ref).to.eq("#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__",
-              `for property ${propertyName}.separateField2.omitted`
+            expect(separateField2InternalSchema?.$ref).to.eq(
+              '#/definitions/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__',
+              `for property ${propertyName}.separateField2.omitted`,
             );
             const separateField2Internal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__', currentSpec);
-            expect(separateField2Internal2Schema).to.deep.eq({
-              properties: {},
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField2.omitted`);
+            expect(separateField2Internal2Schema).to.deep.eq(
+              {
+                properties: {},
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField2.omitted`,
+            );
 
             const separateField3Schema = getValidatedDefinition('Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', currentSpec);
-            expect(separateField3Schema).to.deep.eq({ //Unions are not supported in OpenAPI 2
-              properties:
+            expect(separateField3Schema).to.deep.eq(
               {
-                omitted: {
-                  $ref: "#/definitions/Omit_Partial__a-string--b-number__.a-or-b_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+                //Unions are not supported in OpenAPI 2
+                properties: {
+                  omitted: {
+                    $ref: '#/definitions/Omit_Partial__a-string--b-number__.a-or-b_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    type: 'object',
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  type: "object",
-                  description: undefined,
-                  default: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField3`);
+              `for property ${propertyName}.separateField3`,
+            );
             const separateField3InternalSchema = getValidatedDefinition('Omit_Partial__a-string--b-number__.a-or-b_', currentSpec);
-            expect(separateField3InternalSchema?.$ref).to.eq("#/definitions/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__",
-              `for property ${propertyName}.separateField3.omitted`
+            expect(separateField3InternalSchema?.$ref).to.eq(
+              '#/definitions/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__',
+              `for property ${propertyName}.separateField3.omitted`,
             );
             const separateField3Internal2Schema = getValidatedDefinition('Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__', currentSpec);
-            expect(separateField3Internal2Schema).to.deep.eq({
-              properties: {},
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField3.omitted`);
-          }
+            expect(separateField3Internal2Schema).to.deep.eq(
+              {
+                properties: {},
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField3.omitted`,
+            );
+          },
         };
 
         Object.keys(assertionsPerProperty).forEach(aPropertyName => {
@@ -3507,7 +3590,3 @@ describe('Definition generation', () => {
     });
   });
 });
-
-
-
-

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1982,23 +1982,23 @@ describe('Definition generation', () => {
           jsDocTypeNames: (propertyName, propertySchema) => {
             expect(propertySchema?.properties?.simple?.$ref).to.eq('#/definitions/Partial__a-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.commented?.$ref).to.eq('#/definitions/Partial__a_description-comment_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/definitions/Partial__a_description-multiline%5Cncomment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/definitions/Partial__a_description-multiline_92_ncomment_-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.defaultValue?.$ref).to.eq('#/definitions/Partial__a_default-true_-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.deprecated?.$ref).to.eq('#/definitions/Partial__a_deprecated-true_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/definitions/Partial__a_validators%3A_minLength%3A_value%3A3___-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/definitions/Partial__a_validators_58__minLength_58__value_58_3___-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.examples?.$ref).to.eq('#/definitions/Partial__a_example-example_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/definitions/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/definitions/Partial__a_extensions_58__91__key-x-key-1.value-value-1__93__-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.ignored?.$ref).to.eq('#/definitions/Partial__a_ignored-true_-string__', `for property ${propertyName}`);
 
-            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/definitions/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
 
@@ -2042,7 +2042,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.commented`,
             );
-            const multilineCommentedSchema = getValidatedDefinition('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
+            const multilineCommentedSchema = getValidatedDefinition('Partial__a_description-multiline_92_ncomment_-string__', currentSpec);
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
@@ -2103,7 +2103,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.deprecated`,
             );
-            const validatorsSchema = getValidatedDefinition('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
+            const validatorsSchema = getValidatedDefinition('Partial__a_validators_58__minLength_58__value_58_3___-string__', currentSpec);
             expect(validatorsSchema).to.deep.eq(
               {
                 properties: {
@@ -2144,7 +2144,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.examples`,
             );
-            const extensionsSchema = getValidatedDefinition('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
+            const extensionsSchema = getValidatedDefinition('Partial__a_extensions_58__91__key-x-key-1.value-value-1__93__-string__', currentSpec);
             expect(extensionsSchema).to.deep.eq(
               {
                 properties: {
@@ -2177,7 +2177,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.ignored`,
             );
-            const indexedSchema = getValidatedDefinition('Partial__[a-string]:string__', currentSpec);
+            const indexedSchema = getValidatedDefinition('Partial___91_a-string_93__58_string__', currentSpec);
             expect(indexedSchema).to.deep.eq(
               {
                 properties: {},
@@ -2591,16 +2591,19 @@ describe('Definition generation', () => {
           },
           mappeds: (propertyName, propertySchema) => {
             expect(propertySchema?.properties?.unionMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_b-number__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq('#/definitions/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-_b-number__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq(
-              '#/definitions/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__',
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-__91_b-string_93__58_number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq(
+              '#/definitions/Partial___91_a-string_93__58_string_-or-__91_b-string_93__58_number__',
               `for property ${propertyName}`,
             );
-            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-(_b-string_-and-_c-string_)_', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/definitions/Partial_(_a-string_-or-_b-string_)-and-_c-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-_b-number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/definitions/Partial__a-string_-and-__91_b-string_93__58_number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq(
+              '#/definitions/Partial___91_a-string_93__58_string_-and-__91_b-number_93__58_number__',
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/definitions/Partial__a-string_-or-_40__b-string_-and-_c-string__41__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/definitions/Partial__40__a-string_-or-_b-string__41_-and-_c-string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
@@ -2616,7 +2619,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.unionMap`,
             );
-            const indexedUnionMapSchema = getValidatedDefinition('Partial__a-string_-or-_[b-string]:number__', currentSpec);
+            const indexedUnionMapSchema = getValidatedDefinition('Partial__a-string_-or-__91_b-string_93__58_number__', currentSpec);
             expect(indexedUnionMapSchema).to.deep.eq(
               //Unions are not supported in OpenAPI 2
               {
@@ -2628,7 +2631,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.indexedUnionMap`,
             );
-            const doubleIndexedUnionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
+            const doubleIndexedUnionMapSchema = getValidatedDefinition('Partial___91_a-string_93__58_string_-or-__91_b-string_93__58_number__', currentSpec);
             expect(doubleIndexedUnionMapSchema).to.deep.eq(
               //Unions are not supported in OpenAPI 2
               {
@@ -2667,7 +2670,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.intersectionMap`,
             );
-            const indexedIntersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-_[b-string]:number__', currentSpec);
+            const indexedIntersectionMapSchema = getValidatedDefinition('Partial__a-string_-and-__91_b-string_93__58_number__', currentSpec);
             expect(indexedIntersectionMapSchema).to.deep.eq(
               {
                 properties: {
@@ -2691,7 +2694,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.indexedIntersectionMap`,
             );
-            const doubleIndexedIntersectionMapSchema = getValidatedDefinition('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
+            const doubleIndexedIntersectionMapSchema = getValidatedDefinition('Partial___91_a-string_93__58_string_-and-__91_b-number_93__58_number__', currentSpec);
             expect(doubleIndexedIntersectionMapSchema).to.deep.eq(
               {
                 //Unions are not supported in OpenAPI 2
@@ -2707,7 +2710,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.doubleIndexedIntersectionMap`,
             );
-            const parenthesizedMapSchema = getValidatedDefinition('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
+            const parenthesizedMapSchema = getValidatedDefinition('Partial__a-string_-or-_40__b-string_-and-_c-string__41__', currentSpec);
             expect(parenthesizedMapSchema).to.deep.eq(
               //Unions are not supported in OpenAPI 2
               {
@@ -2719,7 +2722,7 @@ describe('Definition generation', () => {
               },
               `for property ${propertyName}.parenthesizedMap`,
             );
-            const parenthesizedMap2Schema = getValidatedDefinition('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
+            const parenthesizedMap2Schema = getValidatedDefinition('Partial__40__a-string_-or-_b-string__41_-and-_c-string__', currentSpec);
             expect(parenthesizedMap2Schema).to.deep.eq(
               //Unions are not supported in OpenAPI 2
               {
@@ -2757,7 +2760,7 @@ describe('Definition generation', () => {
             expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq('#/definitions/Conditional_string.number.number.boolean_', `for property ${propertyName}`);
             expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq('#/definitions/Dummy_Conditional_string.string.number.boolean__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq('#/definitions/Dummy_Conditional_string.number.number.boolean__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/definitions/Partial_stringextendsstring%3F_a-number_-never_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/definitions/Partial_stringextendsstring_63__a-number_-never_', `for property ${propertyName}`);
             expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq('#/definitions/Partial_Conditional_string.string._a-number_.never__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
@@ -2788,7 +2791,7 @@ describe('Definition generation', () => {
             expect(dummyConditionalSchema?.$ref).to.eq('#/definitions/Conditional_string.string.number.boolean_', `for property ${propertyName}.dummyConditional`);
             const dummyFalseConditionalSchema = getValidatedDefinition('Dummy_Conditional_string.number.number.boolean__', currentSpec);
             expect(dummyFalseConditionalSchema?.$ref).to.eq('#/definitions/Conditional_string.number.number.boolean_', `for property ${propertyName}.dummyFalseConditional`);
-            const mappedConditionalSchema = getValidatedDefinition('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            const mappedConditionalSchema = getValidatedDefinition('Partial_stringextendsstring_63__a-number_-never_', currentSpec);
             expect(mappedConditionalSchema).to.deep.eq(
               {
                 properties: {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -7,6 +7,7 @@ import 'mocha';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultOptions } from '../../../fixtures/defaultOptions';
 import { TestModel } from '../../../fixtures/testModel';
+import * as os from 'os';
 
 describe('Definition generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -2043,12 +2044,13 @@ describe('Definition generation', () => {
               `for property ${propertyName}.commented`,
             );
             const multilineCommentedSchema = getValidatedDefinition('Partial__a_description-multiline_92_ncomment_-string__', currentSpec);
+            const expectedDescription = os.platform() === 'win32' ? 'multiline\r\ncomment' : `multiline\ncomment`;
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
                     type: 'string',
-                    description: 'multiline\ncomment',
+                    description: expectedDescription,
                     default: undefined,
                     example: undefined,
                     format: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1,13 +1,12 @@
+import { ExtendedSpecConfig } from '@tsoa/cli/cli';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { SpecGenerator3 } from '@tsoa/cli/swagger/specGenerator3';
+import { Swagger, Tsoa } from '@tsoa/runtime';
 import { expect } from 'chai';
 import 'mocha';
-import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
-import { Tsoa } from '@tsoa/runtime';
-import { SpecGenerator3 } from '@tsoa/cli/swagger/specGenerator3';
-import { Swagger } from '@tsoa/runtime';
+import { versionMajorMinor } from 'typescript';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
 import { TestModel } from '../../fixtures/testModel';
-import { ExtendedSpecConfig } from '@tsoa/cli/cli';
-import { versionMajorMinor } from 'typescript';
 
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadataGet = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -1201,7 +1200,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           boolValue: (propertyName, propertySchema) => {
             expect(propertySchema.type).to.eq('boolean', `for property ${propertyName}.type`);
-            expect(propertySchema.default).to.eq('true', `for property ${propertyName}.default`);
+            expect(propertySchema.default).to.eq(true, `for property ${propertyName}.default`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
           boolArray: (propertyName, propertySchema) => {
@@ -1598,6 +1597,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                 },
               },
+              required: [
+                'record-foo',
+                'record-bar'
+              ],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -1633,6 +1636,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                 },
               },
+              required: ["1", "2"],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -1641,37 +1645,53 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             });
           },
           stringRecord: (propertyName, propertySchema) => {
-            expect(propertySchema).to.be.deep.eq({
-              properties: {},
+            expect(propertySchema.$ref).to.eq('#/components/schemas/Record_string._data-string__');
+            const schema = getComponentSchema('Record_string._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
               additionalProperties: {
                 properties: {
-                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  data: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: "string"
+                  }
                 },
-                required: ['data'],
-                type: 'object',
+                required: ["data"],
+                type: "object"
               },
-              type: 'object',
               default: undefined,
+              description: "Construct a type with a set of properties K of type T",
               example: undefined,
               format: undefined,
-              description: undefined,
+              properties: {},
+              type: "object"
             });
           },
           numberRecord: (propertyName, propertySchema) => {
-            expect(propertySchema).to.be.deep.eq({
-              properties: {},
+            expect(propertySchema.$ref).to.eq('#/components/schemas/Record_number._data-string__');
+            const schema = getComponentSchema('Record_number._data-string__', currentSpec);
+            expect(schema).to.be.deep.eq({
               additionalProperties: {
                 properties: {
-                  data: { type: 'string', description: undefined, example: undefined, format: undefined, default: undefined },
+                  data: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: "string"
+                  }
                 },
-                required: ['data'],
-                type: 'object',
+                required: ["data"],
+                type: "object"
               },
-              type: 'object',
               default: undefined,
+              description: "Construct a type with a set of properties K of type T",
               example: undefined,
               format: undefined,
-              description: undefined,
+              properties: {},
+              type: "object"
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
@@ -1813,7 +1833,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               example: 42,
               minimum: 42,
               maximum: 42,
-              default: '42',
+              default: 42,
             });
 
             const dateAliasSchema = getComponentSchema('DateAlias', currentSpec);
@@ -2203,7 +2223,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   list: {
-                    items: { $ref: '#/components/schemas/ThingContainerWithTitle_string_' },
+                    items: { type: 'number', format: 'double' },
                     type: 'array',
                     default: undefined,
                     description: undefined,
@@ -2236,6 +2256,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   type: 'string',
                 },
               },
+              required: ['id'],
               type: 'object',
             });
 
@@ -2248,7 +2269,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                     description: undefined,
                     enum: ['OK', 'KO'],
-                    nullable: false,
                     example: undefined,
                     format: undefined,
                     type: 'string',
@@ -2261,7 +2281,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     format: undefined,
                   },
                   indexedResponseObject: {
-                    $ref: '#/components/schemas/Record_id.any_',
+                    $ref: '#/components/schemas/Record_id._myProp1-string__',
                     description: undefined,
                     example: undefined,
                     format: undefined,
@@ -2269,7 +2289,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   indexedType: { type: 'string', default: undefined, description: undefined, format: undefined, example: undefined },
                   indexedTypeToClass: { $ref: '#/components/schemas/IndexedClass', description: undefined, format: undefined, example: undefined },
                   indexedTypeToInterface: { $ref: '#/components/schemas/IndexedInterface', description: undefined, format: undefined, example: undefined },
-                  indexedTypeToAlias: { $ref: '#/components/schemas/IndexedInterfaceAlias', description: undefined, format: undefined, example: undefined },
+                  indexedTypeToAlias: { $ref: '#/components/schemas/IndexedInterface', description: undefined, format: undefined, example: undefined },
                   arrayUnion: {
                     default: undefined,
                     description: undefined,
@@ -2598,6 +2618,21 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     default: undefined,
                   },
                 },
+                required: [
+                  'lastname:asc',
+                  'age:asc',
+                  'weight:asc',
+                  'human:asc',
+                  'gender:asc',
+                  'nicknames:asc',
+                  'firstname:desc',
+                  'lastname:desc',
+                  'age:desc',
+                  'weight:desc',
+                  'human:desc',
+                  'gender:desc',
+                  'nicknames:desc'
+                ],
                 type: 'object',
                 description: undefined,
                 example: undefined,
@@ -2653,6 +2688,1625 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               `for property ${propertyName}`,
             );
           },
+          namespaces: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq(
+              {
+                properties: {
+                  typeHolder2: {
+                    $ref: "#/components/schemas/Namespace2.TypeHolder",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inModule: {
+                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  typeHolder1: {
+                    $ref: "#/components/schemas/Namespace1.TypeHolder",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace1: {
+                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  simple: {
+                    $ref: "#/components/schemas/NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: [
+                  "typeHolder2",
+                  "inModule",
+                  "typeHolder1",
+                  "inNamespace1",
+                  "simple"
+                ],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}`
+            );
+
+            const typeHolder2Schema = getComponentSchema('Namespace2.TypeHolder', currentSpec);
+            expect(typeHolder2Schema).to.deep.eq(
+              {
+                properties: {
+                  inModule: {
+                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace2: {
+                    $ref: "#/components/schemas/Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inModule",
+                  "inNamespace2"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+                description: undefined
+              },
+              `for property ${propertyName}.typeHolder2`
+            );
+
+            const namespace2_namespace2_namespaceTypeSchema = getComponentSchema('Namespace2.Namespace2.NamespaceType', currentSpec);
+            expect(namespace2_namespace2_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inModule: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  other: {
+                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inModule"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+              },
+              `for property ${propertyName}.typeHolder2.inModule`
+            );
+
+            const typeHolderSchema = getComponentSchema('Namespace1.TypeHolder', currentSpec);
+            expect(typeHolderSchema).to.deep.eq(
+              {
+                properties: {
+                  inNamespace1_1:
+                  {
+                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inNamespace1_2: {
+                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inNamespace1_1", "inNamespace1_2"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+                description: undefined
+              },
+              `for property ${propertyName}.typeHolder1`
+            );
+
+            const namespace1_namespaceTypeSchema = getComponentSchema('Namespace1.NamespaceType', currentSpec);
+            expect(namespace1_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inFirstNamespace: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  inFirstNamespace2: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["inFirstNamespace", "inFirstNamespace2"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+              },
+              `for property ${propertyName}.typeHolder1.inNamespace1_1`
+            );
+
+            const namespace2_namespaceTypeSchema = getComponentSchema('Namespace2.NamespaceType', currentSpec);
+            expect(namespace2_namespaceTypeSchema).to.deep.eq(
+              {
+                properties: {
+                  inSecondNamespace: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                },
+                required: ["inSecondNamespace"],
+                type: "object",
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+              },
+              `for property ${propertyName}.typeHolder2.inNamespace2`
+            );
+
+            const namespaceTypeSchema = getComponentSchema('NamespaceType', currentSpec);
+            expect(namespaceTypeSchema).to.deep.eq(
+              {
+                type: "string",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.simple`
+            );
+          },
+          defaults: (propertyName, propertySchema) => {
+            expect(propertySchema).to.deep.eq({
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              properties: {
+                basic: {
+                  $ref: "#/components/schemas/DefaultsClass",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                },
+                defaultNull: {
+                  default: null,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  nullable: true,
+                  type: "string"
+                },
+                defaultObject: {
+                  default: {
+                    a: "a",
+                    b: 2
+                  },
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  properties: {
+                    a: {
+                      default: undefined,
+                      description: undefined,
+                      example: undefined,
+                      format: undefined,
+                      type: "string"
+                    },
+                    b: {
+                      default: undefined,
+                      description: undefined,
+                      example: undefined,
+                      format: "double",
+                      type: "number"
+                    }
+                  },
+                  required: ["b", "a"],
+                  type: "object"
+                },
+                defaultUndefined: {
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                  type: "string"
+                },
+                replacedTypes: {
+                  $ref: "#/components/schemas/ReplaceTypes_DefaultsClass.boolean.string_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              required: ["replacedTypes", "basic"],
+              type: "object"
+            },
+              `for property ${propertyName}`
+            );
+            const basicSchema = getComponentSchema('DefaultsClass', currentSpec);
+            expect(basicSchema).to.deep.eq(
+              {
+                properties: {
+                  boolValue1: {
+                    type: "boolean",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue2: {
+                    type: "boolean",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue3: {
+                    type: "boolean",
+                    default: false,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue4: {
+                    type: "boolean",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                required: undefined,
+                description: undefined,
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+              },
+              `for property ${propertyName}.basic`
+            );
+            const replacedTypesSchema = getComponentSchema('ReplaceTypes_DefaultsClass.boolean.string_', currentSpec);
+            expect(replacedTypesSchema).to.deep.eq(
+              {
+                properties: {
+                  boolValue1: {
+                    type: "string",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue2: {
+                    type: "string",
+                    default: true,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue3: {
+                    type: "string",
+                    default: false,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  boolValue4: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: undefined,
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.replacedTypes`
+            );
+          },
+          jsDocTypeNames: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.simple?.$ref).to.eq("#/components/schemas/Partial__a-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.commented?.$ref).to.eq("#/components/schemas/Partial__a_description-comment_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq("#/components/schemas/Partial__a_description-multiline%5Cncomment_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq("#/components/schemas/Partial__a_default-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.deprecated?.$ref).to.eq("#/components/schemas/Partial__a_deprecated-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq("#/components/schemas/Partial__a_validators%3A_minLength%3A_value%3A3___-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.examples?.$ref).to.eq("#/components/schemas/Partial__a_example-example_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq("#/components/schemas/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.ignored?.$ref).to.eq("#/components/schemas/Partial__a_ignored-true_-string__", `for property ${propertyName}`);
+
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
+
+            const simpleSchema = getComponentSchema('Partial__a-string__', currentSpec);
+            expect(simpleSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.simple`
+            );
+            const commentedSchema = getComponentSchema('Partial__a_description-comment_-string__', currentSpec);
+            expect(commentedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    description: "comment",
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.commented`
+            );
+            const multilineCommentedSchema = getComponentSchema('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
+            expect(multilineCommentedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    description: "multiline\ncomment",
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.multilineCommented`
+            );
+            const defaultValueSchema = getComponentSchema('Partial__a_default-true_-string__', currentSpec);
+            expect(defaultValueSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: "true",
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.defaultValue`
+            );
+            const deprecatedSchema = getComponentSchema('Partial__a_deprecated-true_-string__', currentSpec);
+            expect(deprecatedSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    deprecated: true,
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.deprecated`
+            );
+            const validatorsSchema = getComponentSchema('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
+            expect(validatorsSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    minLength: 3,
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.validators`
+            );
+            const examplesSchema = getComponentSchema('Partial__a_example-example_-string__', currentSpec);
+            expect(examplesSchema).to.deep.eq({
+              default: undefined,
+              description: "Make all properties in T optional",
+              example: undefined,
+              format: undefined,
+              properties: {
+                a: {
+                  default: undefined,
+                  description: undefined,
+                  example: "example",
+                  format: undefined,
+                  type: "string"
+                }
+              },
+              type: "object"
+            },
+              `for property ${propertyName}.examples`
+            );
+            const extensionsSchema = getComponentSchema('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
+            expect(extensionsSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    "x-key-1": "value-1",
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.extensions`
+            );
+            const ignoredSchema = getComponentSchema('Partial__a_ignored-true_-string__', currentSpec);
+            expect(ignoredSchema).to.deep.eq(
+              {
+                properties: {
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.ignored`
+            );
+            const indexedSchema = getComponentSchema('Partial__[a-string]:string__', currentSpec);
+            expect(indexedSchema).to.deep.eq(
+              {
+                properties: {
+                },
+                additionalProperties: {
+                  type: "string"
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.indexedSimple`
+            );
+          },
+          jsdocMap: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.omitted?.$ref).to.eq("#/components/schemas/Omit_JsDocced.notRelevant_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.partial?.$ref).to.eq("#/components/schemas/Partial_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq("#/components/schemas/ReplaceStringAndNumberTypes_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq("#/components/schemas/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.postfixed?.$ref).to.eq("#/components/schemas/Postfixed_JsDocced._PostFix_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.values?.$ref).to.eq("#/components/schemas/Values_JsDocced_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typesValues?.$ref).to.eq("#/components/schemas/InternalTypes_Values_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.onlyOneValue).to.deep.eq(
+              {
+                type: "number",
+                format: "double",
+                default: undefined,
+                description: undefined,
+                example: undefined
+              },
+              `for property ${propertyName}.onlyOneValue`
+            );
+            expect(propertySchema?.properties?.synonym?.$ref).to.eq("#/components/schemas/JsDoccedSynonym", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym2?.$ref).to.eq("#/components/schemas/JsDoccedSynonym2", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
+
+            const omittedSchema = getComponentSchema('Omit_JsDocced.notRelevant_', currentSpec);
+            expect(omittedSchema).to.deep.eq(
+              {
+                $ref: "#/components/schemas/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__",
+                description: "Construct a type with the properties of T except for those in type K.",
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.omitted`
+            );
+            const omittedSchema2 = getComponentSchema('Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__', currentSpec);
+            expect(omittedSchema2).to.deep.eq({
+              properties: {
+                stringValue: {
+                  type: "string",
+                  default: "def",
+                  maxLength: 3,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                },
+                numberValue: {
+                  type: "integer",
+                  format: "int32",
+                  default: 6,
+                  description: undefined,
+                  example: undefined
+                }
+              },
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.omitted`
+            );
+            const partialSchema = getComponentSchema('Partial_JsDocced_', currentSpec);
+            expect(partialSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    format: undefined,
+                    example: undefined,
+                    description: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    example: undefined,
+                    description: undefined
+                  }
+                },
+                type: "object",
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.partial`
+            );
+            const replacedTypesSchema = getComponentSchema('ReplaceStringAndNumberTypes_JsDocced_', currentSpec);
+            expect(replacedTypesSchema).to.deep.eq(
+              {
+                $ref: "#/components/schemas/ReplaceTypes_JsDocced.string.number_",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.replacedTypes`
+            );
+            const replacedTypes2Schema = getComponentSchema('ReplaceTypes_JsDocced.string.number_', currentSpec);
+            expect(replacedTypes2Schema).to.deep.eq({
+              properties: {
+                stringValue: {
+                  type: "number",
+                  format: "double",
+                  default: "def",
+                  maxLength: 3,
+                  description: undefined,
+                  example: undefined,
+                },
+                numberValue: {
+                  type: "string",
+                  default: 6,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.replacedTypes`
+            );
+            const doubleReplacedTypesSchema = getComponentSchema('ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__', currentSpec);
+            expect(doubleReplacedTypesSchema).to.deep.eq(
+              {
+                $ref: "#/components/schemas/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleReplacedTypes`
+            );
+            const doubleReplacedTypes2Schema = getComponentSchema('ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_', currentSpec);
+            expect(doubleReplacedTypes2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  },
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleReplacedTypes`
+            );
+            const postfixedSchema = getComponentSchema('Postfixed_JsDocced._PostFix_', currentSpec);
+            expect(postfixedSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue_PostFix: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue_PostFix: {
+                    type: "number",
+                    format: "double",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined
+                  }
+                },
+                required: [
+                  "stringValue_PostFix", "numberValue_PostFix"
+                ],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.postfixed`
+            );
+            const valuesSchema = getComponentSchema('Values_JsDocced_', currentSpec);
+            expect(valuesSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    properties: {
+                      value: {
+                        type: "string",
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: undefined
+                      }
+                    },
+                    required: ["value"],
+                    type: "object",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    properties: {
+                      value: {
+                        type: "number",
+                        format: "double",
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                      }
+                    },
+                    required: ["value"],
+                    type: "object",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.values`
+            );
+            const typesValuesSchema = getComponentSchema('InternalTypes_Values_JsDocced__', currentSpec);
+            expect(typesValuesSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.typesValues`
+            );
+
+            const synonymSchema = getComponentSchema('JsDoccedSynonym', currentSpec);
+            expect(synonymSchema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "number",
+                    format: "double",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  }
+                },
+                required: ["stringValue", "numberValue"],
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.synonym`
+            );
+            const synonym2Schema = getComponentSchema('JsDoccedSynonym2', currentSpec);
+            expect(synonym2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: "string",
+                    default: "def",
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  numberValue: {
+                    type: "integer",
+                    format: "int32",
+                    default: 6,
+                    description: undefined,
+                    example: undefined
+                  }
+                },
+                type: "object",
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.synonym2`
+            );
+          },
+          duplicatedDefinitions: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.interfaces?.$ref).to.eq("#/components/schemas/DuplicatedInterface", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enums?.$ref).to.eq("#/components/schemas/DuplicatedEnum", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enumMember?.$ref).to.eq("#/components/schemas/DuplicatedEnum.C", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq("#/components/schemas/DuplicatedEnum.D", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
+
+            const interfacesSchema = getComponentSchema('DuplicatedInterface', currentSpec);
+            expect(interfacesSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  },
+                  b: {
+                    type: "string",
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined
+                  }
+                },
+                required: ["a", "b"],
+                type: "object",
+                additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
+                description: undefined,
+
+              },
+              `for property ${propertyName}.interfaces`
+            );
+            const enumsSchema = getComponentSchema('DuplicatedEnum', currentSpec);
+            expect(enumsSchema).to.deep.eq(
+              {
+                enum: ["AA", "BB", "CC"],
+                type: "string",
+                description: undefined
+              },
+              `for property ${propertyName}.enums`
+            );
+            const enumMemberSchema = getComponentSchema('DuplicatedEnum.C', currentSpec);
+            expect(enumMemberSchema).to.deep.eq(
+              {
+                enum: ["CC"],
+                type: "string",
+                description: undefined
+              },
+              `for property ${propertyName}.enumMember`
+            );
+            const namespaceMemberSchema = getComponentSchema('DuplicatedEnum.D', currentSpec);
+            expect(namespaceMemberSchema).to.deep.eq(
+              {
+                enum: ["DD"],
+                type: "string",
+                nullable: false,
+                description: undefined,
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.namespaceMember`
+            );
+          },
+          mappeds: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.unionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-_b-number__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-and-_b-number__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-(_b-string_-and-_c-string_)_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq("#/components/schemas/Partial_(_a-string_-or-_b-string_)-and-_c-string__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+
+            const unionMapSchema = getComponentSchema('Partial__a-string_-or-_b-number__', currentSpec);
+            expect(unionMapSchema).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    properties: {
+                      a: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  },
+                  {
+                    properties: {
+                      b: {
+                        format: "double",
+                        type: "number"
+                      }
+                    },
+                    type: "object"
+                  }
+                ],
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.unionMap`
+            );
+            const indexedUnionMapSchema = getComponentSchema('Partial__a-string_-or-_[b-string]:number__', currentSpec);
+            expect(indexedUnionMapSchema).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    properties: {
+                      a: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  },
+                  {
+                    additionalProperties: {
+                      format: "double",
+                      type: "number"
+                    },
+                    properties: {},
+                    type: "object"
+                  }
+                ],
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.indexedUnionMap`
+            );
+            const doubleIndexedUnionMapSchema = getComponentSchema('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
+            expect(doubleIndexedUnionMapSchema).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    additionalProperties: {
+                      type: "string"
+                    },
+                    properties: {},
+                    type: "object"
+                  },
+                  {
+                    additionalProperties: {
+                      format: "double",
+                      type: "number"
+                    },
+                    properties: {},
+                    type: "object"
+                  }
+                ],
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.doubleIndexedUnionMap`
+            );
+            const intersectionMapSchema = getComponentSchema('Partial__a-string_-and-_b-number__', currentSpec);
+            expect(intersectionMapSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                b: {
+                  type: "number",
+                  format: "double",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.intersectionMap`
+            );
+            const indexedIntersectionMapSchema = getComponentSchema('Partial__a-string_-and-_[b-string]:number__', currentSpec);
+            expect(indexedIntersectionMapSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              additionalProperties: {
+                type: "number",
+                format: "double"
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.indexedIntersectionMap`
+            );
+            const doubleIndexedIntersectionMapSchema = getComponentSchema('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
+            expect(doubleIndexedIntersectionMapSchema).to.deep.eq({
+              properties: {},
+              additionalProperties: {
+                anyOf: [
+                  {
+                    type: "string"
+                  },
+                  {
+                    format: "double",
+                    type: "number"
+                  }
+                ]
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.doubleIndexedIntersectionMap`
+            );
+            const parenthesizedMapSchema = getComponentSchema('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
+            expect(parenthesizedMapSchema).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    properties: {
+                      a: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  },
+                  {
+                    properties: {
+                      b: {
+                        type: "string"
+                      },
+                      c: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  }
+                ],
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.parenthesizedMap`
+            );
+            const parenthesizedMap2Schema = getComponentSchema('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
+            expect(parenthesizedMap2Schema).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    properties: {
+                      a: {
+                        type: "string"
+                      },
+                      c: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  },
+                  {
+                    properties: {
+                      b: {
+                        type: "string"
+                      },
+                      c: {
+                        type: "string"
+                      }
+                    },
+                    type: "object"
+                  }
+                ],
+                description: "Make all properties in T optional",
+                default: undefined,
+                example: undefined,
+                format: undefined
+              },
+              `for property ${propertyName}.parenthesizedMap2`
+            );
+          },
+          conditionals: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.simpeConditional).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq({
+              type: "boolean",
+              format: undefined,
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq("#/components/schemas/Conditional_string.string.number.boolean_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq("#/components/schemas/Conditional_string.number.number.boolean_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq("#/components/schemas/Dummy_Conditional_string.string.number.boolean__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq("#/components/schemas/Dummy_Conditional_string.number.number.boolean__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq("#/components/schemas/Partial_stringextendsstring%3F_a-number_-never_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq("#/components/schemas/Partial_Conditional_string.string._a-number_.never__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+
+            const typedConditionalSchema = getComponentSchema('Conditional_string.string.number.boolean_', currentSpec);
+            expect(typedConditionalSchema).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+            },
+              `for property ${propertyName}.typedConditional`);
+            const typedFalseConditionalSchema = getComponentSchema('Conditional_string.number.number.boolean_', currentSpec);
+            expect(typedFalseConditionalSchema).to.deep.eq({
+              type: "boolean",
+              format: undefined,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+            },
+              `for property ${propertyName}.typedFalseConditional`);
+            const dummyConditionalSchema = getComponentSchema('Dummy_Conditional_string.string.number.boolean__', currentSpec);
+            expect(dummyConditionalSchema?.$ref).to.eq("#/components/schemas/Conditional_string.string.number.boolean_", `for property ${propertyName}.dummyConditional`);
+            const dummyFalseConditionalSchema = getComponentSchema('Dummy_Conditional_string.number.number.boolean__', currentSpec);
+            expect(dummyFalseConditionalSchema?.$ref).to.eq("#/components/schemas/Conditional_string.number.number.boolean_", `for property ${propertyName}.dummyFalseConditional`);
+            const mappedConditionalSchema = getComponentSchema('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            expect(mappedConditionalSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "number",
+                  format: "double",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              example: undefined,
+              default: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.mappedConditional`);
+            const mappedTypedConditionalSchema = getComponentSchema('Partial_Conditional_string.string._a-number_.never__', currentSpec);
+            expect(mappedTypedConditionalSchema).to.deep.eq(mappedConditionalSchema, `for property ${propertyName}.mappedTypedConditional`);
+          },
+          typeOperators: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq("#/components/schemas/KeysMember", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq("#/components/schemas/KeysMember_NestedTypeLiteral_", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple).to.deep.eq({
+              type: "string",
+              enum: ["a", "b", "e"],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.simple`);
+            expect(propertySchema?.properties?.keyofItem).to.deep.eq({
+              type: "string",
+              enum: ["c", "d"],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.keyofItem`);
+            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq({
+              anyOf: [
+                {
+                  type: "string"
+                },
+                {
+                  format: "double",
+                  type: "number"
+                }
+              ],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keyofAnyItem`);
+            expect(propertySchema?.properties?.keyofAny).to.deep.eq(propertySchema?.properties?.keyofAnyItem,
+              `for property ${propertyName}.keyofAny`);
+            expect(propertySchema?.properties?.stringLiterals).to.deep.eq({
+              type: "string",
+              enum: ["A", "B", "C"],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.stringLiterals`);
+            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq({
+              anyOf: [
+                {
+                  enum: [
+                    "A",
+                    "B"
+                  ],
+                  type: "string"
+                },
+                {
+                  enum: [
+                    3
+                  ],
+                  type: "number"
+                }
+              ],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.stringAndNumberLiterals`);
+            expect(propertySchema?.properties?.keyofEnum).to.deep.eq({
+              type: "string",
+              enum: ["A", "B", "C"],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keyofEnum`);
+            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq({
+              anyOf: [
+                {
+                  enum: [
+                    "a"
+                  ],
+                  type: "string"
+                },
+                {
+                  enum: [
+                    3,
+                    4
+                  ],
+                  type: "number"
+                }
+              ],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.numberAndStringKeys`);
+            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq({
+              type: "string",
+              enum: ["a"],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.oneStringKeyInterface`);
+            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq({
+              type: "number",
+              enum: [3],
+              nullable: false,
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.oneNumberKeyInterface`);
+            expect(propertySchema?.properties?.indexStrings).to.deep.eq({
+              anyOf: [
+                {
+                  type: "string"
+                },
+                {
+                  format: "double",
+                  type: "number"
+                }
+              ],
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.indexStrings`);
+            expect(propertySchema?.properties?.indexNumbers).to.deep.eq({
+              type: "number",
+              format: "double",
+              default: undefined,
+              description: undefined,
+              example: undefined
+            },
+              `for property ${propertyName}.indexNumbers`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(14, `for property ${propertyName}`);
+
+            const keysOfAnySchema = getComponentSchema('KeysMember', currentSpec);
+            expect(keysOfAnySchema).to.deep.eq({
+              properties: {
+                keys: {
+                  anyOf: [
+                    {
+                      type: "string"
+                    },
+                    {
+                      format: "double",
+                      type: "number"
+                    }
+                  ],
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                }
+              },
+              required: ["keys"],
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keysOfAny`);
+
+            const keysOfInterfaceSchema = getComponentSchema('KeysMember_NestedTypeLiteral_', currentSpec);
+            expect(keysOfInterfaceSchema).to.deep.eq({
+              properties: {
+                keys: {
+                  type: "string",
+                  enum: ["a", "b", "e"],
+                  nullable: false,
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                }
+              },
+              required: ["keys"],
+              type: "object",
+              default: undefined,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.keysOfInterface`);
+          },
+          nestedTypes: (propertyName, propertySchema) => {
+            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq("#/components/schemas/Partial_Partial__a-string___", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField2?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField3?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__", `for property ${propertyName}`);
+
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
+
+            const multiplePartialSchema = getComponentSchema('Partial_Partial__a-string___', currentSpec);
+            expect(multiplePartialSchema).to.deep.eq({
+              properties: {
+                a: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.multiplePartial`);
+            const separateFieldSchema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldSchema).to.deep.eq({
+              properties: {
+                omitted: {
+                  $ref: "#/components/schemas/Omit_Partial__a-string--b-string__.a_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined,
+                },
+                field: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField`);
+            const separateFieldInternalSchema = getComponentSchema('Omit_Partial__a-string--b-string__.a_', currentSpec);
+            expect(separateFieldInternalSchema).to.deep.eq({
+              $ref: "#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__",
+              description: "Construct a type with the properties of T except for those in type K.",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField.omitted`);
+
+            const separateFieldInternal2Schema = getComponentSchema('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldInternal2Schema).to.deep.eq({
+              properties: {
+                b: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField.omitted`);
+
+            const separateField2Schema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', currentSpec);
+            expect(separateField2Schema).to.deep.eq({
+              properties: {
+                omitted: {
+                  $ref: "#/components/schemas/Omit_Partial__a-string--b-string__.a-or-b_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                field: {
+                  type: "string",
+                  default: undefined,
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField2`);
+            const separateField2InternalSchema = getComponentSchema('Omit_Partial__a-string--b-string__.a-or-b_', currentSpec);
+            expect(separateField2InternalSchema?.$ref).to.eq("#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__",
+              `for property ${propertyName}.separateField2.omitted`
+            );
+            const separateField2Internal2Schema = getComponentSchema('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__', currentSpec);
+            expect(separateField2Internal2Schema).to.deep.eq({
+              properties: {},
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField2.omitted`);
+
+            const separateField3Schema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', currentSpec);
+            expect(separateField3Schema).to.deep.eq({
+              properties:
+              {
+                omitted: {
+                  $ref: "#/components/schemas/Omit_Partial__a-string--b-number__.a-or-b_",
+                  description: undefined,
+                  example: undefined,
+                  format: undefined
+                },
+                field: {
+                  anyOf: [
+                    {
+                      type: "string"
+                    },
+                    {
+                      format: "double",
+                      type: "number"
+                    }
+                  ],
+                  description: undefined,
+                  default: undefined,
+                  example: undefined,
+                  format: undefined
+                }
+              },
+              type: "object",
+              description: "Make all properties in T optional",
+              default: undefined,
+              example: undefined,
+              format: undefined
+            },
+              `for property ${propertyName}.separateField3`);
+            const separateField3InternalSchema = getComponentSchema('Omit_Partial__a-string--b-number__.a-or-b_', currentSpec);
+            expect(separateField3InternalSchema?.$ref).to.eq("#/components/schemas/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__",
+              `for property ${propertyName}.separateField3.omitted`
+            );
+            const separateField3Internal2Schema = getComponentSchema('Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__', currentSpec);
+            expect(separateField3Internal2Schema).to.deep.eq({
+              properties: {},
+              type: "object",
+              description: "From T, pick a set of properties whose keys are in the union K",
+              default: undefined,
+              example: undefined,
+              format: undefined,
+            },
+              `for property ${propertyName}.separateField3.omitted`);
+          }
         };
 
         const testModel = currentSpec.spec.components.schemas[interfaceModelName];
@@ -2841,8 +4495,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       /* tslint:disable:no-string-literal */
       const ref = specDefault.spec.paths['/GetTest/ModuleRedeclarationAndNamespace'].get?.responses['200'].content?.['application/json']['schema']?.['$ref'];
       /* tslint:enable:no-string-literal */
-      expect(ref).to.equal('#/components/schemas/TsoaTest.TestModel73');
-      expect(getComponentSchema('TsoaTest.TestModel73', specDefault)).to.deep.equal({
+      expect(ref).to.equal('#/components/schemas/tsoaTest.TsoaTest.TestModel73');
+      expect(getComponentSchema('tsoaTest.TsoaTest.TestModel73', specDefault)).to.deep.equal({
         additionalProperties: true,
         description: undefined,
         properties: {
@@ -2913,29 +4567,8 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(currentSpec.paths['/ParameterTest/Inline1'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
     });
   });
-
-  describe('defaults on required properties should be documented as optional', () => {
-    it('on models', () => {
-      const testModel = getComponentSchema('TestModel', specDefault);
-
-      const prop = testModel.properties?.boolValue;
-
-      expect(prop).to.deep.eq(
-        {
-          type: 'boolean',
-          default: 'true',
-          description: undefined,
-          format: undefined,
-          example: undefined,
-        },
-        'boolValue has a default value of true',
-      );
-
-      expect(testModel.required).to.be.an('array');
-      expect(testModel.required).to.not.contain('boolValue', 'boolValue is not required');
-
-      // Others should still be required
-      expect(testModel.required).to.contain('boolArray', 'boolArray is required');
-    });
-  });
 });
+
+
+
+

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -3661,8 +3661,10 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             );
             expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_40__b-string_-and-_c-string__41__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/components/schemas/Partial__40__a-string_-or-_b-string__41_-and-_c-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.undefinedMap?.$ref).to.eq('#/components/schemas/Partial_undefined_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.nullMap?.$ref).to.eq('#/components/schemas/Partial_null_', `for property ${propertyName}`);
 
-            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
+            expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
 
             const unionMapSchema = getComponentSchema('Partial__a-string_-or-_b-number__', currentSpec);
             expect(unionMapSchema).to.deep.eq(
@@ -3886,6 +3888,29 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 format: undefined,
               },
               `for property ${propertyName}.parenthesizedMap2`,
+            );
+            const undefinedMapSchema = getComponentSchema('Partial_undefined_', currentSpec);
+            expect(undefinedMapSchema).to.deep.eq(
+              {
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.undefinedMap`,
+            );
+            const nullMapSchema = getComponentSchema('Partial_null_', currentSpec);
+            expect(nullMapSchema).to.deep.eq(
+              {
+                enum: [null],
+                type: 'number',
+                nullable: true,
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.nullMap`,
             );
           },
           conditionals: (propertyName, propertySchema) => {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2947,7 +2947,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     format: undefined,
                   },
                 },
-                required: ['replacedTypes', 'basic'],
+                required: ['defaultNull', 'replacedTypes', 'basic'],
                 type: 'object',
               },
               `for property ${propertyName}`,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -7,6 +7,7 @@ import 'mocha';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
 import { TestModel } from '../../fixtures/testModel';
+import * as os from 'os';
 
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadataGet = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -3097,12 +3098,13 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               `for property ${propertyName}.commented`,
             );
             const multilineCommentedSchema = getComponentSchema('Partial__a_description-multiline_92_ncomment_-string__', currentSpec);
+            const expectedDescription = os.platform() === 'win32' ? 'multiline\r\ncomment' : `multiline\ncomment`;
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
                     type: 'string',
-                    description: 'multiline\ncomment',
+                    description: expectedDescription,
                     default: undefined,
                     example: undefined,
                     format: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -3036,23 +3036,23 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           jsDocTypeNames: (propertyName, propertySchema) => {
             expect(propertySchema?.properties?.simple?.$ref).to.eq('#/components/schemas/Partial__a-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.commented?.$ref).to.eq('#/components/schemas/Partial__a_description-comment_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/components/schemas/Partial__a_description-multiline%5Cncomment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/components/schemas/Partial__a_description-multiline_92_ncomment_-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.defaultValue?.$ref).to.eq('#/components/schemas/Partial__a_default-true_-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.deprecated?.$ref).to.eq('#/components/schemas/Partial__a_deprecated-true_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/components/schemas/Partial__a_validators%3A_minLength%3A_value%3A3___-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/components/schemas/Partial__a_validators_58__minLength_58__value_58_3___-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.examples?.$ref).to.eq('#/components/schemas/Partial__a_example-example_-string__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/components/schemas/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/components/schemas/Partial__a_extensions_58__91__key-x-key-1.value-value-1__93__-string__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.ignored?.$ref).to.eq('#/components/schemas/Partial__a_ignored-true_-string__', `for property ${propertyName}`);
 
-            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/components/schemas/Partial___91_a-string_93__58_string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
 
@@ -3096,7 +3096,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.commented`,
             );
-            const multilineCommentedSchema = getComponentSchema('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
+            const multilineCommentedSchema = getComponentSchema('Partial__a_description-multiline_92_ncomment_-string__', currentSpec);
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
@@ -3157,7 +3157,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.deprecated`,
             );
-            const validatorsSchema = getComponentSchema('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
+            const validatorsSchema = getComponentSchema('Partial__a_validators_58__minLength_58__value_58_3___-string__', currentSpec);
             expect(validatorsSchema).to.deep.eq(
               {
                 properties: {
@@ -3198,7 +3198,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.examples`,
             );
-            const extensionsSchema = getComponentSchema('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
+            const extensionsSchema = getComponentSchema('Partial__a_extensions_58__91__key-x-key-1.value-value-1__93__-string__', currentSpec);
             expect(extensionsSchema).to.deep.eq(
               {
                 properties: {
@@ -3231,7 +3231,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.ignored`,
             );
-            const indexedSchema = getComponentSchema('Partial__[a-string]:string__', currentSpec);
+            const indexedSchema = getComponentSchema('Partial___91_a-string_93__58_string__', currentSpec);
             expect(indexedSchema).to.deep.eq(
               {
                 properties: {},
@@ -3648,19 +3648,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
           },
           mappeds: (propertyName, propertySchema) => {
             expect(propertySchema?.properties?.unionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_b-number__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-__91_b-string_93__58_number__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq(
-              '#/components/schemas/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__',
+              '#/components/schemas/Partial___91_a-string_93__58_string_-or-__91_b-string_93__58_number__',
               `for property ${propertyName}`,
             );
             expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-and-_b-number__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-and-__91_b-string_93__58_number__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq(
-              '#/components/schemas/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__',
+              '#/components/schemas/Partial___91_a-string_93__58_string_-and-__91_b-number_93__58_number__',
               `for property ${propertyName}`,
             );
-            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-(_b-string_-and-_c-string_)_', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/components/schemas/Partial_(_a-string_-or-_b-string_)-and-_c-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_40__b-string_-and-_c-string__41__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/components/schemas/Partial__40__a-string_-or-_b-string__41_-and-_c-string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
@@ -3693,7 +3693,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.unionMap`,
             );
-            const indexedUnionMapSchema = getComponentSchema('Partial__a-string_-or-_[b-string]:number__', currentSpec);
+            const indexedUnionMapSchema = getComponentSchema('Partial__a-string_-or-__91_b-string_93__58_number__', currentSpec);
             expect(indexedUnionMapSchema).to.deep.eq(
               {
                 anyOf: [
@@ -3721,7 +3721,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.indexedUnionMap`,
             );
-            const doubleIndexedUnionMapSchema = getComponentSchema('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
+            const doubleIndexedUnionMapSchema = getComponentSchema('Partial___91_a-string_93__58_string_-or-__91_b-string_93__58_number__', currentSpec);
             expect(doubleIndexedUnionMapSchema).to.deep.eq(
               {
                 anyOf: [
@@ -3775,7 +3775,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.intersectionMap`,
             );
-            const indexedIntersectionMapSchema = getComponentSchema('Partial__a-string_-and-_[b-string]:number__', currentSpec);
+            const indexedIntersectionMapSchema = getComponentSchema('Partial__a-string_-and-__91_b-string_93__58_number__', currentSpec);
             expect(indexedIntersectionMapSchema).to.deep.eq(
               {
                 properties: {
@@ -3799,7 +3799,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.indexedIntersectionMap`,
             );
-            const doubleIndexedIntersectionMapSchema = getComponentSchema('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
+            const doubleIndexedIntersectionMapSchema = getComponentSchema('Partial___91_a-string_93__58_string_-and-__91_b-number_93__58_number__', currentSpec);
             expect(doubleIndexedIntersectionMapSchema).to.deep.eq(
               {
                 properties: {},
@@ -3822,7 +3822,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.doubleIndexedIntersectionMap`,
             );
-            const parenthesizedMapSchema = getComponentSchema('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
+            const parenthesizedMapSchema = getComponentSchema('Partial__a-string_-or-_40__b-string_-and-_c-string__41__', currentSpec);
             expect(parenthesizedMapSchema).to.deep.eq(
               {
                 anyOf: [
@@ -3853,7 +3853,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.parenthesizedMap`,
             );
-            const parenthesizedMap2Schema = getComponentSchema('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
+            const parenthesizedMap2Schema = getComponentSchema('Partial__40__a-string_-or-_b-string__41_-and-_c-string__', currentSpec);
             expect(parenthesizedMap2Schema).to.deep.eq(
               {
                 anyOf: [
@@ -3913,7 +3913,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq('#/components/schemas/Conditional_string.number.number.boolean_', `for property ${propertyName}`);
             expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq('#/components/schemas/Dummy_Conditional_string.string.number.boolean__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq('#/components/schemas/Dummy_Conditional_string.number.number.boolean__', `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/components/schemas/Partial_stringextendsstring%3F_a-number_-never_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/components/schemas/Partial_stringextendsstring_63__a-number_-never_', `for property ${propertyName}`);
             expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq('#/components/schemas/Partial_Conditional_string.string._a-number_.never__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
@@ -3944,7 +3944,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(dummyConditionalSchema?.$ref).to.eq('#/components/schemas/Conditional_string.string.number.boolean_', `for property ${propertyName}.dummyConditional`);
             const dummyFalseConditionalSchema = getComponentSchema('Dummy_Conditional_string.number.number.boolean__', currentSpec);
             expect(dummyFalseConditionalSchema?.$ref).to.eq('#/components/schemas/Conditional_string.number.number.boolean_', `for property ${propertyName}.dummyFalseConditional`);
-            const mappedConditionalSchema = getComponentSchema('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            const mappedConditionalSchema = getComponentSchema('Partial_stringextendsstring_63__a-number_-never_', currentSpec);
             expect(mappedConditionalSchema).to.deep.eq(
               {
                 properties: {

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1597,10 +1597,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                 },
               },
-              required: [
-                'record-foo',
-                'record-bar'
-              ],
+              required: ['record-foo', 'record-bar'],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -1636,7 +1633,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   default: undefined,
                 },
               },
-              required: ["1", "2"],
+              required: ['1', '2'],
               type: 'object',
               default: undefined,
               example: undefined,
@@ -1655,18 +1652,18 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     description: undefined,
                     example: undefined,
                     format: undefined,
-                    type: "string"
-                  }
+                    type: 'string',
+                  },
                 },
-                required: ["data"],
-                type: "object"
+                required: ['data'],
+                type: 'object',
               },
               default: undefined,
-              description: "Construct a type with a set of properties K of type T",
+              description: 'Construct a type with a set of properties K of type T',
               example: undefined,
               format: undefined,
               properties: {},
-              type: "object"
+              type: 'object',
             });
           },
           numberRecord: (propertyName, propertySchema) => {
@@ -1680,18 +1677,18 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                     description: undefined,
                     example: undefined,
                     format: undefined,
-                    type: "string"
-                  }
+                    type: 'string',
+                  },
                 },
-                required: ["data"],
-                type: "object"
+                required: ['data'],
+                type: 'object',
               },
               default: undefined,
-              description: "Construct a type with a set of properties K of type T",
+              description: 'Construct a type with a set of properties K of type T',
               example: undefined,
               format: undefined,
               properties: {},
-              type: "object"
+              type: 'object',
             });
           },
           modelsObjectIndirect: (propertyName, propertySchema) => {
@@ -2631,7 +2628,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   'weight:desc',
                   'human:desc',
                   'gender:desc',
-                  'nicknames:desc'
+                  'nicknames:desc',
                 ],
                 type: 'object',
                 description: undefined,
@@ -2693,50 +2690,44 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   typeHolder2: {
-                    $ref: "#/components/schemas/Namespace2.TypeHolder",
+                    $ref: '#/components/schemas/Namespace2.TypeHolder',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inModule: {
-                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/components/schemas/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   typeHolder1: {
-                    $ref: "#/components/schemas/Namespace1.TypeHolder",
+                    $ref: '#/components/schemas/Namespace1.TypeHolder',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace1: {
-                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                    $ref: '#/components/schemas/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   simple: {
-                    $ref: "#/components/schemas/NamespaceType",
+                    $ref: '#/components/schemas/NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: [
-                  "typeHolder2",
-                  "inModule",
-                  "typeHolder1",
-                  "inNamespace1",
-                  "simple"
-                ],
-                type: "object",
+                required: ['typeHolder2', 'inModule', 'typeHolder1', 'inNamespace1', 'simple'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}`
+              `for property ${propertyName}`,
             );
 
             const typeHolder2Schema = getComponentSchema('Namespace2.TypeHolder', currentSpec);
@@ -2744,25 +2735,24 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   inModule: {
-                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/components/schemas/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace2: {
-                    $ref: "#/components/schemas/Namespace2.NamespaceType",
+                    $ref: '#/components/schemas/Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inModule",
-                  "inNamespace2"],
-                type: "object",
+                required: ['inModule', 'inNamespace2'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
-                description: undefined
+                description: undefined,
               },
-              `for property ${propertyName}.typeHolder2`
+              `for property ${propertyName}.typeHolder2`,
             );
 
             const namespace2_namespace2_namespaceTypeSchema = getComponentSchema('Namespace2.Namespace2.NamespaceType', currentSpec);
@@ -2770,51 +2760,50 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   inModule: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   other: {
-                    $ref: "#/components/schemas/Namespace2.Namespace2.NamespaceType",
+                    $ref: '#/components/schemas/Namespace2.Namespace2.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inModule"],
-                type: "object",
+                required: ['inModule'],
+                type: 'object',
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder2.inModule`
+              `for property ${propertyName}.typeHolder2.inModule`,
             );
 
             const typeHolderSchema = getComponentSchema('Namespace1.TypeHolder', currentSpec);
             expect(typeHolderSchema).to.deep.eq(
               {
                 properties: {
-                  inNamespace1_1:
-                  {
-                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                  inNamespace1_1: {
+                    $ref: '#/components/schemas/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inNamespace1_2: {
-                    $ref: "#/components/schemas/Namespace1.NamespaceType",
+                    $ref: '#/components/schemas/Namespace1.NamespaceType',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inNamespace1_1", "inNamespace1_2"],
-                type: "object",
+                required: ['inNamespace1_1', 'inNamespace1_2'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
-                description: undefined
+                description: undefined,
               },
-              `for property ${propertyName}.typeHolder1`
+              `for property ${propertyName}.typeHolder1`,
             );
 
             const namespace1_namespaceTypeSchema = getComponentSchema('Namespace1.NamespaceType', currentSpec);
@@ -2822,26 +2811,26 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   inFirstNamespace: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   inFirstNamespace2: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["inFirstNamespace", "inFirstNamespace2"],
-                type: "object",
+                required: ['inFirstNamespace', 'inFirstNamespace2'],
+                type: 'object',
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder1.inNamespace1_1`
+              `for property ${propertyName}.typeHolder1.inNamespace1_1`,
             );
 
             const namespace2_namespaceTypeSchema = getComponentSchema('Namespace2.NamespaceType', currentSpec);
@@ -2849,202 +2838,221 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   inSecondNamespace: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                 },
-                required: ["inSecondNamespace"],
-                type: "object",
+                required: ['inSecondNamespace'],
+                type: 'object',
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.typeHolder2.inNamespace2`
+              `for property ${propertyName}.typeHolder2.inNamespace2`,
             );
 
             const namespaceTypeSchema = getComponentSchema('NamespaceType', currentSpec);
             expect(namespaceTypeSchema).to.deep.eq(
               {
-                type: "string",
+                type: 'string',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.simple`
+              `for property ${propertyName}.simple`,
             );
           },
           defaults: (propertyName, propertySchema) => {
-            expect(propertySchema).to.deep.eq({
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-              properties: {
-                basic: {
-                  $ref: "#/components/schemas/DefaultsClass",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                },
-                defaultNull: {
-                  default: null,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  nullable: true,
-                  type: "string"
-                },
-                defaultObject: {
-                  default: {
-                    a: "a",
-                    b: 2
+            expect(propertySchema).to.deep.eq(
+              {
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+                properties: {
+                  basic: {
+                    $ref: '#/components/schemas/DefaultsClass',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
                   },
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  properties: {
-                    a: {
-                      default: undefined,
-                      description: undefined,
-                      example: undefined,
-                      format: undefined,
-                      type: "string"
+                  defaultNull: {
+                    default: null,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    nullable: true,
+                    type: 'string',
+                  },
+                  defaultObject: {
+                    default: {
+                      a: 'a',
+                      b: 2,
                     },
-                    b: {
-                      default: undefined,
-                      description: undefined,
-                      example: undefined,
-                      format: "double",
-                      type: "number"
-                    }
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    properties: {
+                      a: {
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: undefined,
+                        type: 'string',
+                      },
+                      b: {
+                        default: undefined,
+                        description: undefined,
+                        example: undefined,
+                        format: 'double',
+                        type: 'number',
+                      },
+                    },
+                    required: ['b', 'a'],
+                    type: 'object',
                   },
-                  required: ["b", "a"],
-                  type: "object"
+                  defaultUndefined: {
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                    type: 'string',
+                  },
+                  replacedTypes: {
+                    $ref: '#/components/schemas/ReplaceTypes_DefaultsClass.boolean.string_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  comments: {
+                    default: 4,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  jsonCharacters: {
+                    default: { '\\': '\n' },
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  stringEscapeCharacters: {
+                    default: '`"\'"\'\n\t\r\b\fgx\\',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                defaultUndefined: {
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                  type: "string"
-                },
-                replacedTypes: {
-                  $ref: "#/components/schemas/ReplaceTypes_DefaultsClass.boolean.string_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                required: ['replacedTypes', 'basic'],
+                type: 'object',
               },
-              required: ["replacedTypes", "basic"],
-              type: "object"
-            },
-              `for property ${propertyName}`
+              `for property ${propertyName}`,
             );
             const basicSchema = getComponentSchema('DefaultsClass', currentSpec);
             expect(basicSchema).to.deep.eq(
               {
                 properties: {
                   boolValue1: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue2: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue3: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: false,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue4: {
-                    type: "boolean",
+                    type: 'boolean',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 required: undefined,
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
-              `for property ${propertyName}.basic`
+              `for property ${propertyName}.basic`,
             );
             const replacedTypesSchema = getComponentSchema('ReplaceTypes_DefaultsClass.boolean.string_', currentSpec);
             expect(replacedTypesSchema).to.deep.eq(
               {
                 properties: {
                   boolValue1: {
-                    type: "string",
+                    type: 'string',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue2: {
-                    type: "string",
+                    type: 'string',
                     default: true,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue3: {
-                    type: "string",
+                    type: 'string',
                     default: false,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   boolValue4: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 description: undefined,
                 default: undefined,
                 example: undefined,
                 format: undefined,
               },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
           },
           jsDocTypeNames: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.simple?.$ref).to.eq("#/components/schemas/Partial__a-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.commented?.$ref).to.eq("#/components/schemas/Partial__a_description-comment_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq("#/components/schemas/Partial__a_description-multiline%5Cncomment_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq("#/components/schemas/Partial__a_default-true_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.deprecated?.$ref).to.eq("#/components/schemas/Partial__a_deprecated-true_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.validators?.$ref).to.eq("#/components/schemas/Partial__a_validators%3A_minLength%3A_value%3A3___-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.examples?.$ref).to.eq("#/components/schemas/Partial__a_example-example_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.extensions?.$ref).to.eq("#/components/schemas/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.ignored?.$ref).to.eq("#/components/schemas/Partial__a_ignored-true_-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple?.$ref).to.eq('#/components/schemas/Partial__a-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.commented?.$ref).to.eq('#/components/schemas/Partial__a_description-comment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multilineCommented?.$ref).to.eq('#/components/schemas/Partial__a_description-multiline%5Cncomment_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.defaultValue?.$ref).to.eq('#/components/schemas/Partial__a_default-true_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.deprecated?.$ref).to.eq('#/components/schemas/Partial__a_deprecated-true_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.validators?.$ref).to.eq('#/components/schemas/Partial__a_validators%3A_minLength%3A_value%3A3___-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.examples?.$ref).to.eq('#/components/schemas/Partial__a_example-example_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.extensions?.$ref).to.eq('#/components/schemas/Partial__a_extensions%3A%5B_key-x-key-1.value-value-1_%5D_-string__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.ignored?.$ref).to.eq('#/components/schemas/Partial__a_ignored-true_-string__', `for property ${propertyName}`);
 
-            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedSimple?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedCommented?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedMultilineCommented?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDefaultValue?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedDeprecated?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedValidators?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExamples?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedExtensions?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIgnored?.$ref).to.eq('#/components/schemas/Partial__%5Ba-string%5D%3Astring__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(18, `for property ${propertyName}`);
 
@@ -3053,388 +3061,390 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.simple`
+              `for property ${propertyName}.simple`,
             );
             const commentedSchema = getComponentSchema('Partial__a_description-comment_-string__', currentSpec);
             expect(commentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    description: "comment",
+                    type: 'string',
+                    description: 'comment',
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.commented`
+              `for property ${propertyName}.commented`,
             );
             const multilineCommentedSchema = getComponentSchema('Partial__a_description-multiline\\ncomment_-string__', currentSpec);
             expect(multilineCommentedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    description: "multiline\ncomment",
+                    type: 'string',
+                    description: 'multiline\ncomment',
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.multilineCommented`
+              `for property ${propertyName}.multilineCommented`,
             );
             const defaultValueSchema = getComponentSchema('Partial__a_default-true_-string__', currentSpec);
             expect(defaultValueSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    default: "true",
+                    type: 'string',
+                    default: 'true',
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.defaultValue`
+              `for property ${propertyName}.defaultValue`,
             );
             const deprecatedSchema = getComponentSchema('Partial__a_deprecated-true_-string__', currentSpec);
             expect(deprecatedSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     deprecated: true,
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.deprecated`
+              `for property ${propertyName}.deprecated`,
             );
             const validatorsSchema = getComponentSchema('Partial__a_validators:_minLength:_value:3___-string__', currentSpec);
             expect(validatorsSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     minLength: 3,
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.validators`
+              `for property ${propertyName}.validators`,
             );
             const examplesSchema = getComponentSchema('Partial__a_example-example_-string__', currentSpec);
-            expect(examplesSchema).to.deep.eq({
-              default: undefined,
-              description: "Make all properties in T optional",
-              example: undefined,
-              format: undefined,
-              properties: {
-                a: {
-                  default: undefined,
-                  description: undefined,
-                  example: "example",
-                  format: undefined,
-                  type: "string"
-                }
+            expect(examplesSchema).to.deep.eq(
+              {
+                default: undefined,
+                description: 'Make all properties in T optional',
+                example: undefined,
+                format: undefined,
+                properties: {
+                  a: {
+                    default: undefined,
+                    description: undefined,
+                    example: 'example',
+                    format: undefined,
+                    type: 'string',
+                  },
+                },
+                type: 'object',
               },
-              type: "object"
-            },
-              `for property ${propertyName}.examples`
+              `for property ${propertyName}.examples`,
             );
             const extensionsSchema = getComponentSchema('Partial__a_extensions:[_key-x-key-1.value-value-1_]_-string__', currentSpec);
             expect(extensionsSchema).to.deep.eq(
               {
                 properties: {
                   a: {
-                    type: "string",
-                    "x-key-1": "value-1",
+                    type: 'string',
+                    'x-key-1': 'value-1',
                     description: undefined,
                     default: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.extensions`
+              `for property ${propertyName}.extensions`,
             );
             const ignoredSchema = getComponentSchema('Partial__a_ignored-true_-string__', currentSpec);
             expect(ignoredSchema).to.deep.eq(
               {
-                properties: {
-                },
-                type: "object",
-                description: "Make all properties in T optional",
+                properties: {},
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.ignored`
+              `for property ${propertyName}.ignored`,
             );
             const indexedSchema = getComponentSchema('Partial__[a-string]:string__', currentSpec);
             expect(indexedSchema).to.deep.eq(
               {
-                properties: {
-                },
+                properties: {},
                 additionalProperties: {
-                  type: "string"
+                  type: 'string',
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.indexedSimple`
+              `for property ${propertyName}.indexedSimple`,
             );
           },
           jsdocMap: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.omitted?.$ref).to.eq("#/components/schemas/Omit_JsDocced.notRelevant_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.partial?.$ref).to.eq("#/components/schemas/Partial_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq("#/components/schemas/ReplaceStringAndNumberTypes_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq("#/components/schemas/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.postfixed?.$ref).to.eq("#/components/schemas/Postfixed_JsDocced._PostFix_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.values?.$ref).to.eq("#/components/schemas/Values_JsDocced_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typesValues?.$ref).to.eq("#/components/schemas/InternalTypes_Values_JsDocced__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.omitted?.$ref).to.eq('#/components/schemas/Omit_JsDocced.notRelevant_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.partial?.$ref).to.eq('#/components/schemas/Partial_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.replacedTypes?.$ref).to.eq('#/components/schemas/ReplaceStringAndNumberTypes_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleReplacedTypes?.$ref).to.eq(
+              '#/components/schemas/ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__',
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.postfixed?.$ref).to.eq('#/components/schemas/Postfixed_JsDocced._PostFix_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.values?.$ref).to.eq('#/components/schemas/Values_JsDocced_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typesValues?.$ref).to.eq('#/components/schemas/InternalTypes_Values_JsDocced__', `for property ${propertyName}`);
             expect(propertySchema?.properties?.onlyOneValue).to.deep.eq(
               {
-                type: "number",
-                format: "double",
+                type: 'number',
+                format: 'double',
                 default: undefined,
                 description: undefined,
-                example: undefined
+                example: undefined,
               },
-              `for property ${propertyName}.onlyOneValue`
+              `for property ${propertyName}.onlyOneValue`,
             );
-            expect(propertySchema?.properties?.synonym?.$ref).to.eq("#/components/schemas/JsDoccedSynonym", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.synonym2?.$ref).to.eq("#/components/schemas/JsDoccedSynonym2", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym?.$ref).to.eq('#/components/schemas/JsDoccedSynonym', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.synonym2?.$ref).to.eq('#/components/schemas/JsDoccedSynonym2', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(10, `for property ${propertyName}`);
 
             const omittedSchema = getComponentSchema('Omit_JsDocced.notRelevant_', currentSpec);
             expect(omittedSchema).to.deep.eq(
               {
-                $ref: "#/components/schemas/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__",
-                description: "Construct a type with the properties of T except for those in type K.",
+                $ref: '#/components/schemas/Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__',
+                description: 'Construct a type with the properties of T except for those in type K.',
                 default: undefined,
                 example: undefined,
                 format: undefined,
               },
-              `for property ${propertyName}.omitted`
+              `for property ${propertyName}.omitted`,
             );
             const omittedSchema2 = getComponentSchema('Pick_JsDocced.Exclude_keyofJsDocced.notRelevant__', currentSpec);
-            expect(omittedSchema2).to.deep.eq({
-              properties: {
-                stringValue: {
-                  type: "string",
-                  default: "def",
-                  maxLength: 3,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
+            expect(omittedSchema2).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: 'string',
+                    default: 'def',
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  numberValue: {
+                    type: 'integer',
+                    format: 'int32',
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                  },
                 },
-                numberValue: {
-                  type: "integer",
-                  format: "int32",
-                  default: 6,
-                  description: undefined,
-                  example: undefined
-                }
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.omitted`
+              `for property ${propertyName}.omitted`,
             );
             const partialSchema = getComponentSchema('Partial_JsDocced_', currentSpec);
             expect(partialSchema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     format: undefined,
                     example: undefined,
-                    description: undefined
+                    description: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     example: undefined,
-                    description: undefined
-                  }
+                    description: undefined,
+                  },
                 },
-                type: "object",
-                description: "Make all properties in T optional",
+                type: 'object',
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.partial`
+              `for property ${propertyName}.partial`,
             );
             const replacedTypesSchema = getComponentSchema('ReplaceStringAndNumberTypes_JsDocced_', currentSpec);
             expect(replacedTypesSchema).to.deep.eq(
               {
-                $ref: "#/components/schemas/ReplaceTypes_JsDocced.string.number_",
+                $ref: '#/components/schemas/ReplaceTypes_JsDocced.string.number_',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
             const replacedTypes2Schema = getComponentSchema('ReplaceTypes_JsDocced.string.number_', currentSpec);
-            expect(replacedTypes2Schema).to.deep.eq({
-              properties: {
-                stringValue: {
-                  type: "number",
-                  format: "double",
-                  default: "def",
-                  maxLength: 3,
-                  description: undefined,
-                  example: undefined,
+            expect(replacedTypes2Schema).to.deep.eq(
+              {
+                properties: {
+                  stringValue: {
+                    type: 'number',
+                    format: 'double',
+                    default: 'def',
+                    maxLength: 3,
+                    description: undefined,
+                    example: undefined,
+                  },
+                  numberValue: {
+                    type: 'string',
+                    default: 6,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                numberValue: {
-                  type: "string",
-                  default: 6,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.replacedTypes`
+              `for property ${propertyName}.replacedTypes`,
             );
             const doubleReplacedTypesSchema = getComponentSchema('ReplaceStringAndNumberTypes_ReplaceStringAndNumberTypes_JsDocced__', currentSpec);
             expect(doubleReplacedTypesSchema).to.deep.eq(
               {
-                $ref: "#/components/schemas/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_",
+                $ref: '#/components/schemas/ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleReplacedTypes`
+              `for property ${propertyName}.doubleReplacedTypes`,
             );
             const doubleReplacedTypes2Schema = getComponentSchema('ReplaceTypes_ReplaceStringAndNumberTypes_JsDocced_.string.number_', currentSpec);
             expect(doubleReplacedTypes2Schema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
                     example: undefined,
                   },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleReplacedTypes`
+              `for property ${propertyName}.doubleReplacedTypes`,
             );
             const postfixedSchema = getComponentSchema('Postfixed_JsDocced._PostFix_', currentSpec);
             expect(postfixedSchema).to.deep.eq(
               {
                 properties: {
                   stringValue_PostFix: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue_PostFix: {
-                    type: "number",
-                    format: "double",
+                    type: 'number',
+                    format: 'double',
                     default: undefined,
                     description: undefined,
-                    example: undefined
-                  }
+                    example: undefined,
+                  },
                 },
-                required: [
-                  "stringValue_PostFix", "numberValue_PostFix"
-                ],
-                type: "object",
+                required: ['stringValue_PostFix', 'numberValue_PostFix'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.postfixed`
+              `for property ${propertyName}.postfixed`,
             );
             const valuesSchema = getComponentSchema('Values_JsDocced_', currentSpec);
             expect(valuesSchema).to.deep.eq(
@@ -3443,74 +3453,74 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   stringValue: {
                     properties: {
                       value: {
-                        type: "string",
+                        type: 'string',
                         default: undefined,
                         description: undefined,
                         example: undefined,
-                        format: undefined
-                      }
+                        format: undefined,
+                      },
                     },
-                    required: ["value"],
-                    type: "object",
-                    default: "def",
+                    required: ['value'],
+                    type: 'object',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
                     properties: {
                       value: {
-                        type: "number",
-                        format: "double",
+                        type: 'number',
+                        format: 'double',
                         default: undefined,
                         description: undefined,
                         example: undefined,
-                      }
+                      },
                     },
-                    required: ["value"],
-                    type: "object",
+                    required: ['value'],
+                    type: 'object',
                     default: 6,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.values`
+              `for property ${propertyName}.values`,
             );
             const typesValuesSchema = getComponentSchema('InternalTypes_Values_JsDocced__', currentSpec);
             expect(typesValuesSchema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
                     example: undefined,
-                  }
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.typesValues`
+              `for property ${propertyName}.typesValues`,
             );
 
             const synonymSchema = getComponentSchema('JsDoccedSynonym', currentSpec);
@@ -3518,63 +3528,63 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   stringValue: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "number",
-                    format: "double",
+                    type: 'number',
+                    format: 'double',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                  }
+                  },
                 },
-                required: ["stringValue", "numberValue"],
-                type: "object",
+                required: ['stringValue', 'numberValue'],
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.synonym`
+              `for property ${propertyName}.synonym`,
             );
             const synonym2Schema = getComponentSchema('JsDoccedSynonym2', currentSpec);
             expect(synonym2Schema).to.deep.eq(
               {
                 properties: {
                   stringValue: {
-                    type: "string",
-                    default: "def",
+                    type: 'string',
+                    default: 'def',
                     maxLength: 3,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   numberValue: {
-                    type: "integer",
-                    format: "int32",
+                    type: 'integer',
+                    format: 'int32',
                     default: 6,
                     description: undefined,
-                    example: undefined
-                  }
+                    example: undefined,
+                  },
                 },
-                type: "object",
+                type: 'object',
                 default: undefined,
                 description: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.synonym2`
+              `for property ${propertyName}.synonym2`,
             );
           },
           duplicatedDefinitions: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.interfaces?.$ref).to.eq("#/components/schemas/DuplicatedInterface", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.enums?.$ref).to.eq("#/components/schemas/DuplicatedEnum", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.enumMember?.$ref).to.eq("#/components/schemas/DuplicatedEnum.C", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq("#/components/schemas/DuplicatedEnum.D", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.interfaces?.$ref).to.eq('#/components/schemas/DuplicatedInterface', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enums?.$ref).to.eq('#/components/schemas/DuplicatedEnum', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.enumMember?.$ref).to.eq('#/components/schemas/DuplicatedEnum.C', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.namespaceMember?.$ref).to.eq('#/components/schemas/DuplicatedEnum.D', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
 
@@ -3583,69 +3593,74 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               {
                 properties: {
                   a: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
+                    format: undefined,
                   },
                   b: {
-                    type: "string",
+                    type: 'string',
                     default: undefined,
                     description: undefined,
                     example: undefined,
-                    format: undefined
-                  }
+                    format: undefined,
+                  },
                 },
-                required: ["a", "b"],
-                type: "object",
+                required: ['a', 'b'],
+                type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
-
               },
-              `for property ${propertyName}.interfaces`
+              `for property ${propertyName}.interfaces`,
             );
             const enumsSchema = getComponentSchema('DuplicatedEnum', currentSpec);
             expect(enumsSchema).to.deep.eq(
               {
-                enum: ["AA", "BB", "CC"],
-                type: "string",
-                description: undefined
+                enum: ['AA', 'BB', 'CC'],
+                type: 'string',
+                description: undefined,
               },
-              `for property ${propertyName}.enums`
+              `for property ${propertyName}.enums`,
             );
             const enumMemberSchema = getComponentSchema('DuplicatedEnum.C', currentSpec);
             expect(enumMemberSchema).to.deep.eq(
               {
-                enum: ["CC"],
-                type: "string",
-                description: undefined
+                enum: ['CC'],
+                type: 'string',
+                description: undefined,
               },
-              `for property ${propertyName}.enumMember`
+              `for property ${propertyName}.enumMember`,
             );
             const namespaceMemberSchema = getComponentSchema('DuplicatedEnum.D', currentSpec);
             expect(namespaceMemberSchema).to.deep.eq(
               {
-                enum: ["DD"],
-                type: "string",
+                enum: ['DD'],
+                type: 'string',
                 nullable: false,
                 description: undefined,
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.namespaceMember`
+              `for property ${propertyName}.namespaceMember`,
             );
           },
           mappeds: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.unionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-_b-number__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-and-_b-number__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq("#/components/schemas/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq("#/components/schemas/Partial__a-string_-or-(_b-string_-and-_c-string_)_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq("#/components/schemas/Partial_(_a-string_-or-_b-string_)-and-_c-string__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.unionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_b-number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedUnionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedUnionMap?.$ref).to.eq(
+              '#/components/schemas/Partial__%5Ba-string%5D%3Astring_-or-_%5Bb-string%5D%3Anumber__',
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.intersectionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-and-_b-number__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.indexedIntersectionMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-and-_%5Bb-string%5D%3Anumber__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.doubleIndexedIntersectionMap?.$ref).to.eq(
+              '#/components/schemas/Partial__%5Ba-string%5D%3Astring_-and-_%5Bb-number%5D%3Anumber__',
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.parenthesizedMap?.$ref).to.eq('#/components/schemas/Partial__a-string_-or-(_b-string_-and-_c-string_)_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.parenthesizedMap2?.$ref).to.eq('#/components/schemas/Partial_(_a-string_-or-_b-string_)-and-_c-string__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
@@ -3656,27 +3671,27 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   {
                     properties: {
                       a: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
+                    type: 'object',
                   },
                   {
                     properties: {
                       b: {
-                        format: "double",
-                        type: "number"
-                      }
+                        format: 'double',
+                        type: 'number',
+                      },
                     },
-                    type: "object"
-                  }
+                    type: 'object',
+                  },
                 ],
-                description: "Make all properties in T optional",
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.unionMap`
+              `for property ${propertyName}.unionMap`,
             );
             const indexedUnionMapSchema = getComponentSchema('Partial__a-string_-or-_[b-string]:number__', currentSpec);
             expect(indexedUnionMapSchema).to.deep.eq(
@@ -3685,26 +3700,26 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   {
                     properties: {
                       a: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
+                    type: 'object',
                   },
                   {
                     additionalProperties: {
-                      format: "double",
-                      type: "number"
+                      format: 'double',
+                      type: 'number',
                     },
                     properties: {},
-                    type: "object"
-                  }
+                    type: 'object',
+                  },
                 ],
-                description: "Make all properties in T optional",
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.indexedUnionMap`
+              `for property ${propertyName}.indexedUnionMap`,
             );
             const doubleIndexedUnionMapSchema = getComponentSchema('Partial__[a-string]:string_-or-_[b-string]:number__', currentSpec);
             expect(doubleIndexedUnionMapSchema).to.deep.eq(
@@ -3712,97 +3727,100 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 anyOf: [
                   {
                     additionalProperties: {
-                      type: "string"
+                      type: 'string',
                     },
                     properties: {},
-                    type: "object"
+                    type: 'object',
                   },
                   {
                     additionalProperties: {
-                      format: "double",
-                      type: "number"
+                      format: 'double',
+                      type: 'number',
                     },
                     properties: {},
-                    type: "object"
-                  }
+                    type: 'object',
+                  },
                 ],
-                description: "Make all properties in T optional",
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.doubleIndexedUnionMap`
+              `for property ${propertyName}.doubleIndexedUnionMap`,
             );
             const intersectionMapSchema = getComponentSchema('Partial__a-string_-and-_b-number__', currentSpec);
-            expect(intersectionMapSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+            expect(intersectionMapSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  b: {
+                    type: 'number',
+                    format: 'double',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  },
                 },
-                b: {
-                  type: "number",
-                  format: "double",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.intersectionMap`
+              `for property ${propertyName}.intersectionMap`,
             );
             const indexedIntersectionMapSchema = getComponentSchema('Partial__a-string_-and-_[b-string]:number__', currentSpec);
-            expect(indexedIntersectionMapSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+            expect(indexedIntersectionMapSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                additionalProperties: {
+                  type: 'number',
+                  format: 'double',
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              additionalProperties: {
-                type: "number",
-                format: "double"
-              },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.indexedIntersectionMap`
+              `for property ${propertyName}.indexedIntersectionMap`,
             );
             const doubleIndexedIntersectionMapSchema = getComponentSchema('Partial__[a-string]:string_-and-_[b-number]:number__', currentSpec);
-            expect(doubleIndexedIntersectionMapSchema).to.deep.eq({
-              properties: {},
-              additionalProperties: {
-                anyOf: [
-                  {
-                    type: "string"
-                  },
-                  {
-                    format: "double",
-                    type: "number"
-                  }
-                ]
+            expect(doubleIndexedIntersectionMapSchema).to.deep.eq(
+              {
+                properties: {},
+                additionalProperties: {
+                  anyOf: [
+                    {
+                      type: 'string',
+                    },
+                    {
+                      format: 'double',
+                      type: 'number',
+                    },
+                  ],
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.doubleIndexedIntersectionMap`
+              `for property ${propertyName}.doubleIndexedIntersectionMap`,
             );
             const parenthesizedMapSchema = getComponentSchema('Partial__a-string_-or-(_b-string_-and-_c-string_)_', currentSpec);
             expect(parenthesizedMapSchema).to.deep.eq(
@@ -3811,29 +3829,29 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   {
                     properties: {
                       a: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
+                    type: 'object',
                   },
                   {
                     properties: {
                       b: {
-                        type: "string"
+                        type: 'string',
                       },
                       c: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
-                  }
+                    type: 'object',
+                  },
                 ],
-                description: "Make all properties in T optional",
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.parenthesizedMap`
+              `for property ${propertyName}.parenthesizedMap`,
             );
             const parenthesizedMap2Schema = getComponentSchema('Partial_(_a-string_-or-_b-string_)-and-_c-string__', currentSpec);
             expect(parenthesizedMap2Schema).to.deep.eq(
@@ -3842,471 +3860,513 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   {
                     properties: {
                       a: {
-                        type: "string"
+                        type: 'string',
                       },
                       c: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
+                    type: 'object',
                   },
                   {
                     properties: {
                       b: {
-                        type: "string"
+                        type: 'string',
                       },
                       c: {
-                        type: "string"
-                      }
+                        type: 'string',
+                      },
                     },
-                    type: "object"
-                  }
+                    type: 'object',
+                  },
                 ],
-                description: "Make all properties in T optional",
+                description: 'Make all properties in T optional',
                 default: undefined,
                 example: undefined,
-                format: undefined
+                format: undefined,
               },
-              `for property ${propertyName}.parenthesizedMap2`
+              `for property ${propertyName}.parenthesizedMap2`,
             );
           },
           conditionals: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.simpeConditional).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}`);
-            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq({
-              type: "boolean",
-              format: undefined,
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq("#/components/schemas/Conditional_string.string.number.boolean_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq("#/components/schemas/Conditional_string.number.number.boolean_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq("#/components/schemas/Dummy_Conditional_string.string.number.boolean__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq("#/components/schemas/Dummy_Conditional_string.number.number.boolean__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq("#/components/schemas/Partial_stringextendsstring%3F_a-number_-never_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq("#/components/schemas/Partial_Conditional_string.string._a-number_.never__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simpeConditional).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.simpeFalseConditional).to.deep.eq(
+              {
+                type: 'boolean',
+                format: undefined,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}`,
+            );
+            expect(propertySchema?.properties?.typedConditional?.$ref).to.eq('#/components/schemas/Conditional_string.string.number.boolean_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.typedFalseConditional?.$ref).to.eq('#/components/schemas/Conditional_string.number.number.boolean_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyConditional?.$ref).to.eq('#/components/schemas/Dummy_Conditional_string.string.number.boolean__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.dummyFalseConditional?.$ref).to.eq('#/components/schemas/Dummy_Conditional_string.number.number.boolean__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedConditional?.$ref).to.eq('#/components/schemas/Partial_stringextendsstring%3F_a-number_-never_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.mappedTypedConditional?.$ref).to.eq('#/components/schemas/Partial_Conditional_string.string._a-number_.never__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(8, `for property ${propertyName}`);
 
             const typedConditionalSchema = getComponentSchema('Conditional_string.string.number.boolean_', currentSpec);
-            expect(typedConditionalSchema).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-            },
-              `for property ${propertyName}.typedConditional`);
-            const typedFalseConditionalSchema = getComponentSchema('Conditional_string.number.number.boolean_', currentSpec);
-            expect(typedFalseConditionalSchema).to.deep.eq({
-              type: "boolean",
-              format: undefined,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-            },
-              `for property ${propertyName}.typedFalseConditional`);
-            const dummyConditionalSchema = getComponentSchema('Dummy_Conditional_string.string.number.boolean__', currentSpec);
-            expect(dummyConditionalSchema?.$ref).to.eq("#/components/schemas/Conditional_string.string.number.boolean_", `for property ${propertyName}.dummyConditional`);
-            const dummyFalseConditionalSchema = getComponentSchema('Dummy_Conditional_string.number.number.boolean__', currentSpec);
-            expect(dummyFalseConditionalSchema?.$ref).to.eq("#/components/schemas/Conditional_string.number.number.boolean_", `for property ${propertyName}.dummyFalseConditional`);
-            const mappedConditionalSchema = getComponentSchema('Partial_stringextendsstring?_a-number_-never_', currentSpec);
-            expect(mappedConditionalSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "number",
-                  format: "double",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                }
+            expect(typedConditionalSchema).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              example: undefined,
-              default: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.mappedConditional`);
+              `for property ${propertyName}.typedConditional`,
+            );
+            const typedFalseConditionalSchema = getComponentSchema('Conditional_string.number.number.boolean_', currentSpec);
+            expect(typedFalseConditionalSchema).to.deep.eq(
+              {
+                type: 'boolean',
+                format: undefined,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}.typedFalseConditional`,
+            );
+            const dummyConditionalSchema = getComponentSchema('Dummy_Conditional_string.string.number.boolean__', currentSpec);
+            expect(dummyConditionalSchema?.$ref).to.eq('#/components/schemas/Conditional_string.string.number.boolean_', `for property ${propertyName}.dummyConditional`);
+            const dummyFalseConditionalSchema = getComponentSchema('Dummy_Conditional_string.number.number.boolean__', currentSpec);
+            expect(dummyFalseConditionalSchema?.$ref).to.eq('#/components/schemas/Conditional_string.number.number.boolean_', `for property ${propertyName}.dummyFalseConditional`);
+            const mappedConditionalSchema = getComponentSchema('Partial_stringextendsstring?_a-number_-never_', currentSpec);
+            expect(mappedConditionalSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'number',
+                    format: 'double',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                example: undefined,
+                default: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.mappedConditional`,
+            );
             const mappedTypedConditionalSchema = getComponentSchema('Partial_Conditional_string.string._a-number_.never__', currentSpec);
             expect(mappedTypedConditionalSchema).to.deep.eq(mappedConditionalSchema, `for property ${propertyName}.mappedTypedConditional`);
           },
           typeOperators: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq("#/components/schemas/KeysMember", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq("#/components/schemas/KeysMember_NestedTypeLiteral_", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.simple).to.deep.eq({
-              type: "string",
-              enum: ["a", "b", "e"],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.simple`);
-            expect(propertySchema?.properties?.keyofItem).to.deep.eq({
-              type: "string",
-              enum: ["c", "d"],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.keyofItem`);
-            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq({
-              anyOf: [
-                {
-                  type: "string"
-                },
-                {
-                  format: "double",
-                  type: "number"
-                }
-              ],
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keyofAnyItem`);
-            expect(propertySchema?.properties?.keyofAny).to.deep.eq(propertySchema?.properties?.keyofAnyItem,
-              `for property ${propertyName}.keyofAny`);
-            expect(propertySchema?.properties?.stringLiterals).to.deep.eq({
-              type: "string",
-              enum: ["A", "B", "C"],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.stringLiterals`);
-            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq({
-              anyOf: [
-                {
-                  enum: [
-                    "A",
-                    "B"
-                  ],
-                  type: "string"
-                },
-                {
-                  enum: [
-                    3
-                  ],
-                  type: "number"
-                }
-              ],
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.stringAndNumberLiterals`);
-            expect(propertySchema?.properties?.keyofEnum).to.deep.eq({
-              type: "string",
-              enum: ["A", "B", "C"],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keyofEnum`);
-            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq({
-              anyOf: [
-                {
-                  enum: [
-                    "a"
-                  ],
-                  type: "string"
-                },
-                {
-                  enum: [
-                    3,
-                    4
-                  ],
-                  type: "number"
-                }
-              ],
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.numberAndStringKeys`);
-            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq({
-              type: "string",
-              enum: ["a"],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.oneStringKeyInterface`);
-            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq({
-              type: "number",
-              enum: [3],
-              nullable: false,
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.oneNumberKeyInterface`);
-            expect(propertySchema?.properties?.indexStrings).to.deep.eq({
-              anyOf: [
-                {
-                  type: "string"
-                },
-                {
-                  format: "double",
-                  type: "number"
-                }
-              ],
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.indexStrings`);
-            expect(propertySchema?.properties?.indexNumbers).to.deep.eq({
-              type: "number",
-              format: "double",
-              default: undefined,
-              description: undefined,
-              example: undefined
-            },
-              `for property ${propertyName}.indexNumbers`);
+            expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq('#/components/schemas/KeysMember', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.keysOfInterface?.$ref).to.eq('#/components/schemas/KeysMember_NestedTypeLiteral_', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.simple).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['a', 'b', 'e'],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.simple`,
+            );
+            expect(propertySchema?.properties?.keyofItem).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['c', 'd'],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.keyofItem`,
+            );
+            expect(propertySchema?.properties?.keyofAnyItem).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    type: 'string',
+                  },
+                  {
+                    format: 'double',
+                    type: 'number',
+                  },
+                ],
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.keyofAnyItem`,
+            );
+            expect(propertySchema?.properties?.keyofAny).to.deep.eq(propertySchema?.properties?.keyofAnyItem, `for property ${propertyName}.keyofAny`);
+            expect(propertySchema?.properties?.stringLiterals).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['A', 'B', 'C'],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.stringLiterals`,
+            );
+            expect(propertySchema?.properties?.stringAndNumberLiterals).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    enum: ['A', 'B'],
+                    type: 'string',
+                  },
+                  {
+                    enum: [3],
+                    type: 'number',
+                  },
+                ],
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.stringAndNumberLiterals`,
+            );
+            expect(propertySchema?.properties?.keyofEnum).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['A', 'B', 'C'],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.keyofEnum`,
+            );
+            expect(propertySchema?.properties?.numberAndStringKeys).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    enum: ['a'],
+                    type: 'string',
+                  },
+                  {
+                    enum: [3, 4],
+                    type: 'number',
+                  },
+                ],
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.numberAndStringKeys`,
+            );
+            expect(propertySchema?.properties?.oneStringKeyInterface).to.deep.eq(
+              {
+                type: 'string',
+                enum: ['a'],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.oneStringKeyInterface`,
+            );
+            expect(propertySchema?.properties?.oneNumberKeyInterface).to.deep.eq(
+              {
+                type: 'number',
+                enum: [3],
+                nullable: false,
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.oneNumberKeyInterface`,
+            );
+            expect(propertySchema?.properties?.indexStrings).to.deep.eq(
+              {
+                anyOf: [
+                  {
+                    type: 'string',
+                  },
+                  {
+                    format: 'double',
+                    type: 'number',
+                  },
+                ],
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.indexStrings`,
+            );
+            expect(propertySchema?.properties?.indexNumbers).to.deep.eq(
+              {
+                type: 'number',
+                format: 'double',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+              },
+              `for property ${propertyName}.indexNumbers`,
+            );
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(14, `for property ${propertyName}`);
 
             const keysOfAnySchema = getComponentSchema('KeysMember', currentSpec);
-            expect(keysOfAnySchema).to.deep.eq({
-              properties: {
-                keys: {
-                  anyOf: [
-                    {
-                      type: "string"
-                    },
-                    {
-                      format: "double",
-                      type: "number"
-                    }
-                  ],
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                }
+            expect(keysOfAnySchema).to.deep.eq(
+              {
+                properties: {
+                  keys: {
+                    anyOf: [
+                      {
+                        type: 'string',
+                      },
+                      {
+                        format: 'double',
+                        type: 'number',
+                      },
+                    ],
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                required: ['keys'],
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              required: ["keys"],
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keysOfAny`);
+              `for property ${propertyName}.keysOfAny`,
+            );
 
             const keysOfInterfaceSchema = getComponentSchema('KeysMember_NestedTypeLiteral_', currentSpec);
-            expect(keysOfInterfaceSchema).to.deep.eq({
-              properties: {
-                keys: {
-                  type: "string",
-                  enum: ["a", "b", "e"],
-                  nullable: false,
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
-                }
+            expect(keysOfInterfaceSchema).to.deep.eq(
+              {
+                properties: {
+                  keys: {
+                    type: 'string',
+                    enum: ['a', 'b', 'e'],
+                    nullable: false,
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                required: ['keys'],
+                type: 'object',
+                default: undefined,
+                description: undefined,
+                example: undefined,
+                format: undefined,
               },
-              required: ["keys"],
-              type: "object",
-              default: undefined,
-              description: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.keysOfInterface`);
+              `for property ${propertyName}.keysOfInterface`,
+            );
           },
           nestedTypes: (propertyName, propertySchema) => {
-            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq("#/components/schemas/Partial_Partial__a-string___", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField2?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__", `for property ${propertyName}`);
-            expect(propertySchema?.properties?.separateField3?.$ref).to.eq("#/components/schemas/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__", `for property ${propertyName}`);
+            expect(propertySchema?.properties?.multiplePartial?.$ref).to.eq('#/components/schemas/Partial_Partial__a-string___', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField?.$ref).to.eq('#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField2?.$ref).to.eq('#/components/schemas/Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', `for property ${propertyName}`);
+            expect(propertySchema?.properties?.separateField3?.$ref).to.eq('#/components/schemas/Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', `for property ${propertyName}`);
 
             expect(Object.keys(propertySchema?.properties || {}).length).to.eq(4, `for property ${propertyName}`);
 
             const multiplePartialSchema = getComponentSchema('Partial_Partial__a-string___', currentSpec);
-            expect(multiplePartialSchema).to.deep.eq({
-              properties: {
-                a: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
-              },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.multiplePartial`);
-            const separateFieldSchema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
-            expect(separateFieldSchema).to.deep.eq({
-              properties: {
-                omitted: {
-                  $ref: "#/components/schemas/Omit_Partial__a-string--b-string__.a_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined,
+            expect(multiplePartialSchema).to.deep.eq(
+              {
+                properties: {
+                  a: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField`);
+              `for property ${propertyName}.multiplePartial`,
+            );
+            const separateFieldSchema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-string__.a__', currentSpec);
+            expect(separateFieldSchema).to.deep.eq(
+              {
+                properties: {
+                  omitted: {
+                    $ref: '#/components/schemas/Omit_Partial__a-string--b-string__.a_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField`,
+            );
             const separateFieldInternalSchema = getComponentSchema('Omit_Partial__a-string--b-string__.a_', currentSpec);
-            expect(separateFieldInternalSchema).to.deep.eq({
-              $ref: "#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__",
-              description: "Construct a type with the properties of T except for those in type K.",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField.omitted`);
+            expect(separateFieldInternalSchema).to.deep.eq(
+              {
+                $ref: '#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__',
+                description: 'Construct a type with the properties of T except for those in type K.',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField.omitted`,
+            );
 
             const separateFieldInternal2Schema = getComponentSchema('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a__', currentSpec);
-            expect(separateFieldInternal2Schema).to.deep.eq({
-              properties: {
-                b: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+            expect(separateFieldInternal2Schema).to.deep.eq(
+              {
+                properties: {
+                  b: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                },
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField.omitted`);
+              `for property ${propertyName}.separateField.omitted`,
+            );
 
             const separateField2Schema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-string__.a-or-b__', currentSpec);
-            expect(separateField2Schema).to.deep.eq({
-              properties: {
-                omitted: {
-                  $ref: "#/components/schemas/Omit_Partial__a-string--b-string__.a-or-b_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+            expect(separateField2Schema).to.deep.eq(
+              {
+                properties: {
+                  omitted: {
+                    $ref: '#/components/schemas/Omit_Partial__a-string--b-string__.a-or-b_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    type: 'string',
+                    default: undefined,
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  type: "string",
-                  default: undefined,
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField2`);
+              `for property ${propertyName}.separateField2`,
+            );
             const separateField2InternalSchema = getComponentSchema('Omit_Partial__a-string--b-string__.a-or-b_', currentSpec);
-            expect(separateField2InternalSchema?.$ref).to.eq("#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__",
-              `for property ${propertyName}.separateField2.omitted`
+            expect(separateField2InternalSchema?.$ref).to.eq(
+              '#/components/schemas/Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__',
+              `for property ${propertyName}.separateField2.omitted`,
             );
             const separateField2Internal2Schema = getComponentSchema('Pick_Partial__a-string--b-string__.Exclude_keyofPartial__a-string--b-string__.a-or-b__', currentSpec);
-            expect(separateField2Internal2Schema).to.deep.eq({
-              properties: {},
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField2.omitted`);
+            expect(separateField2Internal2Schema).to.deep.eq(
+              {
+                properties: {},
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField2.omitted`,
+            );
 
             const separateField3Schema = getComponentSchema('Partial_SeparateField_Partial__a-string--b-number__.a-or-b__', currentSpec);
-            expect(separateField3Schema).to.deep.eq({
-              properties:
+            expect(separateField3Schema).to.deep.eq(
               {
-                omitted: {
-                  $ref: "#/components/schemas/Omit_Partial__a-string--b-number__.a-or-b_",
-                  description: undefined,
-                  example: undefined,
-                  format: undefined
+                properties: {
+                  omitted: {
+                    $ref: '#/components/schemas/Omit_Partial__a-string--b-number__.a-or-b_',
+                    description: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
+                  field: {
+                    anyOf: [
+                      {
+                        type: 'string',
+                      },
+                      {
+                        format: 'double',
+                        type: 'number',
+                      },
+                    ],
+                    description: undefined,
+                    default: undefined,
+                    example: undefined,
+                    format: undefined,
+                  },
                 },
-                field: {
-                  anyOf: [
-                    {
-                      type: "string"
-                    },
-                    {
-                      format: "double",
-                      type: "number"
-                    }
-                  ],
-                  description: undefined,
-                  default: undefined,
-                  example: undefined,
-                  format: undefined
-                }
+                type: 'object',
+                description: 'Make all properties in T optional',
+                default: undefined,
+                example: undefined,
+                format: undefined,
               },
-              type: "object",
-              description: "Make all properties in T optional",
-              default: undefined,
-              example: undefined,
-              format: undefined
-            },
-              `for property ${propertyName}.separateField3`);
+              `for property ${propertyName}.separateField3`,
+            );
             const separateField3InternalSchema = getComponentSchema('Omit_Partial__a-string--b-number__.a-or-b_', currentSpec);
-            expect(separateField3InternalSchema?.$ref).to.eq("#/components/schemas/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__",
-              `for property ${propertyName}.separateField3.omitted`
+            expect(separateField3InternalSchema?.$ref).to.eq(
+              '#/components/schemas/Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__',
+              `for property ${propertyName}.separateField3.omitted`,
             );
             const separateField3Internal2Schema = getComponentSchema('Pick_Partial__a-string--b-number__.Exclude_keyofPartial__a-string--b-number__.a-or-b__', currentSpec);
-            expect(separateField3Internal2Schema).to.deep.eq({
-              properties: {},
-              type: "object",
-              description: "From T, pick a set of properties whose keys are in the union K",
-              default: undefined,
-              example: undefined,
-              format: undefined,
-            },
-              `for property ${propertyName}.separateField3.omitted`);
-          }
+            expect(separateField3Internal2Schema).to.deep.eq(
+              {
+                properties: {},
+                type: 'object',
+                description: 'From T, pick a set of properties whose keys are in the union K',
+                default: undefined,
+                example: undefined,
+                format: undefined,
+              },
+              `for property ${propertyName}.separateField3.omitted`,
+            );
+          },
         };
 
         const testModel = currentSpec.spec.components.schemas[interfaceModelName];
@@ -4568,7 +4628,3 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
     });
   });
 });
-
-
-
-


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Closing issues**

closes #477
closes #623
closes #681
closes #1191
closes #1204
closes #1266
closes #1447 
closes #1472

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

Fixes:

I have solved locally some problems which are needed for my company. After that I read the TSOA commit guides, so some fixes maybe have no related issues.

1. Namespaces: Every type should be stored with their full-path namespaced types. Even if the source code not uses this name. This reduces conflicts between types.
2. Name conflicts: If every reference type name parts are uniq, then the full type name can be handled as uniq. In this type name, we need to sign the jsdoc params if exists, because its they can make differences in the result. Somehow the reference type names are transformed with an irreversible getRefTypeName(), here we need to check if the result name comes from the same original type names, or from more different names.
3. Handling interfaces - namespaces - enums which have more than one declaration
4. Keep jsdoc comments + defaults after mapping - as intellisense shows
5. Do not use original definition in mapped types, because type can change.
6. Accept unions, intersections, nulls, enums in mapped type.
7. Fix referencer issues. TypeToTypeNode & TypeNodeToType functions are not exactly the inverse function of each other -> use the original types, and remove conversions.
8. Do not name more complicated reference type internal parts as "any". - It is needed to recognize name conflicts.
9. Better keyof handling
10. Do not mark required if a field has a default value. (Not too relevant, but more beautiful)
11. Default values from JSdoc uses the expected type. `@default true` is not a string, but a boolean.

**Potential Problems With The Approach**

- My code sometimes returns with an equivalent type definition, not the original (If #1490 is a bug, then I made bugs). Check original test changes.
- I have not implemented Partial<string> or Partial<number>-like mapped types. I can implement it, but not really know if it is interesting or not/where is the end of this strange types.
- I solved name conflict handling, but for it I generate the type name every time (previously tsoa made it in the else branch, but normally we used the typescript name). For some name, some type formations are not implemented, like:
```type A = Partial<{ [a in keyof B]: string }>```
But there is a workaround:
```type AInternal = { [a in keyof B]: string }; type A = Partial<AInternal>```
- A mapped type can change the type of a member, but can not change the jsdoc of it (sometimes deletes it, but sometimes not). So we can create a number member (with default value 2, and minimum 0), and after that, we can construct a mapped type which can change the type to string. Everything is fine with intellisense, but we can define a type which should have a value, because if not, the default value will have another type, so typecheck fails. Now TSOA handles type restrictions which are related only to one type, so in this case there will be not relevant type checks, not really interesting.
- If a type (interface) has multiple declaration, and both declarations contains the same member with different jsdoc, the program chooses one of them.
- Union types in typescript are a little bit strange, A | B ~ { some properties of A & some properties of B}. TSOA validation not handles them correctly (TSOA validation implementation: A | B = Only A | Only B). In a type with multiple different additionalProperties type I use type unions to "approxximate" the expected operation. It is ok until someone fixes TSOA validation. But I'm not sure, that most programmers love or hate this TSOA validation bug, I enjoy it, it is more strict than ts.

I'm sure, that there are a lot of breaking changes.

**Test plan**

Added test type literals to the TestModel interface. Every literal checks one solved problem. The members represents one test case.