### PR TITLE
Fix invalid implementation of nullable enum

### DIFF
--- a/tests/fixtures/controllers/getController.ts
+++ b/tests/fixtures/controllers/getController.ts
@@ -1,24 +1,24 @@
 ///<reference path="../tsoaTestModule.d.ts" />
+import { Controller, Example, Get, OperationId, Queries, Query, Request, Res, Response, Route, SuccessResponse, Tags, TsoaResponse } from '@tsoa/runtime';
 import { Readable } from 'stream';
-import { Controller, Example, Get, OperationId, Query, Request, Response, Route, SuccessResponse, Tags, Res, TsoaResponse, Queries } from '@tsoa/runtime';
+import TsoaTest from 'tsoaTest';
 import '../duplicateTestModel';
 import {
   GenericModel,
   GetterClass,
   GetterInterface,
   GetterInterfaceHerited,
+  IndexedValue,
+  IndexedValueGeneric,
+  IndexedValueReference,
+  IndexedValueTypeReference,
+  ParenthesizedIndexedValue,
+  SimpleClassWithToJSON,
   TestClassModel,
   TestModel,
   TestSubModel,
-  SimpleClassWithToJSON,
-  IndexedValue,
-  IndexedValueReference,
-  ParenthesizedIndexedValue,
-  IndexedValueGeneric,
-  IndexedValueTypeReference,
 } from '../testModel';
 import { ModelService } from './../services/modelService';
-import TsoaTest from 'tsoaTest';
 
 export const PathFromConstant = 'PathFromConstantValue';
 export enum EnumPaths {
@@ -66,6 +66,7 @@ export class GetTestController extends Controller {
     strLiteralVal: 'Foo',
     stringArray: ['string one', 'string two'],
     stringValue: 'a string',
+    nullableStringLiteral: 'NULLABLE_LIT_1',
     undefineableUnionPrimitiveType: undefined,
     undefinedValue: undefined,
   })

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -67,6 +67,7 @@ export interface TestModel extends Model {
   modelsArray: TestSubModel[];
   strLiteralVal: StrLiteral;
   strLiteralArr: StrLiteral[];
+  nullableStringLiteral?: 'NULLABLE_LIT_1' | 'NULLABLE_LIT_2' | null;
   unionPrimitiveType?: 'String' | 1 | 20.0 | true | false;
   nullableUnionPrimitiveType?: 'String' | 1 | 20.0 | true | false | null;
   undefineableUnionPrimitiveType: 'String' | 1 | 20.0 | true | false | undefined;

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -4,10 +4,10 @@ import { SpecGenerator2 } from '@tsoa/cli/swagger/specGenerator2';
 import { Swagger } from '@tsoa/runtime';
 import { expect } from 'chai';
 import 'mocha';
+import * as os from 'os';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultOptions } from '../../../fixtures/defaultOptions';
 import { TestModel } from '../../../fixtures/testModel';
-import * as os from 'os';
 
 describe('Definition generation', () => {
   const metadata = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -2852,6 +2852,20 @@ describe('Definition generation', () => {
             );
             const mappedTypedConditionalSchema = getValidatedDefinition('Partial_Conditional_string.string._a-number_.never__', currentSpec);
             expect(mappedTypedConditionalSchema).to.deep.eq(mappedConditionalSchema, `for property ${propertyName}.mappedTypedConditional`);
+          },
+          nullableStringLiteral: (propertyName, propertySchema) => {
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema['x-nullable']).to.eq(true, `for property ${propertyName}[x-nullable]`);
+
+            expect(propertySchema).to.deep.eq({
+              type: 'string',
+              enum: ['NULLABLE_LIT_1', 'NULLABLE_LIT_2', null],
+              ['x-nullable']: true,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              default: undefined,
+            });
           },
           typeOperators: (propertyName, propertySchema) => {
             expect(propertySchema?.properties?.keysOfAny?.$ref).to.eq('#/definitions/KeysMember', `for property ${propertyName}`);

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -4,10 +4,10 @@ import { SpecGenerator3 } from '@tsoa/cli/swagger/specGenerator3';
 import { Swagger, Tsoa } from '@tsoa/runtime';
 import { expect } from 'chai';
 import 'mocha';
+import * as os from 'os';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
 import { TestModel } from '../../fixtures/testModel';
-import * as os from 'os';
 
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadataGet = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -4424,6 +4424,20 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               },
               `for property ${propertyName}.separateField3.omitted`,
             );
+          },
+          nullableStringLiteral: (propertyName, propertySchema) => {
+            expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
+            expect(propertySchema.nullable).to.eq(true, `for property ${propertyName}[x-nullable]`);
+
+            expect(propertySchema).to.deep.eq({
+              type: 'string',
+              enum: ['NULLABLE_LIT_1', 'NULLABLE_LIT_2', null],
+              nullable: true,
+              description: undefined,
+              example: undefined,
+              format: undefined,
+              default: undefined,
+            });
           },
         };
 


### PR DESCRIPTION
### What and why?

tsoa currently does not correctly implement OpenAPI v3+ enums when they are marked as nullable. According to the official documentation: https://swagger.io/docs/specification/data-models/enums/

A nullable enum can be defined as follows:
```
    type: string
    nullable: true  # <---
    enum:
      - asc
      - desc
      - null        # <--- without quotes, i.e. null not "null"
```

Note that null must be explicitly included in the list of enum values. Using nullable: true alone [is not enough](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md#if-a-schema-specifies-nullable-true-and-enum-1-2-3-does-that-schema-allow-null-values-see-1900) here.

This PR aims to fix this issue, so that tsoa more closely matches the specifications. This should fix e.g. an issue where `openapi-typescript` would not mark a field as nullable, because `null` is missing from the enum list.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

I made this change mostly motivated by our own goals in using tsoa along with `openapi-typescript` in our product, and this was a pain point I encountered during my implementation, soo I thought I'd take a shot at fixing it.

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

Backwards-compatibility? Edge cases?

I don't know if the way I implemented this "fix" is correct, but it seems to work, and nothing else broke. My understanding of the tsoa codebase is still in the "wtf am I doing" range.

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->

Confirms that `null` is added to the OpenAPI enum field if nullable is also present, to match expected behavior from specifications.
