### PR TITLE
fix: array validation should throw an error if the provided value is not an array

### DIFF
--- a/packages/runtime/src/routeGeneration/templateHelpers.ts
+++ b/packages/runtime/src/routeGeneration/templateHelpers.ts
@@ -417,7 +417,7 @@ export class ValidationService {
   }
 
   public validateArray(name: string, value: any[], fieldErrors: FieldErrors, swaggerConfig: AdditionalProps, schema?: TsoaRoute.PropertySchema, validators?: ArrayValidator, parent = '') {
-    if (!schema || value === undefined) {
+    if (!schema || !Array.isArray(value)) {
       const message = validators && validators.isArray && validators.isArray.errorMsg ? validators.isArray.errorMsg : `invalid array`;
       fieldErrors[parent + name] = {
         message,
@@ -428,13 +428,9 @@ export class ValidationService {
 
     let arrayValue = [] as any[];
     const previousErrors = Object.keys(fieldErrors).length;
-    if (Array.isArray(value)) {
-      arrayValue = value.map((elementValue, index) => {
-        return this.ValidateParam(schema, elementValue, `$${index}`, fieldErrors, name + '.', swaggerConfig);
-      });
-    } else {
-      arrayValue = [this.ValidateParam(schema, value, '$0', fieldErrors, name + '.', swaggerConfig)];
-    }
+    arrayValue = value.map((elementValue, index) => {
+      return this.ValidateParam(schema, elementValue, `$${index}`, fieldErrors, name + '.', swaggerConfig);
+    });
 
     if (Object.keys(fieldErrors).length > previousErrors) {
       return;

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -810,6 +810,16 @@ describe('ValidationService', () => {
       expect(error[`${name}.$2`].value).to.equal(true);
     });
 
+    it('should throw if a non-array value is provided', () => {
+      const name = 'name';
+      const value: any = 'some primitive string';
+      const error: FieldErrors = {};
+      const result = new ValidationService({}).validateArray(name, value, error, { noImplicitAdditionalProperties: 'ignore' }, { dataType: 'string' });
+      expect(result).to.deep.equal(undefined);
+      expect(error[name].message).to.equal('invalid array');
+      expect(error[name].value).to.equal('some primitive string');
+    });
+
     it('should invalid array nested value', () => {
       const name = 'name';
       const value = [{ a: 123 }, { a: 'bcd' }];


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document? AFAIK yes :)
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change? Yes
- [x] Have you written unit tests? Yup
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)? Yup
- [x] This PR is associated with an existing issue? This closes #1563.
