### PR TITLE
fix/hapi imports replace w/ `import type` instead of regular import

### DIFF
--- a/packages/cli/src/routeGeneration/templates/hapi/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi/hapi.hbs
@@ -44,7 +44,11 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     {{/each}}
 };
-const templateService = new HapiTemplateService(models, {{{ json minimalSwaggerConfig }}});
+const templateService = new HapiTemplateService(
+  models,
+  {{{ json minimalSwaggerConfig }}},
+  { boomify, isBoom },
+);
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 

--- a/packages/cli/src/routeGeneration/templates/hapi/hapiTemplateService.ts
+++ b/packages/cli/src/routeGeneration/templates/hapi/hapiTemplateService.ts
@@ -1,5 +1,5 @@
 import { Request as HRequest, ResponseToolkit as HResponse } from '@hapi/hapi';
-import { boomify, isBoom, type Payload } from '@hapi/boom';
+import type { Payload } from '@hapi/boom';
 import { Controller, FieldErrors, TsoaRoute, ValidateError } from '@tsoa/runtime';
 
 import { TemplateService } from '../templateService';
@@ -31,6 +31,10 @@ export class HapiTemplateService extends TemplateService<HapiApiHandlerParameter
   constructor(
     readonly models: any,
     private readonly minimalSwaggerConfig: any,
+    private readonly hapi: {
+      boomify: Function,
+      isBoom: Function,
+    },
   ) {
     super(models);
   }
@@ -50,11 +54,11 @@ export class HapiTemplateService extends TemplateService<HapiApiHandlerParameter
       }
       return this.returnHandler({ h, headers, statusCode, data });
     } catch (error: any) {
-      if (isBoom(error)) {
+      if (this.hapi.isBoom(error)) {
         throw error;
       }
 
-      const boomErr = boomify(error instanceof Error ? error : new Error(error.message));
+      const boomErr = this.hapi.boomify(error instanceof Error ? error : new Error(error.message));
       boomErr.output.statusCode = error.status || 500;
       boomErr.output.payload = {
         name: error.name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6726,10 +6726,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6", typescript@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+"typescript@>=3 < 6", typescript@^5.2.2, typescript@^5.3.3:
+  version "5.4.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

#1573 

### Note

I do confirm that the actual build of `src/package/cli/dist/routeGeneration/templates/hapiTemplateService.js` no longer contains imports of `@hapi`.
