### PR TITLE
Await apiHandler to handle error in try/catch

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -103,7 +103,7 @@ export function RegisterRoutes(app: Router) {
                 const controller = new {{../name}}();
               {{/if}}
 
-              templateService.apiHandler({
+              {{#if ../../iocModule}}await {{/if}}templateService.apiHandler({
                 methodName: '{{name}}',
                 controller,
                 response,

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -79,7 +79,7 @@ export function RegisterRoutes(app: Router) {
             ...(fetchMiddlewares<RequestHandler>({{../name}})),
             ...(fetchMiddlewares<RequestHandler>({{../name}}.prototype.{{name}})),
 
-            {{#if ../../iocModule}}async {{/if}}function {{../name}}_{{name}}(request: ExRequest, response: ExResponse, next: any) {
+            async function {{../name}}_{{name}}(request: ExRequest, response: ExResponse, next: any) {
             const args: Record<string, TsoaRoute.ParameterSchema> = {
                 {{#each parameters}}
                     {{@key}}: {{{json this}}},
@@ -103,7 +103,7 @@ export function RegisterRoutes(app: Router) {
                 const controller = new {{../name}}();
               {{/if}}
 
-              {{#if ../../iocModule}}await {{/if}}templateService.apiHandler({
+              await templateService.apiHandler({
                 methodName: '{{name}}',
                 controller,
                 response,

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -33,8 +33,7 @@ export class ExpressTemplateService extends TemplateService<ExpressApiHandlerPar
     const { methodName, controller, response, validatedArgs, successStatus, next } = params;
 
     try {
-      const promise = this.buildPromise(methodName, controller, validatedArgs);
-      const data = await Promise.resolve(promise);
+      const data = await this.buildPromise(methodName, controller, validatedArgs);
       let statusCode = successStatus;
       let headers;
       if (this.isController(controller)) {

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -31,9 +31,9 @@ type ExpressReturnHandlerParameters = {
 export class ExpressTemplateService extends TemplateService<ExpressApiHandlerParameters, ExpressValidationArgsParameters, ExpressReturnHandlerParameters> {
   async apiHandler(params: ExpressApiHandlerParameters) {
     const { methodName, controller, response, validatedArgs, successStatus, next } = params;
-    const promise = this.buildPromise(methodName, controller, validatedArgs);
 
     try {
+      const promise = this.buildPromise(methodName, controller, validatedArgs);
       const data = await Promise.resolve(promise);
       let statusCode = successStatus;
       let headers;

--- a/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
@@ -47,8 +47,7 @@ export class HapiTemplateService extends TemplateService<HapiApiHandlerParameter
     const { methodName, controller, h, validatedArgs, successStatus } = params;
 
     try {
-      const promise = this.buildPromise(methodName, controller, validatedArgs);
-      const data = await Promise.resolve(promise);
+      const data = await this.buildPromise(methodName, controller, validatedArgs);
       let statusCode = successStatus;
       let headers;
 

--- a/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
@@ -45,9 +45,9 @@ export class HapiTemplateService extends TemplateService<HapiApiHandlerParameter
 
   async apiHandler(params: HapiApiHandlerParameters) {
     const { methodName, controller, h, validatedArgs, successStatus } = params;
-    const promise = this.buildPromise(methodName, controller, validatedArgs);
 
     try {
+      const promise = this.buildPromise(methodName, controller, validatedArgs);
       const data = await Promise.resolve(promise);
       let statusCode = successStatus;
       let headers;

--- a/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
@@ -33,9 +33,9 @@ type KoaReturnHandlerParameters = {
 export class KoaTemplateService extends TemplateService<KoaApiHandlerParameters, KoaValidationArgsParameters, KoaReturnHandlerParameters> {
   async apiHandler(params: KoaApiHandlerParameters) {
     const { methodName, controller, context, validatedArgs, successStatus } = params;
-    const promise = this.buildPromise(methodName, controller, validatedArgs);
 
     try {
+      const promise = this.buildPromise(methodName, controller, validatedArgs);
       const data = await Promise.resolve(promise);
       let statusCode = successStatus;
       let headers;

--- a/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
@@ -35,8 +35,7 @@ export class KoaTemplateService extends TemplateService<KoaApiHandlerParameters,
     const { methodName, controller, context, validatedArgs, successStatus } = params;
 
     try {
-      const promise = this.buildPromise(methodName, controller, validatedArgs);
-      const data = await Promise.resolve(promise);
+      const data = await this.buildPromise(methodName, controller, validatedArgs);
       let statusCode = successStatus;
       let headers;
 

--- a/tests/fixtures/inversify-cpg/managedController.ts
+++ b/tests/fixtures/inversify-cpg/managedController.ts
@@ -14,4 +14,9 @@ export class ManagedController {
   public async getModel(): Promise<TestModel> {
     return this.managedService.getModel();
   }
+
+  @Get('ThrowsError')
+  public getThrowsError(): void {
+    throw new Error('error thrown');
+  }
 }

--- a/tests/integration/inversify-glob.spec.ts
+++ b/tests/integration/inversify-glob.spec.ts
@@ -22,6 +22,16 @@ describe('Inversify Express Server with ControllerPathGlob', () => {
     });
   });
 
+  it('can handle error', async () => {
+    return verifyGetRequest(
+      basePath + '/ManagedTest/ThrowsError?tsoa=abc123456',
+      (_err, res) => {
+        expect(res.text).to.equal('error thrown');
+      },
+      500,
+    );
+  });
+
   function verifyGetRequest(path: string, verifyResponse: (err: any, res: request.Response) => any, expectedStatus?: number) {
     return verifyRequest(verifyResponse, request => request.get(path), expectedStatus);
   }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1598

**Test plan**

Checks that a controller method without `async` keyword throwing an error is caught.

The real problem is if method is not a promise (`async` keyword), and error throw immediately when building promise, server is no more responding, and we get a time out (actually 5sec in tests).

The problem could resolve in two ways : 
- put the `buildPromise` int the try/catch  https://github.com/lukeautry/tsoa/blob/efdb468a5cedcb9bef345f1eed776e8fc621b443/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts#L41
- wait for `apiHandler` to be resolved on generated template https://github.com/lukeautry/tsoa/blob/efdb468a5cedcb9bef345f1eed776e8fc621b443/packages/cli/src/routeGeneration/templates/express.hbs#L106
I have chosen to apply both, as I think code will be more robust.
