### PR TITLE
Refactor(resolver): clear logics

### DIFF
--- a/packages/cli/src/metadataGeneration/transformer/dateTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/dateTransformer.ts
@@ -1,11 +1,11 @@
-import * as ts from 'typescript';
+import type { Node } from 'typescript';
 import { Tsoa } from '@tsoa/runtime';
 
 import { Transformer } from './transformer';
 import { getJSDocTagNames } from '../../utils/jsDocUtils';
 
 export class DateTransformer extends Transformer {
-  public transform(parentNode?: ts.Node): Tsoa.DateType | Tsoa.DateTimeType {
+  public transform(parentNode?: Node): Tsoa.DateType | Tsoa.DateTimeType {
     if (!parentNode) {
       return { dataType: 'datetime' };
     }

--- a/packages/cli/src/metadataGeneration/transformer/dateTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/dateTransformer.ts
@@ -1,0 +1,28 @@
+import * as ts from 'typescript';
+import { Tsoa } from '@tsoa/runtime';
+
+import { Transformer } from './transformer';
+import { getJSDocTagNames } from '../../utils/jsDocUtils';
+
+export class DateTransformer extends Transformer {
+  public transform(parentNode?: ts.Node): Tsoa.DateType | Tsoa.DateTimeType {
+    if (!parentNode) {
+      return { dataType: 'datetime' };
+    }
+    const tags = getJSDocTagNames(parentNode).filter(name => {
+      return ['isDate', 'isDateTime'].some(m => m === name);
+    });
+
+    if (tags.length === 0) {
+      return { dataType: 'datetime' };
+    }
+    switch (tags[0]) {
+      case 'isDate':
+        return { dataType: 'date' };
+      case 'isDateTime':
+        return { dataType: 'datetime' };
+      default:
+        return { dataType: 'datetime' };
+    }
+  }
+}

--- a/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
@@ -44,8 +44,11 @@ export class EnumTransformer extends Transformer {
   }
 
   private transformDeclaration(declaration: ts.EnumDeclaration, enumName: string): Tsoa.RefEnumType {
-    const enums = declaration.members.map(e => this.resolver.current.typeChecker.getConstantValue(e)).filter(this.isNotUndefined);
-    const enumVarnames = declaration.members.map(e => e.name.getText()).filter(this.isNotUndefined);
+    const isNotUndefined = <T>(item: T): item is Exclude<T, undefined> => {
+      return item === undefined ? false : true;
+    }
+    const enums = declaration.members.map(e => this.resolver.current.typeChecker.getConstantValue(e)).filter(isNotUndefined);
+    const enumVarnames = declaration.members.map(e => e.name.getText()).filter(isNotUndefined);
 
     return {
       dataType: 'refEnum',
@@ -65,9 +68,5 @@ export class EnumTransformer extends Transformer {
       enumVarnames: [declaration.name.getText()],
       deprecated: isExistJSDocTag(declaration, tag => tag.tagName.text === 'deprecated'),
     }
-  }
-
-  private isNotUndefined<T>(item: T): item is Exclude<T, undefined> {
-    return item === undefined ? false : true;
   }
 }

--- a/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
@@ -1,0 +1,73 @@
+import * as ts from 'typescript';
+import { Tsoa } from '@tsoa/runtime';
+
+import { Transformer } from './transformer';
+import { isExistJSDocTag } from '../../utils/jsDocUtils';
+
+export class EnumTransformer extends Transformer {
+  public static mergeMany(many: Tsoa.RefEnumType[]): Tsoa.RefEnumType {
+    let merged = this.merge(many[0], many[1]);
+    for (let i = 2; i < many.length; ++i) {
+      merged = this.merge(merged, many[i]);
+    }
+    return merged;
+  }
+
+  public static merge(first: Tsoa.RefEnumType, second: Tsoa.RefEnumType): Tsoa.RefEnumType {
+    const description = first.description ? (second.description ? `${first.description}\n${second.description}` : first.description) : second.description;
+
+    const deprecated = first.deprecated || second.deprecated;
+
+    const enums = first.enums ? (second.enums ? [...first.enums, ...second.enums] : first.enums) : second.enums;
+
+    const enumVarnames = first.enumVarnames ? (second.enumVarnames ? [...first.enumVarnames, ...second.enumVarnames] : first.enumVarnames) : second.enumVarnames;
+
+    return {
+      dataType: 'refEnum',
+      description,
+      enums,
+      enumVarnames,
+      refName: first.refName,
+      deprecated,
+    };
+  }
+
+  public static transformable(declaration: ts.Node): declaration is ts.EnumDeclaration | ts.EnumMember {
+    return ts.isEnumDeclaration(declaration) || ts.isEnumMember(declaration);
+  }
+
+  public transform(declaration: ts.EnumDeclaration | ts.EnumMember, enumName: string): Tsoa.RefEnumType {
+    if (ts.isEnumDeclaration(declaration)) {
+      return this.transformDeclaration(declaration, enumName);
+    }
+    return this.transformMember(declaration, enumName);
+  }
+
+  private transformDeclaration(declaration: ts.EnumDeclaration, enumName: string): Tsoa.RefEnumType {
+    const enums = declaration.members.map(e => this.resolver.current.typeChecker.getConstantValue(e)).filter(this.isNotUndefined);
+    const enumVarnames = declaration.members.map(e => e.name.getText()).filter(this.isNotUndefined);
+
+    return {
+      dataType: 'refEnum',
+      description: this.resolver.getNodeDescription(declaration),
+      enums,
+      enumVarnames,
+      refName: enumName,
+      deprecated: isExistJSDocTag(declaration, tag => tag.tagName.text === 'deprecated'),
+    };
+  }
+
+  private transformMember(declaration: ts.EnumMember, enumName: string): Tsoa.RefEnumType {
+    return {
+      dataType: 'refEnum',
+      refName: enumName,
+      enums: [this.resolver.current.typeChecker.getConstantValue(declaration)!],
+      enumVarnames: [declaration.name.getText()],
+      deprecated: isExistJSDocTag(declaration, tag => tag.tagName.text === 'deprecated'),
+    }
+  }
+
+  private isNotUndefined<T>(item: T): item is Exclude<T, undefined> {
+    return item === undefined ? false : true;
+  }
+}

--- a/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
@@ -1,4 +1,5 @@
-import * as ts from 'typescript';
+import type { Node, EnumDeclaration, EnumMember } from 'typescript';
+import { isEnumDeclaration, isEnumMember } from 'typescript';
 import { Tsoa } from '@tsoa/runtime';
 
 import { Transformer } from './transformer';
@@ -32,18 +33,18 @@ export class EnumTransformer extends Transformer {
     };
   }
 
-  public static transformable(declaration: ts.Node): declaration is ts.EnumDeclaration | ts.EnumMember {
-    return ts.isEnumDeclaration(declaration) || ts.isEnumMember(declaration);
+  public static transformable(declaration: Node): declaration is EnumDeclaration | EnumMember {
+    return isEnumDeclaration(declaration) || isEnumMember(declaration);
   }
 
-  public transform(declaration: ts.EnumDeclaration | ts.EnumMember, enumName: string): Tsoa.RefEnumType {
-    if (ts.isEnumDeclaration(declaration)) {
+  public transform(declaration: EnumDeclaration | EnumMember, enumName: string): Tsoa.RefEnumType {
+    if (isEnumDeclaration(declaration)) {
       return this.transformDeclaration(declaration, enumName);
     }
     return this.transformMember(declaration, enumName);
   }
 
-  private transformDeclaration(declaration: ts.EnumDeclaration, enumName: string): Tsoa.RefEnumType {
+  private transformDeclaration(declaration: EnumDeclaration, enumName: string): Tsoa.RefEnumType {
     const isNotUndefined = <T>(item: T): item is Exclude<T, undefined> => {
       return item === undefined ? false : true;
     }
@@ -60,7 +61,7 @@ export class EnumTransformer extends Transformer {
     };
   }
 
-  private transformMember(declaration: ts.EnumMember, enumName: string): Tsoa.RefEnumType {
+  private transformMember(declaration: EnumMember, enumName: string): Tsoa.RefEnumType {
     return {
       dataType: 'refEnum',
       refName: enumName,

--- a/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
@@ -1,28 +1,29 @@
-import * as ts from 'typescript';
+import type { TypeNode, Node } from 'typescript';
+import { SyntaxKind } from 'typescript';
 import { Tsoa, assertNever } from '@tsoa/runtime';
 
 import { Transformer } from './transformer';
 import { getJSDocTagNames } from '../../utils/jsDocUtils';
 
 export class PrimitiveTransformer extends Transformer {
-  public static resolveKindToPrimitive(syntaxKind: ts.SyntaxKind): ResolvesToPrimitive {
+  public static resolveKindToPrimitive(syntaxKind: SyntaxKind): ResolvesToPrimitive {
     switch (syntaxKind) {
-      case ts.SyntaxKind.NumberKeyword:
+      case SyntaxKind.NumberKeyword:
         return 'number';
-      case ts.SyntaxKind.StringKeyword:
+      case SyntaxKind.StringKeyword:
         return 'string';
-      case ts.SyntaxKind.BooleanKeyword:
+      case SyntaxKind.BooleanKeyword:
         return 'boolean';
-      case ts.SyntaxKind.VoidKeyword:
+      case SyntaxKind.VoidKeyword:
         return 'void';
-      case ts.SyntaxKind.UndefinedKeyword:
+      case SyntaxKind.UndefinedKeyword:
         return 'undefined';
       default:
         return undefined;
     }
   };
 
-  public transform(typeNode: ts.TypeNode, parentNode?: ts.Node): Tsoa.PrimitiveType | undefined {
+  public transform(typeNode: TypeNode, parentNode?: Node): Tsoa.PrimitiveType | undefined {
     const resolvedType = PrimitiveTransformer.resolveKindToPrimitive(typeNode.kind);
     if (!resolvedType) {
       return;
@@ -45,7 +46,7 @@ export class PrimitiveTransformer extends Transformer {
 
   private transformNumber(
     defaultNumberType: NonNullable<"double" | "float" | "integer" | "long" | undefined>,
-    parentNode?: ts.Node,
+    parentNode?: Node,
   ): Tsoa.PrimitiveType {
     if (!parentNode) {
       return { dataType: defaultNumberType };

--- a/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
@@ -1,0 +1,83 @@
+import * as ts from 'typescript';
+import { Tsoa, assertNever } from '@tsoa/runtime';
+
+import { Transformer } from './transformer';
+import { getJSDocTagNames } from '../../utils/jsDocUtils';
+
+export class PrimitiveTransformer extends Transformer {
+  public static attemptToResolveKindToPrimitive(syntaxKind: ts.SyntaxKind): ResolvesToPrimitive | DoesNotResolveToPrimitive {
+    switch (syntaxKind) {
+      case ts.SyntaxKind.NumberKeyword:
+        return { foundMatch: true, resolvedType: 'number' };
+      case ts.SyntaxKind.StringKeyword:
+        return { foundMatch: true, resolvedType: 'string' };
+      case ts.SyntaxKind.BooleanKeyword:
+        return { foundMatch: true, resolvedType: 'boolean' };
+      case ts.SyntaxKind.VoidKeyword:
+        return { foundMatch: true, resolvedType: 'void' };
+      case ts.SyntaxKind.UndefinedKeyword:
+        return { foundMatch: true, resolvedType: 'undefined' };
+      default:
+        return { foundMatch: false };
+    }
+  };
+
+  public transform(typeNode: ts.TypeNode, parentNode?: ts.Node): Tsoa.PrimitiveType | undefined {
+    const resolution = PrimitiveTransformer.attemptToResolveKindToPrimitive(typeNode.kind);
+    if (!resolution.foundMatch) {
+      return;
+    }
+
+    const defaultNumberType = this.resolver.current.defaultNumberType;
+
+    switch (resolution.resolvedType) {
+      case 'number':
+        return this.transformNumber(defaultNumberType, parentNode);
+      case 'string':
+      case 'boolean':
+      case 'void':
+      case 'undefined':
+        return { dataType: resolution.resolvedType };
+      default:
+        return assertNever(resolution.resolvedType);
+    }
+  }
+
+  private transformNumber(
+    defaultNumberType: NonNullable<"double" | "float" | "integer" | "long" | undefined>,
+    parentNode?: ts.Node,
+  ): Tsoa.PrimitiveType {
+    if (!parentNode) {
+      return { dataType: defaultNumberType };
+    }
+
+    const tags = getJSDocTagNames(parentNode).filter(name => {
+      return ['isInt', 'isLong', 'isFloat', 'isDouble'].some(m => m === name);
+    });
+    if (tags.length === 0) {
+      return { dataType: defaultNumberType };
+    }
+
+    switch (tags[0]) {
+      case 'isInt':
+        return { dataType: 'integer' };
+      case 'isLong':
+        return { dataType: 'long' };
+      case 'isFloat':
+        return { dataType: 'float' };
+      case 'isDouble':
+        return { dataType: 'double' };
+      default:
+        return { dataType: defaultNumberType };
+    }
+  }
+}
+
+interface ResolvesToPrimitive {
+  foundMatch: true;
+  resolvedType: 'number' | 'string' | 'boolean' | 'void' | 'undefined';
+}
+
+interface DoesNotResolveToPrimitive {
+  foundMatch: false;
+}

--- a/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/primitiveTransformer.ts
@@ -5,41 +5,41 @@ import { Transformer } from './transformer';
 import { getJSDocTagNames } from '../../utils/jsDocUtils';
 
 export class PrimitiveTransformer extends Transformer {
-  public static attemptToResolveKindToPrimitive(syntaxKind: ts.SyntaxKind): ResolvesToPrimitive | DoesNotResolveToPrimitive {
+  public static resolveKindToPrimitive(syntaxKind: ts.SyntaxKind): ResolvesToPrimitive {
     switch (syntaxKind) {
       case ts.SyntaxKind.NumberKeyword:
-        return { foundMatch: true, resolvedType: 'number' };
+        return 'number';
       case ts.SyntaxKind.StringKeyword:
-        return { foundMatch: true, resolvedType: 'string' };
+        return 'string';
       case ts.SyntaxKind.BooleanKeyword:
-        return { foundMatch: true, resolvedType: 'boolean' };
+        return 'boolean';
       case ts.SyntaxKind.VoidKeyword:
-        return { foundMatch: true, resolvedType: 'void' };
+        return 'void';
       case ts.SyntaxKind.UndefinedKeyword:
-        return { foundMatch: true, resolvedType: 'undefined' };
+        return 'undefined';
       default:
-        return { foundMatch: false };
+        return undefined;
     }
   };
 
   public transform(typeNode: ts.TypeNode, parentNode?: ts.Node): Tsoa.PrimitiveType | undefined {
-    const resolution = PrimitiveTransformer.attemptToResolveKindToPrimitive(typeNode.kind);
-    if (!resolution.foundMatch) {
+    const resolvedType = PrimitiveTransformer.resolveKindToPrimitive(typeNode.kind);
+    if (!resolvedType) {
       return;
     }
 
     const defaultNumberType = this.resolver.current.defaultNumberType;
 
-    switch (resolution.resolvedType) {
+    switch (resolvedType) {
       case 'number':
         return this.transformNumber(defaultNumberType, parentNode);
       case 'string':
       case 'boolean':
       case 'void':
       case 'undefined':
-        return { dataType: resolution.resolvedType };
+        return { dataType: resolvedType };
       default:
-        return assertNever(resolution.resolvedType);
+        return assertNever(resolvedType);
     }
   }
 
@@ -73,11 +73,4 @@ export class PrimitiveTransformer extends Transformer {
   }
 }
 
-interface ResolvesToPrimitive {
-  foundMatch: true;
-  resolvedType: 'number' | 'string' | 'boolean' | 'void' | 'undefined';
-}
-
-interface DoesNotResolveToPrimitive {
-  foundMatch: false;
-}
+type ResolvesToPrimitive = 'number' | 'string' | 'boolean' | 'void' | 'undefined' | undefined;

--- a/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
@@ -8,6 +8,7 @@ import { getInitializerValue } from '../initializer-value';
 import { getPropertyValidators } from '../../utils/validatorUtils';
 import { isExistJSDocTag } from '../../utils/jsDocUtils';
 import { isDecorator } from '../../utils/decoratorUtils';
+import { throwUnless } from '../../utils/flowUtils';
 
 type OverrideToken = ts.Token<ts.SyntaxKind.QuestionToken> | ts.Token<ts.SyntaxKind.PlusToken> | ts.Token<ts.SyntaxKind.MinusToken> | undefined;
 
@@ -47,9 +48,10 @@ export class PropertyTransformer extends Transformer {
   private propertyFromSignature(propertySignature: ts.PropertySignature, overrideToken?: OverrideToken): Tsoa.Property {
     const identifier = propertySignature.name as ts.Identifier;
 
-    if (!propertySignature.type) {
-      throw new GenerateMetadataError(`No valid type found for property declaration.`);
-    }
+    throwUnless(
+      propertySignature.type,
+      new GenerateMetadataError(`No valid type found for property declaration.`),
+    );
 
     let required = !propertySignature.questionToken;
     if (overrideToken && overrideToken.kind === ts.SyntaxKind.MinusToken) {

--- a/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
@@ -1,0 +1,117 @@
+import * as ts from 'typescript';
+import { Tsoa } from '@tsoa/runtime';
+
+import { Transformer } from './transformer';
+import { GenerateMetadataError } from '../exceptions';
+import { TypeResolver } from '../typeResolver';
+import { getInitializerValue } from '../initializer-value';
+import { getPropertyValidators } from '../../utils/validatorUtils';
+import { isExistJSDocTag } from '../../utils/jsDocUtils';
+import { isDecorator } from '../../utils/decoratorUtils';
+
+type OverrideToken = ts.Token<ts.SyntaxKind.QuestionToken> | ts.Token<ts.SyntaxKind.PlusToken> | ts.Token<ts.SyntaxKind.MinusToken> | undefined;
+
+export class PropertyTransformer extends Transformer {
+  public transform(node: ts.InterfaceDeclaration | ts.ClassDeclaration, overrideToken?: OverrideToken): Tsoa.Property[] {
+    const isIgnored = (e: ts.TypeElement | ts.ClassElement) => {
+      let ignore = isExistJSDocTag(e, tag => tag.tagName.text === 'ignore');
+      ignore = ignore || (e.flags & ts.NodeFlags.ThisNodeHasError) > 0;
+      return ignore;
+    };
+
+    // Interface model
+    if (ts.isInterfaceDeclaration(node)) {
+      return node.members
+        .filter((member): member is ts.PropertySignature => !isIgnored(member) && ts.isPropertySignature(member))
+        .map((member: ts.PropertySignature) => this.propertyFromSignature(member, overrideToken));
+    }
+
+    const properties: Array<ts.PropertyDeclaration | ts.ParameterDeclaration> = [];
+    for (const member of node.members) {
+      if (!isIgnored(member) && ts.isPropertyDeclaration(member) && !this.hasStaticModifier(member) && this.hasPublicModifier(member)) {
+        properties.push(member);
+      }
+    }
+
+    const classConstructor = node.members.find(member => ts.isConstructorDeclaration(member)) as ts.ConstructorDeclaration;
+
+    if (classConstructor && classConstructor.parameters) {
+      const constructorProperties = classConstructor.parameters.filter(parameter => this.isAccessibleParameter(parameter));
+
+      properties.push(...constructorProperties);
+    }
+
+    return properties.map(property => this.propertyFromDeclaration(property, overrideToken));
+  }
+
+  private propertyFromSignature(propertySignature: ts.PropertySignature, overrideToken?: OverrideToken): Tsoa.Property {
+    const identifier = propertySignature.name as ts.Identifier;
+
+    if (!propertySignature.type) {
+      throw new GenerateMetadataError(`No valid type found for property declaration.`);
+    }
+
+    let required = !propertySignature.questionToken;
+    if (overrideToken && overrideToken.kind === ts.SyntaxKind.MinusToken) {
+      required = true;
+    } else if (overrideToken && overrideToken.kind === ts.SyntaxKind.QuestionToken) {
+      required = false;
+    }
+
+    const def = TypeResolver.getDefault(propertySignature);
+
+    const property: Tsoa.Property = {
+      default: def,
+      description: this.resolver.getNodeDescription(propertySignature),
+      example: this.resolver.getNodeExample(propertySignature),
+      format: this.resolver.getNodeFormat(propertySignature),
+      name: identifier.text,
+      required,
+      type: new TypeResolver(propertySignature.type, this.resolver.current, propertySignature.type.parent, this.resolver.context).resolve(),
+      validators: getPropertyValidators(propertySignature) || {},
+      deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
+      extensions: this.resolver.getNodeExtension(propertySignature),
+    };
+    return property;
+  }
+
+  private propertyFromDeclaration(propertyDeclaration: ts.PropertyDeclaration | ts.ParameterDeclaration, overrideToken?: OverrideToken): Tsoa.Property {
+    const identifier = propertyDeclaration.name as ts.Identifier;
+    let typeNode = propertyDeclaration.type;
+
+    const tsType = this.resolver.current.typeChecker.getTypeAtLocation(propertyDeclaration);
+
+    if (!typeNode) {
+      // Type is from initializer
+      typeNode = this.resolver.current.typeChecker.typeToTypeNode(tsType, undefined, ts.NodeBuilderFlags.NoTruncation)!;
+    }
+
+    const type = new TypeResolver(typeNode, this.resolver.current, propertyDeclaration, this.resolver.context, tsType).resolve();
+
+    let required = !propertyDeclaration.questionToken && !propertyDeclaration.initializer;
+    if (overrideToken && overrideToken.kind === ts.SyntaxKind.MinusToken) {
+      required = true;
+    } else if (overrideToken && overrideToken.kind === ts.SyntaxKind.QuestionToken) {
+      required = false;
+    }
+    let def = getInitializerValue(propertyDeclaration.initializer, this.resolver.current.typeChecker);
+    if (def === undefined) {
+      def = TypeResolver.getDefault(propertyDeclaration);
+    }
+
+    const property: Tsoa.Property = {
+      default: def,
+      description: this.resolver.getNodeDescription(propertyDeclaration),
+      example: this.resolver.getNodeExample(propertyDeclaration),
+      format: this.resolver.getNodeFormat(propertyDeclaration),
+      name: identifier.text,
+      required,
+      type,
+      validators: getPropertyValidators(propertyDeclaration) || {},
+      // class properties and constructor parameters may be deprecated either via jsdoc annotation or decorator
+      deprecated: isExistJSDocTag(propertyDeclaration, tag => tag.tagName.text === 'deprecated') || isDecorator(propertyDeclaration, identifier => identifier.text === 'Deprecated'),
+      extensions: this.resolver.getNodeExtension(propertyDeclaration),
+    };
+    return property;
+  }
+}

--- a/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import type { TypeAliasDeclaration, Type } from 'typescript';
 import { Tsoa } from '@tsoa/runtime';
 
 import { Transformer } from './transformer';
@@ -66,7 +66,7 @@ export class ReferenceTransformer extends Transformer {
     return result;
   }
 
-  public transform(declaration: ts.TypeAliasDeclaration, refTypeName: string, referencer?: ts.Type): Tsoa.ReferenceType {
+  public transform(declaration: TypeAliasDeclaration, refTypeName: string, referencer?: Type): Tsoa.ReferenceType {
     const example = this.resolver.getNodeExample(declaration);
 
     const referenceType: Tsoa.ReferenceType = {

--- a/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
@@ -1,0 +1,84 @@
+import * as ts from 'typescript';
+import { Tsoa } from '@tsoa/runtime';
+
+import { Transformer } from './transformer';
+import { EnumTransformer } from './enumTransformer';
+import { TypeResolver } from '../typeResolver';
+import { GenerateMetadataError } from '../exceptions';
+import { getPropertyValidators } from '../../utils/validatorUtils';
+
+export class ReferenceTransformer extends Transformer {
+  public static merge(referenceTypes: Tsoa.ReferenceType[]): Tsoa.ReferenceType {
+    if (referenceTypes.length === 1) {
+      return referenceTypes[0];
+    }
+
+    if (referenceTypes.every(refType => refType.dataType === 'refEnum')) {
+      return EnumTransformer.mergeMany(referenceTypes as Tsoa.RefEnumType[]);
+    }
+
+    if (referenceTypes.every(refType => refType.dataType === 'refObject')) {
+      return this.mergeManyRefObj(referenceTypes as Tsoa.RefObjectType[]);
+    }
+
+    throw new GenerateMetadataError(`These resolved type merge rules are not defined: ${JSON.stringify(referenceTypes)}`);
+  }
+
+  public static mergeManyRefObj(many: Tsoa.RefObjectType[]): Tsoa.RefObjectType {
+    let merged = this.mergeRefObj(many[0], many[1]);
+    for (let i = 2; i < many.length; ++i) {
+      merged = this.mergeRefObj(merged, many[i]);
+    }
+    return merged;
+  }
+
+  public static mergeRefObj(first: Tsoa.RefObjectType, second: Tsoa.RefObjectType): Tsoa.RefObjectType {
+    const description = first.description ? (second.description ? `${first.description}\n${second.description}` : first.description) : second.description;
+
+    const deprecated = first.deprecated || second.deprecated;
+    const example = first.example || second.example;
+
+    const properties = [...first.properties, ...second.properties.filter(prop => first.properties.every(firstProp => firstProp.name !== prop.name))];
+
+    const mergeAdditionalTypes = (first: Tsoa.Type, second: Tsoa.Type): Tsoa.Type => {
+      return {
+        dataType: 'union',
+        types: [first, second],
+      };
+    };
+
+    const additionalProperties = first.additionalProperties
+      ? second.additionalProperties
+        ? mergeAdditionalTypes(first.additionalProperties, second.additionalProperties)
+        : first.additionalProperties
+      : second.additionalProperties;
+
+    const result: Tsoa.RefObjectType = {
+      dataType: 'refObject',
+      description,
+      properties,
+      additionalProperties,
+      refName: first.refName,
+      deprecated,
+      example,
+    };
+
+    return result;
+  }
+
+  public transform(declaration: ts.TypeAliasDeclaration, refTypeName: string, referencer?: ts.Type): Tsoa.ReferenceType {
+    const example = this.resolver.getNodeExample(declaration);
+
+    const referenceType: Tsoa.ReferenceType = {
+      dataType: 'refAlias',
+      default: TypeResolver.getDefault(declaration),
+      description: this.resolver.getNodeDescription(declaration),
+      refName: refTypeName,
+      format: this.resolver.getNodeFormat(declaration),
+      type: new TypeResolver(declaration.type, this.resolver.current, declaration, this.resolver.context, this.resolver.referencer || referencer).resolve(),
+      validators: getPropertyValidators(declaration) || {},
+      ...(example && { example }),
+    };
+    return referenceType;
+  }
+}

--- a/packages/cli/src/metadataGeneration/transformer/transformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/transformer.ts
@@ -1,4 +1,5 @@
-import * as ts from 'typescript';
+import type { HasModifiers } from 'typescript';
+import { SyntaxKind, getModifiers } from 'typescript';
 
 import { TypeResolver } from '../typeResolver';
 
@@ -10,40 +11,40 @@ export abstract class Transformer {
     protected readonly resolver: TypeResolver,
   ) {}
 
-  protected hasPublicModifier(node: ts.HasModifiers): boolean {
+  protected hasPublicModifier(node: HasModifiers): boolean {
     return (
       !node.modifiers ||
       node.modifiers.every(modifier => {
-        return modifier.kind !== ts.SyntaxKind.ProtectedKeyword && modifier.kind !== ts.SyntaxKind.PrivateKeyword;
+        return modifier.kind !== SyntaxKind.ProtectedKeyword && modifier.kind !== SyntaxKind.PrivateKeyword;
       })
     );
   }
 
-  protected hasStaticModifier(node: ts.HasModifiers): boolean | undefined {
+  protected hasStaticModifier(node: HasModifiers): boolean | undefined {
     return (
       node.modifiers &&
       node.modifiers.some(modifier => {
-        return modifier.kind === ts.SyntaxKind.StaticKeyword;
+        return modifier.kind === SyntaxKind.StaticKeyword;
       })
     );
   }
 
-  protected isAccessibleParameter(node: ts.HasModifiers): boolean {
-    const modifiers = ts.getModifiers(node);
+  protected isAccessibleParameter(node: HasModifiers): boolean {
+    const modifiers = getModifiers(node);
 
     if (modifiers == null || modifiers.length === 0) {
       return false;
     }
 
     // public || public readonly
-    if (modifiers.some(modifier => modifier.kind === ts.SyntaxKind.PublicKeyword)) {
+    if (modifiers.some(modifier => modifier.kind === SyntaxKind.PublicKeyword)) {
       return true;
     }
 
     // readonly, not private readonly, not public readonly
-    const isReadonly = modifiers.some(modifier => modifier.kind === ts.SyntaxKind.ReadonlyKeyword);
+    const isReadonly = modifiers.some(modifier => modifier.kind === SyntaxKind.ReadonlyKeyword);
     const isProtectedOrPrivate = modifiers.some(modifier => {
-      return modifier.kind === ts.SyntaxKind.ProtectedKeyword || modifier.kind === ts.SyntaxKind.PrivateKeyword;
+      return modifier.kind === SyntaxKind.ProtectedKeyword || modifier.kind === SyntaxKind.PrivateKeyword;
     });
     return isReadonly && !isProtectedOrPrivate;
   }

--- a/packages/cli/src/metadataGeneration/transformer/transformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/transformer.ts
@@ -1,5 +1,4 @@
-import type { HasModifiers } from 'typescript';
-import { SyntaxKind, getModifiers } from 'typescript';
+import { SyntaxKind, getModifiers, type HasModifiers } from 'typescript';
 
 import { TypeResolver } from '../typeResolver';
 

--- a/packages/cli/src/metadataGeneration/transformer/transformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/transformer.ts
@@ -1,0 +1,50 @@
+import * as ts from 'typescript';
+
+import { TypeResolver } from '../typeResolver';
+
+/**
+ * Transformer responsible to transforming native ts node into tsoa type.
+ */
+export abstract class Transformer {
+  constructor(
+    protected readonly resolver: TypeResolver,
+  ) {}
+
+  protected hasPublicModifier(node: ts.HasModifiers): boolean {
+    return (
+      !node.modifiers ||
+      node.modifiers.every(modifier => {
+        return modifier.kind !== ts.SyntaxKind.ProtectedKeyword && modifier.kind !== ts.SyntaxKind.PrivateKeyword;
+      })
+    );
+  }
+
+  protected hasStaticModifier(node: ts.HasModifiers): boolean | undefined {
+    return (
+      node.modifiers &&
+      node.modifiers.some(modifier => {
+        return modifier.kind === ts.SyntaxKind.StaticKeyword;
+      })
+    );
+  }
+
+  protected isAccessibleParameter(node: ts.HasModifiers): boolean {
+    const modifiers = ts.getModifiers(node);
+
+    if (modifiers == null || modifiers.length === 0) {
+      return false;
+    }
+
+    // public || public readonly
+    if (modifiers.some(modifier => modifier.kind === ts.SyntaxKind.PublicKeyword)) {
+      return true;
+    }
+
+    // readonly, not private readonly, not public readonly
+    const isReadonly = modifiers.some(modifier => modifier.kind === ts.SyntaxKind.ReadonlyKeyword);
+    const isProtectedOrPrivate = modifiers.some(modifier => {
+      return modifier.kind === ts.SyntaxKind.ProtectedKeyword || modifier.kind === ts.SyntaxKind.PrivateKeyword;
+    });
+    return isReadonly && !isProtectedOrPrivate;
+  }
+}

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -706,9 +706,9 @@ export class TypeResolver {
       }
       return `${literalValue}`;
     }
-    const resolved = PrimitiveTransformer.attemptToResolveKindToPrimitive(arg.kind);
-    if (resolved.foundMatch) {
-      return resolved.resolvedType;
+    const resolvedType = PrimitiveTransformer.resolveKindToPrimitive(arg.kind);
+    if (resolvedType) {
+      return resolvedType;
     }
     if (ts.isTypeReferenceNode(arg) || ts.isExpressionWithTypeArguments(arg)) {
       const [_, name] = this.calcTypeReferenceTypeName(arg);

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -402,59 +402,9 @@ export class TypeResolver {
       return new TypeResolver(this.typeNode.type, this.current, this.typeNode, this.context, this.referencer).resolve();
     }
 
-    // Indexed by keyword
-    if (ts.isIndexedAccessTypeNode(this.typeNode) && (this.typeNode.indexType.kind === ts.SyntaxKind.NumberKeyword || this.typeNode.indexType.kind === ts.SyntaxKind.StringKeyword)) {
-      const numberIndexType = this.typeNode.indexType.kind === ts.SyntaxKind.NumberKeyword;
-      const objectType = this.current.typeChecker.getTypeFromTypeNode(this.typeNode.objectType);
-      const type = numberIndexType ? objectType.getNumberIndexType() : objectType.getStringIndexType();
-      if (type === undefined) {
-        throw new GenerateMetadataError(`Could not determine ${numberIndexType ? 'number' : 'string'} index on ${this.current.typeChecker.typeToString(objectType)}`, this.typeNode);
-      }
-      return new TypeResolver(this.current.typeChecker.typeToTypeNode(type, this.typeNode.objectType, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context).resolve();
-    }
-
-    // Indexed by literal
-    if (
-      ts.isIndexedAccessTypeNode(this.typeNode) &&
-      ts.isLiteralTypeNode(this.typeNode.indexType) &&
-      (ts.isStringLiteral(this.typeNode.indexType.literal) || ts.isNumericLiteral(this.typeNode.indexType.literal))
-    ) {
-      const hasType = (node: ts.Node | undefined): node is ts.HasType => node !== undefined && Object.prototype.hasOwnProperty.call(node, 'type');
-      const symbol = this.current.typeChecker.getPropertyOfType(this.current.typeChecker.getTypeFromTypeNode(this.typeNode.objectType), this.typeNode.indexType.literal.text);
-      if (symbol === undefined) {
-        throw new GenerateMetadataError(
-          `Could not determine the keys on ${this.current.typeChecker.typeToString(this.current.typeChecker.getTypeFromTypeNode(this.typeNode.objectType))}`,
-          this.typeNode,
-        );
-      }
-      if (hasType(symbol.valueDeclaration) && symbol.valueDeclaration.type) {
-        return new TypeResolver(symbol.valueDeclaration.type, this.current, this.typeNode, this.context).resolve();
-      }
-      const declaration = this.current.typeChecker.getTypeOfSymbolAtLocation(symbol, this.typeNode.objectType);
-      try {
-        return new TypeResolver(this.current.typeChecker.typeToTypeNode(declaration, this.typeNode.objectType, ts.NodeBuilderFlags.NoTruncation)!, this.current, this.typeNode, this.context).resolve();
-      } catch {
-        throw new GenerateMetadataError(
-          `Could not determine the keys on ${this.current.typeChecker.typeToString(
-            this.current.typeChecker.getTypeFromTypeNode(this.current.typeChecker.typeToTypeNode(declaration, undefined, ts.NodeBuilderFlags.NoTruncation)!),
-          )}`,
-          this.typeNode,
-        );
-      }
-    }
-
-    // Indexed by keyof typeof value
-    if (ts.isIndexedAccessTypeNode(this.typeNode) && ts.isTypeOperatorNode(this.typeNode.indexType) && this.typeNode.indexType.operator === ts.SyntaxKind.KeyOfKeyword) {
-      const resolveParenthesis = (node: ts.TypeNode) => (ts.isParenthesizedTypeNode(node) ? node.type : node);
-      const objectType = resolveParenthesis(this.typeNode.objectType);
-      const indexType = this.typeNode.indexType.type;
-      const isSameTypeQuery = ts.isTypeQueryNode(objectType) && ts.isTypeQueryNode(indexType) && objectType.exprName.getText() === indexType.exprName.getText();
-      const isSameTypeReference = ts.isTypeReferenceNode(objectType) && ts.isTypeReferenceNode(indexType) && objectType.typeName.getText() === indexType.typeName.getText();
-      if (isSameTypeQuery || isSameTypeReference) {
-        const type = this.getReferencer();
-        const node = this.current.typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias | ts.NodeBuilderFlags.NoTruncation)!;
-        return new TypeResolver(node, this.current, this.typeNode, this.context, this.referencer).resolve();
-      }
+    // Indexed type
+    if (ts.isIndexedAccessTypeNode(this.typeNode)) {
+      return this.resolveIndexedAccessTypeNode(this.typeNode, this.current.typeChecker, this.current, this.context);
     }
 
     if (ts.isTemplateLiteralTypeNode(this.typeNode)) {
@@ -519,6 +469,61 @@ export class TypeResolver {
 
     const referenceType = this.getReferenceType(typeReference);
     return referenceType;
+  }
+
+  private resolveIndexedAccessTypeNode(typeNode: ts.IndexedAccessTypeNode, typeChecker: ts.TypeChecker, current: MetadataGenerator, context: Context): Tsoa.Type {
+    const indexType = typeNode.indexType;
+
+    if ([ts.SyntaxKind.NumberKeyword, ts.SyntaxKind.StringKeyword].includes(indexType.kind)) {
+      // Indexed by keyword
+      const isNumberIndexType = indexType.kind === ts.SyntaxKind.NumberKeyword;
+      const objectType = typeChecker.getTypeFromTypeNode(typeNode.objectType);
+      const type = isNumberIndexType ? objectType.getNumberIndexType() : objectType.getStringIndexType();
+      if (type === undefined) {
+        throw new GenerateMetadataError(`Could not determine ${isNumberIndexType ? 'number' : 'string'} index on ${typeChecker.typeToString(objectType)}`, typeNode);
+      }
+      return new TypeResolver(typeChecker.typeToTypeNode(type, typeNode.objectType, ts.NodeBuilderFlags.NoTruncation)!, current, typeNode, context).resolve();
+    } else if (
+      ts.isLiteralTypeNode(indexType)
+      && (ts.isStringLiteral(indexType.literal) || ts.isNumericLiteral(indexType.literal))
+    ) {
+      // Indexed by literal
+      const hasType = (node: ts.Node | undefined): node is ts.HasType => node !== undefined && Object.prototype.hasOwnProperty.call(node, 'type');
+      const symbol = typeChecker.getPropertyOfType(typeChecker.getTypeFromTypeNode(typeNode.objectType), indexType.literal.text);
+      if (symbol === undefined) {
+        throw new GenerateMetadataError(
+          `Could not determine the keys on ${typeChecker.typeToString(typeChecker.getTypeFromTypeNode(typeNode.objectType))}`,
+          typeNode,
+        );
+      }
+      if (hasType(symbol.valueDeclaration) && symbol.valueDeclaration.type) {
+        return new TypeResolver(symbol.valueDeclaration.type, current, typeNode, context).resolve();
+      }
+      const declaration = typeChecker.getTypeOfSymbolAtLocation(symbol, typeNode.objectType);
+      try {
+        return new TypeResolver(typeChecker.typeToTypeNode(declaration, typeNode.objectType, ts.NodeBuilderFlags.NoTruncation)!, current, typeNode, context).resolve();
+      } catch {
+        throw new GenerateMetadataError(
+          `Could not determine the keys on ${typeChecker.typeToString(
+            typeChecker.getTypeFromTypeNode(typeChecker.typeToTypeNode(declaration, undefined, ts.NodeBuilderFlags.NoTruncation)!),
+          )}`,
+          typeNode,
+        );
+      }
+    } else if (ts.isTypeOperatorNode(indexType) && indexType.operator === ts.SyntaxKind.KeyOfKeyword) {
+      // Indexed by keyof typeof value
+      const resolveParenthesis = (node: ts.TypeNode) => (ts.isParenthesizedTypeNode(node) ? node.type : node);
+      const typeOfObjectType = resolveParenthesis(typeNode.objectType);
+      const typeOfIndexType = indexType.type;
+      const isSameTypeQuery = ts.isTypeQueryNode(typeOfObjectType) && ts.isTypeQueryNode(typeOfIndexType) && typeOfObjectType.exprName.getText() === typeOfIndexType.exprName.getText();
+      const isSameTypeReference = ts.isTypeReferenceNode(typeOfObjectType) && ts.isTypeReferenceNode(typeOfIndexType) && typeOfObjectType.typeName.getText() === typeOfIndexType.typeName.getText();
+      if (isSameTypeQuery || isSameTypeReference) {
+        const type = this.getReferencer();
+        const node = typeChecker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias | ts.NodeBuilderFlags.NoTruncation)!;
+        return new TypeResolver(node, current, typeNode, context, this.referencer).resolve();
+      }
+    }
+    throw new GenerateMetadataError(`Unknown type: ${ts.SyntaxKind[typeNode.kind]}`, typeNode);
   }
 
   private getLiteralValue(typeNode: ts.LiteralTypeNode): string | number | boolean | null {

--- a/packages/cli/src/utils/flowUtils.ts
+++ b/packages/cli/src/utils/flowUtils.ts
@@ -1,0 +1,3 @@
+export function throwUnless(condition: unknown, error: Error): asserts condition {
+  if (!condition) throw error;
+}


### PR DESCRIPTION
- Splitting logics of TypeResolver into Transformer class.
- Clean up some nested logics in TypeResolver.
- Rewrite the flow of throwing error with throwUnless instead of if branch.