### PR TITLE
Fix Multer error when @UploadedFiles() is used twice in a route

### DIFF
--- a/packages/cli/src/routeGeneration/routeGenerator.ts
+++ b/packages/cli/src/routeGeneration/routeGenerator.ts
@@ -97,8 +97,9 @@ export abstract class AbstractRouteGenerator<Config extends ExtendedRoutesConfig
 
             const normalisedFullPath = normalisePath(`${normalisedBasePath}${normalisedControllerPath}${normalisedMethodPath}`, '/', '', false);
 
-            const uploadFilesWithDifferentFieldParameter = method.parameters.filter(parameter => parameter.type.dataType === 'file');
-            const uploadFilesParameter = method.parameters.find(parameter => parameter.type.dataType === 'array' && parameter.type.elementType.dataType === 'file');
+            const uploadFilesWithDifferentFieldParameter = method.parameters.filter(
+              parameter => parameter.type.dataType === 'file' || (parameter.type.dataType === 'array' && parameter.type.elementType.dataType === 'file'),
+            );
             return {
               fullPath: normalisedFullPath,
               method: method.method.toLowerCase(),
@@ -108,9 +109,9 @@ export abstract class AbstractRouteGenerator<Config extends ExtendedRoutesConfig
               uploadFile: uploadFilesWithDifferentFieldParameter.length > 0,
               uploadFileName: uploadFilesWithDifferentFieldParameter.map(parameter => ({
                 name: parameter.name,
+                maxCount: parameter.type.dataType === 'file' ? 1 : undefined,
+                multiple: parameter.type.dataType === 'array' && parameter.type.elementType.dataType === 'file',
               })),
-              uploadFiles: !!uploadFilesParameter,
-              uploadFilesName: uploadFilesParameter?.name,
               security: method.security,
               successStatus: method.successStatus ? method.successStatus : 'undefined',
             };

--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -73,9 +73,6 @@ export function RegisterRoutes(app: Router) {
             {{#if uploadFile}}
             upload.fields({{json uploadFileName}}),
             {{/if}}
-            {{#if uploadFiles}}
-            upload.array('{{uploadFilesName}}'),
-            {{/if}}
             ...(fetchMiddlewares<RequestHandler>({{../name}})),
             ...(fetchMiddlewares<RequestHandler>({{../name}}.prototype.{{name}})),
 

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -71,14 +71,13 @@ export function RegisterRoutes(server: any) {
                     {{#if uploadFile}}
                       {{#each uploadFileName}}
                     {
+                      {{#if multiple}}
+                      method: fileUploadMiddleware('{{name}}', true)
+                      {{else}}
                       method: fileUploadMiddleware('{{name}}', false)
+                      {{/if}}
                     },
                       {{/each}}
-                    {{/if}}
-                    {{#if uploadFiles}}
-                    {
-                      method: fileUploadMiddleware('{{uploadFilesName}}', true)
-                    },
                     {{/if}}
                     ...(fetchMiddlewares<RouteOptionsPreAllOptions>({{../name}})),
                     ...(fetchMiddlewares<RouteOptionsPreAllOptions>({{../name}}.prototype.{{name}})),

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -73,9 +73,6 @@ export function RegisterRoutes(router: KoaRouter) {
             {{#if uploadFile}}
             upload.fields({{json uploadFileName}}),
             {{/if}}
-            {{#if uploadFiles}}
-            upload.array('{{uploadFilesName}}'),
-            {{/if}}
             ...(fetchMiddlewares<Middleware>({{../name}})),
             ...(fetchMiddlewares<Middleware>({{../name}}.prototype.{{name}})),
 

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -82,6 +82,9 @@ export class ExpressTemplateService extends TemplateService<ExpressApiHandlerPar
             }
 
             const fileArgs = this.validationService.ValidateParam(param, requestFiles[name], name, fieldErrors, false, undefined);
+            if (param.dataType === 'array') {
+              return fileArgs;
+            }
             return fileArgs.length === 1 ? fileArgs[0] : fileArgs;
           }
           return this.validationService.ValidateParam(param, request.body[name], name, fieldErrors, false, undefined);

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -74,8 +74,8 @@ export class ExpressTemplateService extends TemplateService<ExpressApiHandlerPar
         case 'body-prop':
           return this.validationService.ValidateParam(param, request.body[name], name, fieldErrors, true, 'body.');
         case 'formData': {
-          const files = Object.values(args).filter(param => param.dataType === 'file');
-          if (param.dataType === 'file' && files.length > 0) {
+          const files = Object.values(args).filter(p => p.dataType === 'file' || (p.dataType === 'array' && p.array && p.array.dataType === 'file'));
+          if ((param.dataType === 'file' || (param.dataType === 'array' && param.array && param.array.dataType === 'file')) && files.length > 0) {
             const requestFiles = request.files as { [fileName: string]: Express.Multer.File[] };
             if (requestFiles[name] === undefined) {
               return undefined;
@@ -83,8 +83,6 @@ export class ExpressTemplateService extends TemplateService<ExpressApiHandlerPar
 
             const fileArgs = this.validationService.ValidateParam(param, requestFiles[name], name, fieldErrors, false, undefined);
             return fileArgs.length === 1 ? fileArgs[0] : fileArgs;
-          } else if (param.dataType === 'array' && param.array && param.array.dataType === 'file') {
-            return this.validationService.ValidateParam(param, request.files, name, fieldErrors, false, undefined);
           }
           return this.validationService.ValidateParam(param, request.body[name], name, fieldErrors, false, undefined);
         }

--- a/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
@@ -91,6 +91,9 @@ export class KoaTemplateService extends TemplateService<KoaApiHandlerParameters,
             }
 
             const fileArgs = this.validationService.ValidateParam(param, contextRequest.files[name], name, errorFields, false, undefined);
+            if (param.dataType === 'array') {
+              return fileArgs;
+            }
             return fileArgs.length === 1 ? fileArgs[0] : fileArgs;
           }
           return this.validationService.ValidateParam(param, contextRequest.body[name], name, errorFields, false, undefined);

--- a/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
@@ -83,17 +83,15 @@ export class KoaTemplateService extends TemplateService<KoaApiHandlerParameters,
           return this.validationService.ValidateParam(param, value, name, errorFields, true, 'body.');
         }
         case 'formData': {
-          const files = Object.values(args).filter(param => param.dataType === 'file');
+          const files = Object.values(args).filter(p => p.dataType === 'file' || (p.dataType === 'array' && p.array && p.array.dataType === 'file'));
           const contextRequest = context.request as any;
-          if (param.dataType === 'file' && files.length > 0) {
+          if ((param.dataType === 'file' || (param.dataType === 'array' && param.array && param.array.dataType === 'file')) && files.length > 0) {
             if (contextRequest.files[name] === undefined) {
               return undefined;
             }
 
             const fileArgs = this.validationService.ValidateParam(param, contextRequest.files[name], name, errorFields, false, undefined);
             return fileArgs.length === 1 ? fileArgs[0] : fileArgs;
-          } else if (param.dataType === 'array' && param.array && param.array.dataType === 'file') {
-            return this.validationService.ValidateParam(param, contextRequest.files, name, errorFields, false, undefined);
           }
           return this.validationService.ValidateParam(param, contextRequest.body[name], name, errorFields, false, undefined);
         }

--- a/tests/fixtures/controllers/postController.ts
+++ b/tests/fixtures/controllers/postController.ts
@@ -68,11 +68,13 @@ export class PostTestController {
   }
 
   @Post('ManyFilesInDifferentFields')
-  public async postWithDifferentFields(
-    @UploadedFile('file_a') fileA: File,
-    @UploadedFile('file_b') fileB: File,
-  ): Promise<File[]> {
+  public async postWithDifferentFields(@UploadedFile('file_a') fileA: File, @UploadedFile('file_b') fileB: File): Promise<File[]> {
     return [fileA, fileB];
+  }
+
+  @Post('ManyFilesInDifferentArrayFields')
+  public async postWithDifferentArrayFields(@UploadedFiles('files_a') filesA: File[], @UploadedFile('file_b') fileB: File, @UploadedFiles('files_c') filesC: File[]): Promise<File[][]> {
+    return [filesA, [fileB], filesC];
   }
 
   @Post('MixedFormDataWithFilesContainsOptionalFile')
@@ -80,7 +82,7 @@ export class PostTestController {
     @FormField('username') username: string,
     @UploadedFile('avatar') avatar: File,
     @UploadedFile('optionalAvatar') optionalAvatar?: File,
-  ): Promise<{ username: string; avatar: File; optionalAvatar?: File; }> {
+  ): Promise<{ username: string; avatar: File; optionalAvatar?: File }> {
     return { username, avatar, optionalAvatar };
   }
 

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1560,6 +1560,28 @@ describe('Express Server', () => {
       });
     });
 
+    it('can post multiple files with different array fields', () => {
+      const formData = {
+        files_a: ['@../package.json', '@../tsconfig.json'],
+        file_b: '@../tsoa.json',
+        files_c: ['@../tsconfig.json', '@../package.json'],
+      };
+      return verifyFileUploadRequest(`${basePath}/PostTest/ManyFilesInDifferentArrayFields`, formData, (_err, res) => {
+        for (const fileList of res.body as File[][]) {
+          for (const file of fileList) {
+            const packageJsonBuffer = readFileSync(resolve(__dirname, `../${file.originalname}`));
+            const returnedBuffer = Buffer.from(file.buffer);
+            expect(file).to.not.be.undefined;
+            expect(file.fieldname).to.be.not.undefined;
+            expect(file.originalname).to.be.not.undefined;
+            expect(file.encoding).to.be.not.undefined;
+            expect(file.mimetype).to.equal('application/json');
+            expect(Buffer.compare(returnedBuffer, packageJsonBuffer)).to.equal(0);
+          }
+        }
+      });
+    });
+
     it('can post mixed form data content with file and not providing optional file', () => {
       const formData = {
         username: 'test',

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -1541,6 +1541,18 @@ describe('Express Server', () => {
       });
     });
 
+    it('can post single file to multi file field', () => {
+      const formData = {
+        a: 'b',
+        c: 'd',
+        someFiles: ['@../package.json'],
+      };
+
+      return verifyFileUploadRequest(basePath + '/PostTest/ManyFilesAndFormFields', formData, (_err, res) => {
+        expect(res.body).to.be.length(1);
+      });
+    });
+
     it('can post multiple files with different field', () => {
       const formData = {
         file_a: '@../package.json',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1443,6 +1443,28 @@ describe('Hapi Server', () => {
       });
     });
 
+    it('can post multiple files with different array fields', () => {
+      const formData = {
+        files_a: ['@../package.json', '@../tsconfig.json'],
+        file_b: '@../tsoa.json',
+        files_c: ['@../tsconfig.json', '@../package.json'],
+      };
+      return verifyFileUploadRequest(`${basePath}/PostTest/ManyFilesInDifferentArrayFields`, formData, (_err, res) => {
+        for (const fileList of res.body as File[][]) {
+          for (const file of fileList) {
+            const packageJsonBuffer = readFileSync(resolve(__dirname, `../${file.originalname}`));
+            const returnedBuffer = Buffer.from(file.buffer);
+            expect(file).to.not.be.undefined;
+            expect(file.fieldname).to.be.not.undefined;
+            expect(file.originalname).to.be.not.undefined;
+            expect(file.encoding).to.be.not.undefined;
+            expect(file.mimetype).to.equal('application/json');
+            expect(Buffer.compare(returnedBuffer, packageJsonBuffer)).to.equal(0);
+          }
+        }
+      });
+    });
+
     it('can post mixed form data content with file and not providing optional file', () => {
       const formData = {
         username: 'test',

--- a/tests/integration/hapi-server.spec.ts
+++ b/tests/integration/hapi-server.spec.ts
@@ -1424,6 +1424,18 @@ describe('Hapi Server', () => {
       });
     });
 
+    it('can post single file to multi file field', () => {
+      const formData = {
+        a: 'b',
+        c: 'd',
+        someFiles: ['@../package.json'],
+      };
+
+      return verifyFileUploadRequest(basePath + '/PostTest/ManyFilesAndFormFields', formData, (_err, res) => {
+        expect(res.body).to.be.length(1);
+      });
+    });
+
     it('can post multiple files with different field', () => {
       const formData = {
         file_a: '@../package.json',

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1404,6 +1404,18 @@ describe('Koa Server', () => {
       });
     });
 
+    it('can post single file to multi file field', () => {
+      const formData = {
+        a: 'b',
+        c: 'd',
+        someFiles: ['@../package.json'],
+      };
+
+      return verifyFileUploadRequest(basePath + '/PostTest/ManyFilesAndFormFields', formData, (_err, res) => {
+        expect(res.body).to.be.length(1);
+      });
+    });
+
     it('can post multiple files with different field', () => {
       const formData = {
         file_a: '@../package.json',

--- a/tests/integration/koa-server.spec.ts
+++ b/tests/integration/koa-server.spec.ts
@@ -1423,6 +1423,28 @@ describe('Koa Server', () => {
       });
     });
 
+    it('can post multiple files with different array fields', () => {
+      const formData = {
+        files_a: ['@../package.json', '@../tsconfig.json'],
+        file_b: '@../tsoa.json',
+        files_c: ['@../tsconfig.json', '@../package.json'],
+      };
+      return verifyFileUploadRequest(`${basePath}/PostTest/ManyFilesInDifferentArrayFields`, formData, (_err, res) => {
+        for (const fileList of res.body as File[][]) {
+          for (const file of fileList) {
+            const packageJsonBuffer = readFileSync(resolve(__dirname, `../${file.originalname}`));
+            const returnedBuffer = Buffer.from(file.buffer);
+            expect(file).to.not.be.undefined;
+            expect(file.fieldname).to.be.not.undefined;
+            expect(file.originalname).to.be.not.undefined;
+            expect(file.encoding).to.be.not.undefined;
+            expect(file.mimetype).to.equal('application/json');
+            expect(Buffer.compare(returnedBuffer, packageJsonBuffer)).to.equal(0);
+          }
+        }
+      });
+    });
+
     it('can post mixed form data content with file and not providing optional file', () => {
       const formData = {
         username: 'test',


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

Closes https://github.com/lukeautry/tsoa/issues/1619.

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->
There are not that many files present in the test folder to use for testing uploading files. Right now the same file is included multiple times, but the order is always different, so this should not matter.

The `routeGenerator.ts` now also adds two extra attributes to each file upload field, namely `maxCount` and `multiple`. The `maxCount` attribute is used by Multer to enforce only one file is uploaded to that field. However, HandleBars aims to be logic free, so a simple check (`maxCount == 1`) cannot be done in `hapi.hbs` to determine whether multiple files can be uploaded or not. Therefore, the `multiple` attribute is also added, but by design of the `json` function in Handlebars, this extra variable is also included in the Express and Koa `routes.ts`. Luckily, it does not do anything, but it is not very elegant. If there is a better way to do this, I would love to hear it!

**Test plan**

The unit tests that I added includes the case mentioned in the issue, but also two `@UploadedFiles()` statement to truly verify that these arrays are separated correctly.

The fix simply removes the `upload.array()` lines from any `routes.ts` files, because the same can be achieved by using `upload.fields()`.