### PR TITLE
add next() to express template, closes #1593

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -111,6 +111,7 @@ export function RegisterRoutes(app: Router) {
                 validatedArgs,
                 successStatus: {{successStatus}},
               });
+              next();
             } catch (err) {
                 return next(err);
             }

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -36,7 +36,21 @@ app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
+let postRouteMiddlwareCalled = false;
 RegisterRoutes(app);
+app.get('/reset-post-route-middleware-status', (req, res, next) => {
+  postRouteMiddlwareCalled = false;
+  res.json({ postRouteMiddlwareCalled }).send();
+  next();
+});
+app.get('/post-route-middleware-status', (req, res, next) => {
+  res.json({ postRouteMiddlwareCalled }).send();
+  next();
+});
+app.use((req, res, next) => {
+  postRouteMiddlwareCalled = true;
+  next();
+});
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/integration/express-server.spec.ts
+++ b/tests/integration/express-server.spec.ts
@@ -24,13 +24,22 @@ import {
 const basePath = '/v1';
 
 describe('Express Server', () => {
+  it('can reset the post route middleware status', () => {
+    return verifyGetRequest('/reset-post-route-middleware-status', (_err, res) => {
+      expect(res.body.postRouteMiddlwareCalled).to.eq(false);
+    });
+  });
   it('can handle get request to root controller`s path', () => {
     return verifyGetRequest(basePath + '/', (_err, res) => {
       const model = res.body as TestModel;
       expect(model.id).to.equal(1);
     });
   });
-
+  it('can verify that post request middleware was called', () => {
+    return verifyGetRequest('/post-route-middleware-status', (_err, res) => {
+      expect(res.body.postRouteMiddlwareCalled).to.eq(true);
+    });
+  });
   it('can handle get request to root controller`s method path', () => {
     return verifyGetRequest(basePath + '/rootControllerMethodWithPath', (_err, res) => {
       const model = res.body as TestModel;


### PR DESCRIPTION

closes #1593
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [X] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [X] This PR is associated with an existing issue?

**Closing issues**

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

Technically this could be considered a breaking change, but IMO it should be considered a bug fix.

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->

I added an in memory boolean to the express server, added routes to check/modify that boolean, and a middleware which modifies the bool after the register routes. The tests first set that boolean to false, then, after a route has run through tsoa, checks that the boolean was modified by the middleware.
