### PR TITLE
let CLI accept .cjs config files

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,14 +47,18 @@ const authorInformation: Promise<
     }
 > = getPackageJsonValue('author', 'unknown');
 
+const isYamlExtension = (extension: string): boolean => extension === '.yaml' || extension === '.yml';
+
+const isJsExtension = (extension: string): boolean => extension === '.js' || extension === '.cjs';
+
 const getConfig = async (configPath = 'tsoa.json'): Promise<Config> => {
   let config: Config;
   const ext = extname(configPath);
   try {
-    if (ext === '.yaml' || ext === '.yml') {
+    if (isYamlExtension(ext)) {
       const configRaw = await fsReadFile(`${workingDir}/${configPath}`);
       config = YAML.parse(configRaw.toString('utf8'));
-    } else if (ext === '.js') {
+    } else if (isJsExtension(ext)) {
       config = await import(`${workingDir}/${configPath}`);
     } else {
       const configRaw = await fsReadFile(`${workingDir}/${configPath}`);
@@ -68,7 +72,7 @@ const getConfig = async (configPath = 'tsoa.json'): Promise<Config> => {
       throw Error(`No config file found at '${configPath}'`);
     } else if (err.name === 'SyntaxError') {
       console.error(err);
-      const errorType = ext === '.js' ? 'JS' : 'JSON';
+      const errorType = isJsExtension(ext) ? 'JS' : 'JSON';
       throw Error(`Invalid ${errorType} syntax in config at '${configPath}': ${err.message}`);
     } else {
       console.error(err);


### PR DESCRIPTION
Hello 👋 
I opened an issue (#1630) a couple of days ago and found some time today to open this PR.

The CLI is a CJS package, so all modules it imports must be CJS. tsoa configs are located outside the CLI, potentially in an ESM package. To force these configs to be treated as CJS, they need to have the .cjs extension and the CLI must accept them.

Closes #1630.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests? I did not find any tests specifically for `getConfig` or `resolveConfig`. There is `config.spec.ts`, but it's just tests for resolved configs. Let me know if I missed something.
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue? #1630.

**Closing issues**

closes #1630

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->
None I can think of. In the long run, I think it's worth considering to move the CLI package to ESM.

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
