### PR TITLE
feat: add setHeader conditional value types

### DIFF
--- a/packages/runtime/src/interfaces/controller.ts
+++ b/packages/runtime/src/interfaces/controller.ts
@@ -1,3 +1,8 @@
+import type { OutgoingHttpHeaders } from "node:http";
+
+type HeaderNames = keyof OutgoingHttpHeaders;
+type HeaderValue<H extends HeaderNames> = OutgoingHttpHeaders[H];
+
 export class Controller {
   private statusCode?: number = undefined;
   private headers = {} as { [name: string]: string | string[] | undefined };
@@ -9,6 +14,9 @@ export class Controller {
   public getStatus() {
     return this.statusCode;
   }
+
+  public setHeader<H extends HeaderNames>(name: H, value?: HeaderValue<H>): void;
+  public setHeader(name: string, value?: string | string[]): void
 
   public setHeader(name: string, value?: string | string[]) {
     this.headers[name] = value;


### PR DESCRIPTION
Improve `setHeader` type hinting for standard headers based on `@types/node`.

e.g.

```ts
// `name: "authorization"` hints👇
setHeader(name: "authorization", value?: string | undefined): void

// `name: "accept-charset"` hints👇
setHeader(name: "accept-charset", value?: string | string[] | undefined): void
```

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?