### PR TITLE
Fix typescript build error when using file upload

### DIFF
--- a/packages/cli/src/routeGeneration/templates/express.hbs
+++ b/packages/cli/src/routeGeneration/templates/express.hbs
@@ -85,10 +85,16 @@ export function RegisterRoutes(app: Router) {
             authenticateMiddleware({{json security}}),
             {{/if}}
             {{#if uploadFile}}
-            upload.fields({{json uploadFileName}}),
-            {{/if}}
-            {{#if uploadFiles}}
-            upload.array('{{uploadFilesName}}'),
+            upload.fields([
+                {{#each uploadFileName}}
+                {
+                    name: {{json name}},
+                    {{#if maxCount}}
+                    maxCount: {{maxCount}}
+                    {{/if}}
+                }{{#if @last}}{{else}},{{/if}}
+                {{/each}}
+            ]),
             {{/if}}
             ...(fetchMiddlewares<RequestHandler>({{../name}})),
             ...(fetchMiddlewares<RequestHandler>({{../name}}.prototype.{{name}})),

--- a/packages/cli/src/routeGeneration/templates/hapi.hbs
+++ b/packages/cli/src/routeGeneration/templates/hapi.hbs
@@ -89,13 +89,6 @@ export function RegisterRoutes(server: any) {
                   multipart: true,
                   allow: 'multipart/form-data'
                 },
-                {{else if uploadFiles}}
-                payload: {
-                  output: 'stream',
-                  parse: true,
-                  multipart: true,
-                  allow: 'multipart/form-data'
-                },
                 {{/if}}
                 handler: {{#if ../../iocModule}}async {{/if}}function {{../name}}_{{name}}(request: Request, h: ResponseToolkit) {
                     const args: Record<string, TsoaRoute.ParameterSchema> = {

--- a/packages/cli/src/routeGeneration/templates/koa.hbs
+++ b/packages/cli/src/routeGeneration/templates/koa.hbs
@@ -81,10 +81,16 @@ export function RegisterRoutes(router: KoaRouter) {
             authenticateMiddleware({{json security}}),
             {{/if}}
             {{#if uploadFile}}
-            upload.fields({{json uploadFileName}}),
-            {{/if}}
-            {{#if uploadFiles}}
-            upload.array('{{uploadFilesName}}'),
+            upload.fields([
+                {{#each uploadFileName}}
+                {
+                    name: {{json name}},
+                    {{#if maxCount}}
+                    maxCount: {{maxCount}}
+                    {{/if}}
+                }{{#if @last}}{{else}},{{/if}}
+                {{/each}}
+            ]),
             {{/if}}
             ...(fetchMiddlewares<Middleware>({{../name}})),
             ...(fetchMiddlewares<Middleware>({{../name}}.prototype.{{name}})),


### PR DESCRIPTION
This PR fixes an issue where the generated `routes.ts` for an `express` or `koa` based project has invalid usage of the `multer` `upload.fields` method when uploading files. This is because  of an extra rendered field `multiple` which is used in the `hapi` template. Note I have also removed some conditional rendering when the property `uploadFiles` is present on the `action` as this is now never generated.

Note I think the best way to unit test this would be to enable type checking in the `tsc` build of usages against external libraries. This has very clearly been disabled intensionallty so I've left it as is, hence no tests in the checklist.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1642