### PR TITLE
refactor/remove @typescript-eslint/ban-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
         default: 'array-simple',
       },
     ],
-    '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/packages/runtime/src/decorators/customAttribute.ts
+++ b/packages/runtime/src/decorators/customAttribute.ts
@@ -1,4 +1,4 @@
-export function CustomAttribute(_name: string, _value: string): Function {
+export function CustomAttribute(_name: string, _value: string): PropertyDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/deprecated.ts
+++ b/packages/runtime/src/decorators/deprecated.ts
@@ -1,7 +1,7 @@
 /**
  * used to show a method as deprecated on swagger documentation
  */
-export function Deprecated(): Function {
+export function Deprecated(): PropertyDecorator & ClassDecorator & ParameterDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/example.ts
+++ b/packages/runtime/src/decorators/example.ts
@@ -1,4 +1,4 @@
-export function Example<T>(exampleModel: T, exampleLabel?: string): Function {
+export function Example<T>(exampleModel: T, exampleLabel?: string): PropertyDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/extension.ts
+++ b/packages/runtime/src/decorators/extension.ts
@@ -1,4 +1,4 @@
-export function Extension(_name: string, _value: ExtensionType | ExtensionType[]): Function {
+export function Extension(_name: string, _value: ExtensionType | ExtensionType[]): PropertyDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/methods.ts
+++ b/packages/runtime/src/decorators/methods.ts
@@ -1,40 +1,40 @@
-export function Options(value?: string): Function {
+export function Options(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Get(value?: string): Function {
+export function Get(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Post(value?: string): Function {
+export function Post(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Put(value?: string): Function {
+export function Put(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Patch(value?: string): Function {
+export function Patch(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Delete(value?: string): Function {
+export function Delete(value?: string): MethodDecorator {
   return () => {
     return;
   };
 }
 
-export function Head(value?: string): Function {
+export function Head(value?: string): MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/middlewares.ts
+++ b/packages/runtime/src/decorators/middlewares.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-type Middleware<T extends Function | Object> = T;
+type Middleware<T extends Function | object> = T;
 
 const TSOA_MIDDLEWARES = Symbol('@tsoa:middlewares');
 
@@ -34,7 +34,7 @@ function decorator(fn: (value: any) => void) {
  * @param middlewares
  * @returns
  */
-export function Middlewares<T extends Function | Object>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
+export function Middlewares<T extends Function | object>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
   return decorator(target => {
     if (mws) {
       const current = fetchMiddlewares<T>(target);
@@ -49,6 +49,6 @@ export function Middlewares<T extends Function | Object>(...mws: Array<Middlewar
  * @param target
  * @returns list of middlewares
  */
-export function fetchMiddlewares<T extends Function | Object>(target: any): Array<Middleware<T>> {
+export function fetchMiddlewares<T extends Function | object>(target: any): Array<Middleware<T>> {
   return Reflect.getMetadata(TSOA_MIDDLEWARES, target) || [];
 }

--- a/packages/runtime/src/decorators/middlewares.ts
+++ b/packages/runtime/src/decorators/middlewares.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type Middleware<T extends Function | object> = T;
+type Middleware<T extends CallableFunction | object> = T;
 
 const TSOA_MIDDLEWARES = Symbol('@tsoa:middlewares');
 
@@ -34,7 +32,7 @@ function decorator(fn: (value: any) => void) {
  * @param middlewares
  * @returns
  */
-export function Middlewares<T extends Function | object>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
+export function Middlewares<T extends CallableFunction | object>(...mws: Array<Middleware<T>>): ClassDecorator & MethodDecorator {
   return decorator(target => {
     if (mws) {
       const current = fetchMiddlewares<T>(target);
@@ -49,6 +47,6 @@ export function Middlewares<T extends Function | object>(...mws: Array<Middlewar
  * @param target
  * @returns list of middlewares
  */
-export function fetchMiddlewares<T extends Function | object>(target: any): Array<Middleware<T>> {
+export function fetchMiddlewares<T extends CallableFunction | object>(target: any): Array<Middleware<T>> {
   return Reflect.getMetadata(TSOA_MIDDLEWARES, target) || [];
 }

--- a/packages/runtime/src/decorators/operationid.ts
+++ b/packages/runtime/src/decorators/operationid.ts
@@ -1,4 +1,4 @@
-export function OperationId(value: string): Function {
+export function OperationId(value: string): MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -2,7 +2,7 @@
  * Inject http Body
  *  @param {string} [name] properties name in body object
  */
-export function Body(): Function {
+export function Body(): ParameterDecorator {
   return () => {
     return;
   };
@@ -13,7 +13,7 @@ export function Body(): Function {
  *
  * @param {string} [name] The name of the body parameter
  */
-export function BodyProp(name?: string): Function {
+export function BodyProp(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -22,7 +22,7 @@ export function BodyProp(name?: string): Function {
 /**
  * Inject http request
  */
-export function Request(): Function {
+export function Request(): ParameterDecorator {
   return () => {
     return;
   };
@@ -33,7 +33,7 @@ export function Request(): Function {
  *
  * @param {name} [name] The name of the request parameter
  */
-export function RequestProp(name?: string): Function {
+export function RequestProp(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -44,7 +44,7 @@ export function RequestProp(name?: string): Function {
  *
  * @param {string} [name] The name of the path parameter
  */
-export function Path(name?: string): Function {
+export function Path(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -55,7 +55,7 @@ export function Path(name?: string): Function {
  *
  * @param {string} [name] The name of the query parameter
  */
-export function Query(name?: string): Function {
+export function Query(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -64,7 +64,7 @@ export function Query(name?: string): Function {
 /**
  * Inject all query values in a single object
  */
-export function Queries(): Function {
+export function Queries(): ParameterDecorator {
   return () => {
     return;
   };
@@ -75,7 +75,7 @@ export function Queries(): Function {
  *
  * @param {string} [name] The name of the header parameter
  */
-export function Header(name?: string): Function {
+export function Header(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -84,7 +84,7 @@ export function Header(name?: string): Function {
 /**
  * Mark parameter as manually injected, which will not be generated
  */
-export function Inject(): Function {
+export function Inject(): ParameterDecorator {
   return () => {
     return;
   };
@@ -95,7 +95,7 @@ export function Inject(): Function {
  *
  * @param {string} [name] The name of the uploaded file parameter
  */
-export function UploadedFile(name?: string): Function {
+export function UploadedFile(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -106,7 +106,7 @@ export function UploadedFile(name?: string): Function {
  *
  * @param {string} [name] The name of the uploaded files parameter
  */
-export function UploadedFiles(name?: string): Function {
+export function UploadedFiles(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -117,7 +117,7 @@ export function UploadedFiles(name?: string): Function {
  *
  * @param {string} [name] The name of the uploaded files parameter
  */
-export function FormField(name?: string): Function {
+export function FormField(name?: string): ParameterDecorator {
   return () => {
     return;
   };
@@ -130,7 +130,7 @@ export function FormField(name?: string): Function {
  *
  * @link https://swagger.io/docs/specification/describing-request-body/
  */
-export function Consumes(value: string): Function {
+export function Consumes(value: string): ParameterDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/parameter.ts
+++ b/packages/runtime/src/decorators/parameter.ts
@@ -130,7 +130,7 @@ export function FormField(name?: string): ParameterDecorator {
  *
  * @link https://swagger.io/docs/specification/describing-request-body/
  */
-export function Consumes(value: string): ParameterDecorator {
+export function Consumes(value: string): MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -12,7 +12,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
   description?: string,
   example?: ExampleType,
   produces?: string | string[],
-): MethodDecorator {
+): ClassDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -35,7 +35,7 @@ export function Res(): ParameterDecorator {
  *
  * @link https://swagger.io/docs/specification/media-types/
  */
-export function Produces(value: string): MethodDecorator {
+export function Produces(value: string): MethodDecorator & ClassDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -1,13 +1,13 @@
 import { IsValidHeader } from '../utils/isHeaderType';
 import { HttpStatusCodeLiteral, HttpStatusCodeStringLiteral, OtherValidOpenApiHttpStatusCode } from '../interfaces/response';
 
-export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = {}>(name: string | number, description?: string, produces?: string | string[]): Function {
+export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = object>(name: string | number, description?: string, produces?: string | string[]): Function {
   return () => {
     return;
   };
 }
 
-export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderType> = {}>(
+export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderType> = object>(
   name: HttpStatusCodeLiteral | HttpStatusCodeStringLiteral | OtherValidOpenApiHttpStatusCode,
   description?: string,
   example?: ExampleType,

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -1,7 +1,7 @@
 import { IsValidHeader } from '../utils/isHeaderType';
 import { HttpStatusCodeLiteral, HttpStatusCodeStringLiteral, OtherValidOpenApiHttpStatusCode } from '../interfaces/response';
 
-export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = object>(name: string | number, description?: string, produces?: string | string[]): Function {
+export function SuccessResponse<HeaderType extends IsValidHeader<HeaderType> = object>(name: string | number, description?: string, produces?: string | string[]): MethodDecorator {
   return () => {
     return;
   };
@@ -12,7 +12,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
   description?: string,
   example?: ExampleType,
   produces?: string | string[],
-): Function {
+): MethodDecorator {
   return () => {
     return;
   };
@@ -23,7 +23,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
  *
  * The type of the responder function should be annotated `TsoaResponse<Status, Data, Headers>` in order to support OpenAPI documentation.
  */
-export function Res(): Function {
+export function Res(): ParameterDecorator {
   return () => {
     return;
   };
@@ -35,7 +35,7 @@ export function Res(): Function {
  *
  * @link https://swagger.io/docs/specification/media-types/
  */
-export function Produces(value: string): Function {
+export function Produces(value: string): MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/response.ts
+++ b/packages/runtime/src/decorators/response.ts
@@ -12,7 +12,7 @@ export function Response<ExampleType, HeaderType extends IsValidHeader<HeaderTyp
   description?: string,
   example?: ExampleType,
   produces?: string | string[],
-): ClassDecorator {
+): MethodDecorator & ClassDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/route.ts
+++ b/packages/runtime/src/decorators/route.ts
@@ -1,4 +1,4 @@
-export function Route(name?: string): Function {
+export function Route(name?: string): ClassDecorator {
   return () => {
     return;
   };
@@ -7,7 +7,7 @@ export function Route(name?: string): Function {
 /**
  * can be used to entirely hide an method from documentation
  */
-export function Hidden(): Function {
+export function Hidden(): ClassDecorator & MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/route.ts
+++ b/packages/runtime/src/decorators/route.ts
@@ -7,7 +7,7 @@ export function Route(name?: string): ClassDecorator {
 /**
  * can be used to entirely hide an method from documentation
  */
-export function Hidden(): ClassDecorator & MethodDecorator {
+export function Hidden(): ClassDecorator & MethodDecorator & ParameterDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/security.ts
+++ b/packages/runtime/src/decorators/security.ts
@@ -1,7 +1,7 @@
 /**
  * Can be used to indicate that a method requires no security.
  */
-export function NoSecurity(): Function {
+export function NoSecurity(): ClassDecorator & MethodDecorator {
   return () => {
     return;
   };
@@ -10,7 +10,7 @@ export function NoSecurity(): Function {
 /**
  * @param {name} security name from securityDefinitions
  */
-export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): Function {
+export function Security(name: string | { [name: string]: string[] }, scopes?: string[]): ClassDecorator & MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/decorators/tags.ts
+++ b/packages/runtime/src/decorators/tags.ts
@@ -1,4 +1,4 @@
-export function Tags(...values: string[]): Function {
+export function Tags(...values: string[]): MethodDecorator {
   return () => {
     return;
   };

--- a/packages/runtime/src/interfaces/response.ts
+++ b/packages/runtime/src/interfaces/response.ts
@@ -65,4 +65,4 @@ export type HttpStatusCodeStringLiteral = `${HttpStatusCodeLiteral}`;
 
 export type OtherValidOpenApiHttpStatusCode = '1XX' | '2XX' | '3XX' | '4XX' | '5XX' | 'default';
 
-export type TsoaResponse<T extends HttpStatusCodeLiteral, BodyType, HeaderType extends IsValidHeader<HeaderType> = {}> = (status: T, data: BodyType, headers?: HeaderType) => any;
+export type TsoaResponse<T extends HttpStatusCodeLiteral, BodyType, HeaderType extends IsValidHeader<HeaderType> = object> = (status: T, data: BodyType, headers?: HeaderType) => any;

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -8,7 +8,7 @@ import { TemplateService } from '../templateService';
 
 type ExpressApiHandlerParameters = {
   methodName: string;
-  controller: Controller | Object;
+  controller: Controller | object;
   response: ExResponse;
   next: ExNext;
   validatedArgs: any[];

--- a/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
@@ -36,8 +36,8 @@ export class HapiTemplateService extends TemplateService<HapiApiHandlerParameter
     protected readonly models: TsoaRoute.Models,
     protected readonly config: AdditionalProps,
     private readonly hapi: {
-      boomify: Function;
-      isBoom: Function;
+      boomify: CallableFunction;
+      isBoom: CallableFunction;
     },
   ) {
     super(models, config);

--- a/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/hapi/hapiTemplateService.ts
@@ -12,7 +12,7 @@ const hapiTsoaResponsed = Symbol('@tsoa:template_service:hapi:responsed');
 
 type HapiApiHandlerParameters = {
   methodName: string;
-  controller: Controller | Object;
+  controller: Controller | object;
   h: HResponse;
   validatedArgs: any[];
   successStatus?: number;

--- a/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/koa/koaTemplateService.ts
@@ -10,7 +10,7 @@ const koaTsoaResponsed = Symbol('@tsoa:template_service:koa:is_responsed');
 
 type KoaApiHandlerParameters = {
   methodName: string;
-  controller: Controller | Object;
+  controller: Controller | object;
   context: Context;
   validatedArgs: any[];
   successStatus?: number;

--- a/packages/runtime/src/routeGeneration/templates/templateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/templateService.ts
@@ -19,11 +19,11 @@ export abstract class TemplateService<ApiHandlerParameters, ValidationArgsParame
 
   protected abstract returnHandler(params: ReturnHandlerParameters): any;
 
-  protected isController(object: Controller | Object): object is Controller {
+  protected isController(object: Controller | object): object is Controller {
     return 'getHeaders' in object && 'getStatus' in object && 'setStatus' in object;
   }
 
-  protected buildPromise(methodName: string, controller: Controller | Object, validatedArgs: any) {
+  protected buildPromise(methodName: string, controller: Controller | object, validatedArgs: any) {
     const prototype = Object.getPrototypeOf(controller);
     const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
     return descriptor!.value.apply(controller, validatedArgs);

--- a/packages/runtime/src/utils/isHeaderType.ts
+++ b/packages/runtime/src/utils/isHeaderType.ts
@@ -4,6 +4,6 @@
  */
 export type IsValidHeader<Header> = keyof Header extends string | number
   ? Header[keyof Header] extends string | string[] | undefined
-    ? {}
+    ? object
     : 'Header values must be string or string[]'
   : 'Header names must be of type string';


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

contributes to https://github.com/lukeautry/tsoa/issues/1165 by solving all @typescript-eslint/ban-types, and removing the rule.

- converting Function to the various Decorator types.

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

<!-- explain why the unit tests that you added are demonstrating that the feature works -->
