### PR TITLE
feat: Support string variable in the first argument of @Extension

### DIFF
--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -18,8 +18,8 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const attributeKey = ts.isIdentifier(decoratorKeyArg) ? getInitializerValue(decoratorKeyArg, metadataGenerator.typeChecker) : decoratorKeyArg.text;
 
-    if (typeof attributeKey !== 'string') {
-      throw new Error('The first argument of @Extension must be a string');
+    if (typeof attributeKey !== 'string' || attributeKey == null) {
+      throw new Error('The first argument of @Extension must a string');
     }
 
     if (!decoratorValueArg) {

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -18,7 +18,7 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const attributeKey = ts.isIdentifier(decoratorKeyArg) ? getInitializerValue(decoratorKeyArg, metadataGenerator.typeChecker) : decoratorKeyArg.text;
 
-    if (typeof attributeKey !== 'string' || attributeKey == null) {
+    if (typeof attributeKey !== 'string') {
       throw new Error('The first argument of @Extension must a string');
     }
 
@@ -29,12 +29,6 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
     assertValidExtensionKey(attributeKey);
 
     const attributeValue = getInitializerValue(decoratorValueArg, metadataGenerator.typeChecker);
-    if (attributeValue == null) {
-      throw new Error(`The value for extension '${attributeKey}' cannot be null or undefined.`);
-    }
-    if (typeof attributeValue !== 'string' && typeof attributeValue !== 'number' && typeof attributeValue !== 'boolean') {
-      throw new Error(`Extension '${attributeKey}' has an invalid value type: ${typeof attributeValue}`);
-    }
     if (!isNonUndefinedInitializerValue(attributeValue)) {
       throw new Error(`Extension '${attributeKey}' cannot have an undefined initializer value`);
     }

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -29,8 +29,8 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
     assertValidExtensionKey(attributeKey);
 
     const attributeValue = getInitializerValue(decoratorValueArg, metadataGenerator.typeChecker);
-    if (attributeValue === undefined) {
-      throw new Error(`'${attributeKey}' is undefined`);
+    if (attributeValue == null) {
+      throw new Error(`The value for extension '${attributeKey}' cannot be null or undefined.`);
     }
     if (!isNonUndefinedInitializerValue(attributeValue)) {
       throw new Error(`Extension '${attributeKey}' cannot have an undefined initializer value`);

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -12,11 +12,15 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const [decoratorKeyArg, decoratorValueArg] = extensionDecorator.parent.arguments;
 
-    if (!ts.isStringLiteral(decoratorKeyArg)) {
+    if (!ts.isStringLiteral(decoratorKeyArg) && !ts.isIdentifier(decoratorKeyArg)) {
       throw new Error('The first argument of @Extension must be a string');
     }
 
-    const attributeKey = decoratorKeyArg.text;
+    const attributeKey = ts.isIdentifier(decoratorKeyArg) ? getInitializerValue(decoratorKeyArg, metadataGenerator.typeChecker) : decoratorKeyArg.text;
+
+    if (typeof attributeKey !== 'string') {
+      throw new Error('The first argument of @Extension must be a string');
+    }
 
     if (!decoratorValueArg) {
       throw new Error(`Extension '${attributeKey}' must contain a value`);

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -12,7 +12,7 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const [decoratorKeyArg, decoratorValueArg] = extensionDecorator.parent.arguments;
 
-    if (!ts.isStringLiteral(decoratorKeyArg) && !ts.isIdentifier(decoratorKeyArg)) {
+    if (!ts.isStringLiteral(decoratorKeyArg)) {
       throw new Error('The first argument of @Extension must be a string');
     }
 

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -29,6 +29,9 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
     assertValidExtensionKey(attributeKey);
 
     const attributeValue = getInitializerValue(decoratorValueArg, metadataGenerator.typeChecker);
+    if (attributeValue === undefined) {
+      throw new Error(`'${attributeKey}' is undefined`);
+    }
     if (!isNonUndefinedInitializerValue(attributeValue)) {
       throw new Error(`Extension '${attributeKey}' cannot have an undefined initializer value`);
     }

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -32,6 +32,9 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
     if (attributeValue == null) {
       throw new Error(`The value for extension '${attributeKey}' cannot be null or undefined.`);
     }
+    if (typeof attributeValue !== 'string' && typeof attributeValue !== 'number' && typeof attributeValue !== 'boolean') {
+      throw new Error(`Extension '${attributeKey}' has an invalid value type: ${typeof attributeValue}`);
+    }
     if (!isNonUndefinedInitializerValue(attributeValue)) {
       throw new Error(`Extension '${attributeKey}' cannot have an undefined initializer value`);
     }

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -12,15 +12,11 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const [decoratorKeyArg, decoratorValueArg] = extensionDecorator.parent.arguments;
 
-    if (!ts.isStringLiteral(decoratorKeyArg) && !ts.isIdentifier(decoratorKeyArg)) {
+    if (!ts.isStringLiteral(decoratorKeyArg)) {
       throw new Error('The first argument of @Extension must be a string');
     }
 
     const attributeKey = decoratorKeyArg.text;
-
-    if (typeof attributeKey !== 'string') {
-      throw new Error('The first argument of @Extension must a string');
-    }
 
     if (!decoratorValueArg) {
       throw new Error(`Extension '${attributeKey}' must contain a value`);

--- a/packages/cli/src/metadataGeneration/extension.ts
+++ b/packages/cli/src/metadataGeneration/extension.ts
@@ -12,11 +12,11 @@ export function getExtensions(decorators: ts.Identifier[], metadataGenerator: Me
 
     const [decoratorKeyArg, decoratorValueArg] = extensionDecorator.parent.arguments;
 
-    if (!ts.isStringLiteral(decoratorKeyArg)) {
+    if (!ts.isStringLiteral(decoratorKeyArg) && !ts.isIdentifier(decoratorKeyArg)) {
       throw new Error('The first argument of @Extension must be a string');
     }
 
-    const attributeKey = ts.isIdentifier(decoratorKeyArg) ? getInitializerValue(decoratorKeyArg, metadataGenerator.typeChecker) : decoratorKeyArg.text;
+    const attributeKey = decoratorKeyArg.text;
 
     if (typeof attributeKey !== 'string') {
       throw new Error('The first argument of @Extension must a string');

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -696,7 +696,6 @@ export class SpecGenerator3 extends SpecGenerator {
 
     if (types.size === 1) {
       const type = types.values().next().value;
-      if (!type) throw new Error('Enum must be defined');
       const nullable = enumType.enums.includes(null) ? true : false;
       return { ...(title && { title }), type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
     } else {

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -696,6 +696,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     if (types.size === 1) {
       const type = types.values().next().value;
+      if (!type) throw new Error('Enum must be defined');
       const nullable = enumType.enums.includes(null) ? true : false;
       return { ...(title && { title }), type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
     } else {

--- a/tests/fixtures/controllers/methodController.ts
+++ b/tests/fixtures/controllers/methodController.ts
@@ -27,6 +27,8 @@ const TEST_SEC = {
   secondSec: [TEST_ENUM.ADMIN, TEST_ENUM.OWNER],
 };
 
+const ATT_KEY9 = 'x-attKey9';
+
 @Route('MethodTest')
 export class MethodController extends Controller {
   @Options('Options')
@@ -165,6 +167,7 @@ export class MethodController extends Controller {
   @Extension('x-attKey6', [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }])
   @Extension('x-attKey7', { test: ['testVal', 123, true, null] })
   @Extension('x-attKey8', { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } })
+  @Extension(ATT_KEY9, 'identifierAttValue')
   @Get('Extension')
   public async extension(): Promise<TestModel> {
     return new ModelService().getModel();

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -166,10 +166,13 @@ describe('Metadata generation', () => {
 
       expect(method.responses.length).to.equal(5);
 
-      const badResponse = method.responses[1]
+      const badResponse = method.responses[1];
       expect(badResponse.name).to.equal('400');
       expect(badResponse.description).to.equal('Bad Request');
-      expect(badResponse.examples).to.deep.equal([{ status: 400, message: 'reason 1' }, { status: 400, message: 'reason 2' }]);
+      expect(badResponse.examples).to.deep.equal([
+        { status: 400, message: 'reason 1' },
+        { status: 400, message: 'reason 2' },
+      ]);
 
       const unauthResponse = method.responses[2];
       expect(unauthResponse.name).to.equal('401');
@@ -316,6 +319,7 @@ describe('Metadata generation', () => {
         { key: 'x-attKey6', value: [{ y0: 'yt0', y1: 'yt1', y2: 123, y3: true, y4: null }, { y2: 'yt2' }] },
         { key: 'x-attKey7', value: { test: ['testVal', 123, true, null] } },
         { key: 'x-attKey8', value: { test: { testArray: ['testVal1', true, null, ['testVal2', 'testVal3', 123, true, null]] } } },
+        { key: 'x-attKey9', value: 'identifierAttValue' },
       ];
 
       expect(method.extensions).to.deep.equal(expectedExtensions);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1520

Adds support of string identifiers to be passed into `@Extension`'s attribute key.

This is accomplished by adding `ts.isIdentifier` checks into `getExtensions`. If it is an identifier -> `getInitializerValue()`

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**
I added test case to the existing extensions tests.
