### PR TITLE
fix(lint): methodOverride cause lint fail

### DIFF
--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -10,7 +10,9 @@ import { RegisterRoutes } from './routes.js';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }) as RequestHandler);
 app.use(bodyParser.json() as RequestHandler);
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/custom/server.ts
+++ b/tests/fixtures/custom/server.ts
@@ -20,7 +20,9 @@ import { RegisterRoutes } from './customRoutes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/express-dynamic-controllers/server.ts
+++ b/tests/fixtures/express-dynamic-controllers/server.ts
@@ -7,7 +7,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/express-openapi3/server.ts
+++ b/tests/fixtures/express-openapi3/server.ts
@@ -23,7 +23,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/express-router-with-custom-multer/server.ts
+++ b/tests/fixtures/express-router-with-custom-multer/server.ts
@@ -10,7 +10,9 @@ export const router = express.Router();
 app.use('/v1', router);
 router.use(bodyParser.urlencoded({ extended: true }));
 router.use(bodyParser.json());
-router.use(methodOverride());
+router.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 router.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/express-router/server.ts
+++ b/tests/fixtures/express-router/server.ts
@@ -10,7 +10,9 @@ export const router = express.Router();
 app.use('/v1', router);
 router.use(bodyParser.urlencoded({ extended: true }));
 router.use(bodyParser.json());
-router.use(methodOverride());
+router.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 router.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -31,7 +31,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 app.use((req: any, res: any, next: any) => {
   req.stringValue = 'fancyStringForContext';
   next();

--- a/tests/fixtures/inversify-async/server.ts
+++ b/tests/fixtures/inversify-async/server.ts
@@ -9,7 +9,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered

--- a/tests/fixtures/inversify-cpg/server.ts
+++ b/tests/fixtures/inversify-cpg/server.ts
@@ -8,7 +8,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered

--- a/tests/fixtures/inversify-dynamic-container/server.ts
+++ b/tests/fixtures/inversify-dynamic-container/server.ts
@@ -8,7 +8,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered

--- a/tests/fixtures/inversify/server.ts
+++ b/tests/fixtures/inversify/server.ts
@@ -8,7 +8,9 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(methodOverride());
+app.use((req, res, next) => {
+  methodOverride()(req, res, next);
+});
 RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered


### PR DESCRIPTION
The `method-override` package's method somehow causing lint error.
After digging into package version and @types definitions, I cannot find any error on it causing eslint error.
Thus re-wrap the calling with arrow functions.

Interesting thing is that : typescript 5.6.2 is fine.

note: this should fix the CI error @ 2c85ac966392b82f74bea7fb96916d91c949746e and e04625ec4e6ea53d6790412988418a1c681ff16a.
### All Submissions

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?
