### PR TITLE
remove @typescript-eslint/no-unsafe-call

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
     ],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
-    '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -397,7 +397,6 @@ export async function generateSpecAndRoutes(args: SwaggerArgs, metadata?: Tsoa.M
     throw err;
   }
 }
-
 export type RouteGeneratorModule<Config extends ExtendedRoutesConfig> = {
   default: new (
     metadata: Tsoa.Metadata,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -397,3 +397,12 @@ export async function generateSpecAndRoutes(args: SwaggerArgs, metadata?: Tsoa.M
     throw err;
   }
 }
+
+export type RouteGeneratorModule<Config extends ExtendedRoutesConfig> = {
+  default: new (
+    metadata: Tsoa.Metadata,
+    routesConfig: Config,
+  ) => {
+    GenerateCustomRoutes: () => Promise<void>;
+  };
+};

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -47,7 +47,6 @@ async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: 
       try {
         // try as a module import
         const module = (await import(routeGenerator)) as RouteGeneratorModule<Config>;
-
         return new module.default(metadata, routesConfig);
       } catch (_err) {
         // try to find a relative import path

--- a/packages/cli/src/module/generate-routes.ts
+++ b/packages/cli/src/module/generate-routes.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { ExtendedRoutesConfig } from '../cli';
+import { ExtendedRoutesConfig, RouteGeneratorModule } from '../cli';
 import { MetadataGenerator } from '../metadataGeneration/metadataGenerator';
 import { Tsoa } from '@tsoa/runtime';
 import { DefaultRouteGenerator } from '../routeGeneration/defaultRouteGenerator';
@@ -46,12 +46,13 @@ async function getRouteGenerator<Config extends ExtendedRoutesConfig>(metadata: 
     if (typeof routeGenerator === 'string') {
       try {
         // try as a module import
-        const module = await import(routeGenerator);
+        const module = (await import(routeGenerator)) as RouteGeneratorModule<Config>;
+
         return new module.default(metadata, routesConfig);
       } catch (_err) {
         // try to find a relative import path
         const relativePath = path.relative(__dirname, routeGenerator);
-        const module = await import(relativePath);
+        const module = (await import(relativePath)) as RouteGeneratorModule<Config>;
         return new module.default(metadata, routesConfig);
       }
     } else {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -68,13 +68,13 @@ export class SpecGenerator2 extends SpecGenerator {
 
     if (this.config.spec) {
       this.config.specMerging = this.config.specMerging || 'immediate';
-      const mergeFuncs: { [key: string]: any } = {
+      const mergeFuncs: { [key: string]: (spec: UnspecifiedObject, merge: UnspecifiedObject) => UnspecifiedObject } = {
         immediate: Object.assign,
         recursive: mergeAnything,
         deepmerge: (spec: UnspecifiedObject, merge: UnspecifiedObject): UnspecifiedObject => deepMerge(spec, merge),
       };
 
-      spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);
+      spec = mergeFuncs[this.config.specMerging](spec as unknown as UnspecifiedObject, this.config.spec as unknown as UnspecifiedObject) as unknown as Swagger.Spec2;
     }
     if (this.config.schemes) {
       spec.schemes = this.config.schemes;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -39,13 +39,13 @@ export class SpecGenerator3 extends SpecGenerator {
 
     if (this.config.spec) {
       this.config.specMerging = this.config.specMerging || 'immediate';
-      const mergeFuncs: { [key: string]: any } = {
+      const mergeFuncs: { [key: string]: (spec: UnspecifiedObject, merge: UnspecifiedObject) => UnspecifiedObject } = {
         immediate: Object.assign,
         recursive: mergeAnything,
         deepmerge: (spec: UnspecifiedObject, merge: UnspecifiedObject): UnspecifiedObject => deepMerge(spec, merge),
       };
 
-      spec = mergeFuncs[this.config.specMerging](spec, this.config.spec);
+      spec = mergeFuncs[this.config.specMerging](spec as unknown as UnspecifiedObject, this.config.spec as UnspecifiedObject) as unknown as Swagger.Spec3;
     }
 
     return spec;

--- a/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/express/expressTemplateService.ts
@@ -5,6 +5,7 @@ import { FieldErrors } from '../../templateHelpers';
 import { TsoaRoute } from '../../tsoa-route';
 import { ValidateError } from '../../templateHelpers';
 import { TemplateService } from '../templateService';
+import { Readable } from 'node:stream';
 
 type ExpressApiHandlerParameters = {
   methodName: string;
@@ -115,7 +116,7 @@ export class ExpressTemplateService extends TemplateService<ExpressApiHandlerPar
     });
     if (data && typeof data.pipe === 'function' && data.readable && typeof data._read === 'function') {
       response.status(statusCode || 200);
-      data.pipe(response);
+      (data as Readable).pipe(response);
     } else if (data !== null && data !== undefined) {
       response.status(statusCode || 200).json(data);
     } else {

--- a/packages/runtime/src/routeGeneration/templates/templateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/templateService.ts
@@ -26,7 +26,6 @@ export abstract class TemplateService<ApiHandlerParameters, ValidationArgsParame
   protected buildPromise(methodName: string, controller: Controller | object, validatedArgs: any) {
     const prototype = Object.getPrototypeOf(controller);
     const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
-
     return (descriptor!.value as () => Promise<PropertyDescriptor>).apply(controller, validatedArgs);
   }
 }

--- a/packages/runtime/src/routeGeneration/templates/templateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/templateService.ts
@@ -26,6 +26,7 @@ export abstract class TemplateService<ApiHandlerParameters, ValidationArgsParame
   protected buildPromise(methodName: string, controller: Controller | object, validatedArgs: any) {
     const prototype = Object.getPrototypeOf(controller);
     const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
-    return descriptor!.value.apply(controller, validatedArgs);
+
+    return (descriptor!.value as () => Promise<PropertyDescriptor>).apply(controller, validatedArgs);
   }
 }

--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -17,7 +17,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-if (RegisterRoutes) RegisterRoutes(app);
+if (RegisterRoutes) (RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -17,7 +17,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-RegisterRoutes(app);
+if (RegisterRoutes) RegisterRoutes(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -13,7 +13,7 @@ app.use(bodyParser.json() as RequestHandler);
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-app.use((req: any, res: any, next: any) => {
+app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/esm/fixtures/express/server.ts
+++ b/tests/esm/fixtures/express/server.ts
@@ -17,7 +17,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-if (RegisterRoutes) (RegisterRoutes as (app: express.Express) => void)(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/custom/custom-route-generator/serverlessRouteGenerator.ts
+++ b/tests/fixtures/custom/custom-route-generator/serverlessRouteGenerator.ts
@@ -77,7 +77,7 @@ export default class ServerlessRouteGenerator extends AbstractRouteGenerator<Ser
     // This would need to generate a CDK "Stack" that takes the tsoa metadata as input and generates a valid serverless CDK infrastructure stack from template
     const templateFileName = this.options.stackTemplate;
     const fileName = `${this.options.routesDir}/stack.ts`;
-    const context = this.buildContext() as unknown as any;
+    const context = this.buildContext();
     context.controllers = context.controllers.map(controller => {
       controller.actions = controller.actions.map(action => {
         return {

--- a/tests/fixtures/custom/server.ts
+++ b/tests/fixtures/custom/server.ts
@@ -23,7 +23,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-app.use((req: any, res: any, next: any) => {
+app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/custom/server.ts
+++ b/tests/fixtures/custom/server.ts
@@ -27,7 +27,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/express-dynamic-controllers/server.ts
+++ b/tests/fixtures/express-dynamic-controllers/server.ts
@@ -14,7 +14,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/express-dynamic-controllers/server.ts
+++ b/tests/fixtures/express-dynamic-controllers/server.ts
@@ -10,7 +10,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-app.use((req: any, res: any, next: any) => {
+app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/express-openapi3/server.ts
+++ b/tests/fixtures/express-openapi3/server.ts
@@ -30,7 +30,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/express-openapi3/server.ts
+++ b/tests/fixtures/express-openapi3/server.ts
@@ -26,7 +26,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-app.use((req: any, res: any, next: any) => {
+app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/express-root-security/server.ts
+++ b/tests/fixtures/express-root-security/server.ts
@@ -8,7 +8,7 @@ import { RegisterRoutes } from './routes';
 export const app: express.Express = express();
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/express-router-with-custom-multer/server.ts
+++ b/tests/fixtures/express-router-with-custom-multer/server.ts
@@ -13,7 +13,7 @@ router.use(bodyParser.json());
 router.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-router.use((req: any, res: any, next: any) => {
+router.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/express-router-with-custom-multer/server.ts
+++ b/tests/fixtures/express-router-with-custom-multer/server.ts
@@ -20,7 +20,7 @@ router.use((req: any, res: any, next: express.NextFunction) => {
 
 import multer = require('multer');
 
-RegisterRoutes(router, {
+(RegisterRoutes as (router: express.Router, options: { multer: ReturnType<typeof multer> }) => void)(router, {
   multer: multer({
     limits: {
       fieldNameSize: 120,

--- a/tests/fixtures/express-router/server.ts
+++ b/tests/fixtures/express-router/server.ts
@@ -13,7 +13,7 @@ router.use(bodyParser.json());
 router.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-router.use((req: any, res: any, next: any) => {
+router.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/express-router/server.ts
+++ b/tests/fixtures/express-router/server.ts
@@ -18,7 +18,7 @@ router.use((req: any, res: any, next: express.NextFunction) => {
   next();
 });
 
-RegisterRoutes(router);
+(RegisterRoutes as (router: express.Router) => void)(router);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -34,7 +34,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-app.use((req: any, res: any, next: any) => {
+app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });

--- a/tests/fixtures/express/server.ts
+++ b/tests/fixtures/express/server.ts
@@ -38,7 +38,7 @@ app.use((req: any, res: any, next: express.NextFunction) => {
   req.stringValue = 'fancyStringForContext';
   next();
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -1,4 +1,4 @@
-import { Server } from '@hapi/hapi';
+import { Server, ServerApplicationState } from '@hapi/hapi';
 import '../controllers/rootController';
 
 import '../controllers/optionsController';
@@ -23,7 +23,7 @@ import { RegisterRoutes } from './routes';
 
 export const server = new Server({});
 
-RegisterRoutes(server);
+(RegisterRoutes as (app: Server<ServerApplicationState>) => void)(server);
 
 server.start().catch(err => {
   if (err) {

--- a/tests/fixtures/hapi/server.ts
+++ b/tests/fixtures/hapi/server.ts
@@ -1,4 +1,4 @@
-import { Server, ServerApplicationState } from '@hapi/hapi';
+import { Server } from '@hapi/hapi';
 import '../controllers/rootController';
 
 import '../controllers/optionsController';
@@ -23,7 +23,7 @@ import { RegisterRoutes } from './routes';
 
 export const server = new Server({});
 
-(RegisterRoutes as (app: Server<ServerApplicationState>) => void)(server);
+(RegisterRoutes as (app: Server) => void)(server);
 
 server.start().catch(err => {
   if (err) {

--- a/tests/fixtures/inversify-async/server.ts
+++ b/tests/fixtures/inversify-async/server.ts
@@ -12,7 +12,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Router) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/inversify-cpg/server.ts
+++ b/tests/fixtures/inversify-cpg/server.ts
@@ -11,7 +11,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/inversify-dynamic-container/server.ts
+++ b/tests/fixtures/inversify-dynamic-container/server.ts
@@ -11,7 +11,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Express) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/tests/fixtures/inversify/server.ts
+++ b/tests/fixtures/inversify/server.ts
@@ -11,7 +11,7 @@ app.use(bodyParser.json());
 app.use((req, res, next) => {
   methodOverride()(req, res, next);
 });
-RegisterRoutes(app);
+(RegisterRoutes as (app: express.Router) => void)(app);
 
 // It's important that this come after the main routes are registered
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/tests/fixtures/koa-multer-options/server.ts
+++ b/tests/fixtures/koa-multer-options/server.ts
@@ -11,7 +11,7 @@ app.use(bodyParser());
 
 const router = new KoaRouter();
 
-RegisterRoutes(router);
+(RegisterRoutes as (router: KoaRouter) => void)(router);
 
 // It's important that this come after the main routes are registered
 app.use(async (context, next) => {

--- a/tests/fixtures/koa/server.ts
+++ b/tests/fixtures/koa/server.ts
@@ -29,7 +29,7 @@ app.use(bodyParser());
 
 const router = new KoaRouter();
 
-RegisterRoutes(router);
+(RegisterRoutes as (router: KoaRouter) => void)(router);
 
 // It's important that this come after the main routes are registered
 app.use(async (context, next) => {

--- a/tests/fixtures/koaNoAdditional/server.ts
+++ b/tests/fixtures/koaNoAdditional/server.ts
@@ -25,7 +25,7 @@ app.use(bodyParser());
 
 const router = new KoaRouter();
 
-RegisterRoutes(router);
+(RegisterRoutes as (router: KoaRouter) => void)(router);
 
 // It's important that this come after the main routes are registered
 app.use(async (context, next) => {

--- a/tests/integration/koa-multer-options.spec.ts
+++ b/tests/integration/koa-multer-options.spec.ts
@@ -19,7 +19,7 @@ describe('Koa Server (with multerOpts)', () => {
         expect(res.body.originalname).to.equal('package.json');
         expect(res.body.encoding).to.be.not.undefined;
         expect(res.body.mimetype).to.equal('application/json');
-        expect(res.body.path).to.satisfy(value => value.startsWith(os.tmpdir()));
+        expect(res.body.path).to.satisfy((value: string) => value.startsWith(os.tmpdir()));
       });
     });
 
@@ -31,7 +31,7 @@ describe('Koa Server (with multerOpts)', () => {
         expect(res.body.fieldname).to.equal('someFile');
         expect(res.body.originalname).to.equal('lessThan8mb');
         expect(res.body.encoding).to.be.not.undefined;
-        expect(res.body.path).to.satisfy(value => value.startsWith(os.tmpdir()));
+        expect(res.body.path).to.satisfy((value: string) => value.startsWith(os.tmpdir()));
         unlinkSync('./lessThan8mb');
       });
     });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -3272,7 +3272,7 @@ describe('Definition generation', () => {
             throw new Error(`There was no ${aPropertyName} schema generated for the ${currentSpec.specName}`);
           }
           it(`should produce a valid schema for the ${aPropertyName} property on ${interfaceName} for the ${currentSpec.specName}`, () => {
-            assertionsPerProperty[aPropertyName](aPropertyName, propertySchema);
+            assertionsPerProperty[aPropertyName as keyof TestModel](aPropertyName, propertySchema);
           });
         });
 

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1056,7 +1056,7 @@ describe('Metadata generation', () => {
 
     if (!controller || !controllerIntDefault) throw new Error('AnnotatedTypesController not defined!');
 
-    const getControllerNumberMethods = controller => {
+    const getControllerNumberMethods = (controller: Tsoa.Controller) => {
       const getDefault = controller.methods.find(method => method.name === 'getDefault');
       const getDouble = controller.methods.find(method => method.name === 'getDouble');
       const getInteger = controller.methods.find(method => method.name === 'getInteger');

--- a/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/getRoutes.spec.ts
@@ -43,7 +43,7 @@ describe('GET route generation', () => {
       throw new Error('No operation parameters.');
     }
 
-    return get.parameters as any;
+    return get.parameters;
   };
 
   it('should generate a path for a GET route with no path argument', () => {

--- a/tests/unit/utilities/verifyParameter.ts
+++ b/tests/unit/utilities/verifyParameter.ts
@@ -9,7 +9,15 @@ export function VerifyPathableParameter(params: Swagger.Parameter[], paramValue:
   }
 }
 
-export function VerifyPathableStringParameter(params: Swagger.PathParameter[], paramValue: string, paramType: string, paramIn: string, min?: number, max?: number, pattern?: string) {
+export function VerifyPathableStringParameter(
+  params: Swagger.PathParameter[] | Swagger.Parameter2[],
+  paramValue: string,
+  paramType: string,
+  paramIn: string,
+  min?: number,
+  max?: number,
+  pattern?: string,
+) {
   const parameter = verifyParameter(params, paramValue, paramIn);
   expect(parameter.type).to.equal(paramType);
   if (min) {
@@ -23,7 +31,15 @@ export function VerifyPathableStringParameter(params: Swagger.PathParameter[], p
   }
 }
 
-export function VerifyPathableNumberParameter(params: Swagger.PathParameter[], paramValue: string, paramType: string, paramIn: string, formatType?: string, min?: number, max?: number) {
+export function VerifyPathableNumberParameter(
+  params: Swagger.PathParameter[] | Swagger.Parameter2[],
+  paramValue: string,
+  paramType: string,
+  paramIn: string,
+  formatType?: string,
+  min?: number,
+  max?: number,
+) {
   const parameter = verifyParameter(params, paramValue, paramIn);
   expect(parameter.type).to.equal(paramType);
   if (formatType) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [ ] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

contributes to #1165 by removing @typescript-eslint/no-unsafe-call

note: had to assert `RegisterRoutes` in the test/*/server.ts files because seems like when routes.ts regenerates, RegisterRoutes would default briefly to any and linting would fail.
