### PR TITLE
refactor(specGenerator)/remove request-prop param

### DIFF
--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -192,7 +192,7 @@ export class SpecGenerator2 extends SpecGenerator {
 
     pathMethod.parameters = method.parameters
       .filter(p => {
-        return ['request', 'body-prop', 'res', 'queries'].indexOf(p.in) === -1;
+        return ['request', 'body-prop', 'res', 'queries', 'request-prop'].indexOf(p.in) === -1;
       })
       .map(p => this.buildParameter(p));
 

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -282,7 +282,7 @@ export class SpecGenerator3 extends SpecGenerator {
 
     pathMethod.parameters = method.parameters
       .filter(p => {
-        return ['body', 'formData', 'request', 'body-prop', 'res', 'queries'].indexOf(p.in) === -1;
+        return ['body', 'formData', 'request', 'body-prop', 'res', 'queries', 'request-prop'].indexOf(p.in) === -1;
       })
       .map(p => this.buildParameter(p));
 

--- a/tests/fixtures/controllers/parameterController.ts
+++ b/tests/fixtures/controllers/parameterController.ts
@@ -1,4 +1,4 @@
-import { Body, BodyProp, Get, Header, Path, Post, Query, Request, Route, Res, TsoaResponse, Deprecated, Queries, RequestProp } from '@tsoa/runtime';
+import { Body, BodyProp, Get, Header, Path, Post, Query, Request, Route, Res, TsoaResponse, Deprecated, Queries, RequestProp, FormField } from '@tsoa/runtime';
 import { Gender, ParameterTestModel } from '../testModel';
 
 @Route('ParameterTest')
@@ -308,12 +308,27 @@ export class ParameterController {
     });
   }
 
-  @Get('ParamaterQueyAnyType')
+  @Get('ParameterHeaderStringType')
+  public async headerStringType(@Header() header: string): Promise<void> {
+    //
+  }
+
+  @Get('FormDataStringType')
+  public async formData(@FormField() data: string): Promise<void> {
+    //
+  }
+
+  @Get('Path/{test}')
+  public async pathStringType(@Path() test: string): Promise<void> {
+    //
+  }
+
+  @Get('ParamaterQueryAnyType')
   public async queryAnyType(@Query() name: any): Promise<void> {
     //
   }
 
-  @Post('ParamaterQueyArray')
+  @Post('ParamaterQueryArray')
   public async queyArray(@Query() name: string[]): Promise<void> {
     //
   }

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -820,4 +820,19 @@ describe('Schema details generation', () => {
       expect(errToTest!.message).to.match(/Swagger 2.0 does not support "openIdConnect" security scheme/);
     });
   });
+
+  describe('should exclude @RequestProp', () => {
+    it('should exclude request-prop from method parameters', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/RequestProps'].post?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(0);
+
+      method.forEach(p => {
+        expect(p.in).to.not.equal('request-prop');
+      });
+    });
+  });
 });

--- a/tests/unit/swagger/schemaDetails.spec.ts
+++ b/tests/unit/swagger/schemaDetails.spec.ts
@@ -821,6 +821,63 @@ describe('Schema details generation', () => {
     });
   });
 
+  describe('should include valid params', () => {
+    it('should include query', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/ParamaterQueryAnyType'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('query');
+    });
+
+    it('should include body', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/ParamaterBodyAnyType'].post?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('body');
+    });
+
+    it('should include header', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/ParameterHeaderStringType'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('header');
+    });
+
+    it('should include path', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/Path/{test}'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('path');
+    });
+
+    it('should include formData', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator2(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/FormDataStringType'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('formData');
+    });
+  });
+
   describe('should exclude @RequestProp', () => {
     it('should exclude request-prop from method parameters', () => {
       const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -4752,4 +4752,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(currentSpec.paths['/ParameterTest/Inline1'].post?.requestBody?.content['application/json'].schema?.title).to.equal(undefined);
     });
   });
+
+  describe('should exclude @RequestProp', () => {
+    it('should exclude request-prop from method parameters', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/RequestProps'].post?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(0);
+
+      method.forEach(p => {
+        expect(p.in).to.not.equal('request-prop');
+      });
+    });
+  });
 });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -4753,6 +4753,41 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
     });
   });
 
+  describe('should include valid params', () => {
+    it('should include query', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/ParamaterQueryAnyType'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('query');
+    });
+
+    it('should include header', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/ParameterHeaderStringType'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('header');
+    });
+
+    it('should include path', () => {
+      const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();
+      const spec = new SpecGenerator3(metadata, getDefaultExtendedOptions()).GetSpec();
+
+      const method = spec.paths['/ParameterTest/Path/{test}'].get?.parameters ?? [];
+
+      expect(method).to.have.lengthOf(1);
+      const queryParam = method[0];
+      expect(queryParam.in).to.equal('path');
+    });
+  });
+
   describe('should exclude @RequestProp', () => {
     it('should exclude request-prop from method parameters', () => {
       const metadata = new MetadataGenerator('./fixtures/controllers/parameterController.ts').Generate();


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [ ] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #1663

adjusted spec generators to match `in` params (removed request-prop)

https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md

**Test plan**

added test cases for both SpecGenerator2 and SpecGenerator3 to ensure request-props aren't added to the spec.
