### PR TITLE
perf: skip validation on default value

### DIFF
--- a/packages/runtime/src/routeGeneration/templateHelpers.ts
+++ b/packages/runtime/src/routeGeneration/templateHelpers.ts
@@ -53,7 +53,10 @@ export class ValidationService {
         return value;
       }
     }
-
+    // performance improvement: if the provided value is the default value, no need to validate
+    if( property.default === value ){
+        return value;
+    }
     switch (property.dataType) {
       case 'string':
         return this.validateString(name, value, fieldErrors, property.validators as StringValidator, parent);

--- a/packages/runtime/src/routeGeneration/templateHelpers.ts
+++ b/packages/runtime/src/routeGeneration/templateHelpers.ts
@@ -54,7 +54,7 @@ export class ValidationService {
       }
     }
     // performance improvement: if the provided value is the default value, no need to validate
-    if( property.default === value ){
+    if(property.default === value){
         return value;
     }
     switch (property.dataType) {

--- a/tests/unit/swagger/templateHelpers.spec.ts
+++ b/tests/unit/swagger/templateHelpers.spec.ts
@@ -325,7 +325,7 @@ describe('ValidationService', () => {
   describe('Param validate', () => {
     it('should apply defaults for optional properties', () => {
       const value = undefined;
-      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'integer', default: '666', required: false, validators: {} };
+      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'integer', default: 666, required: false, validators: {} };
       const result = new ValidationService(
         {},
         {
@@ -351,7 +351,7 @@ describe('ValidationService', () => {
 
     it('should apply defaults for required properties', () => {
       const value = undefined;
-      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'integer', default: '666', required: true, validators: {} };
+      const propertySchema: TsoaRoute.PropertySchema = { dataType: 'integer', default: 666, required: true, validators: {} };
       const result = new ValidationService(
         {},
         {


### PR DESCRIPTION
performance improvement: if the provided value is the default value, no need to validate
