### PR TITLE
title: add from annotation

### DIFF
--- a/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/enumTransformer.ts
@@ -28,6 +28,7 @@ export class EnumTransformer extends Transformer {
     const enumVarnames = first.enumVarnames ? (second.enumVarnames ? [...first.enumVarnames, ...second.enumVarnames] : first.enumVarnames) : second.enumVarnames;
 
     const example = first.example || second.example;
+    const title = first.title || second.title;
 
     return {
       dataType: 'refEnum',
@@ -37,6 +38,7 @@ export class EnumTransformer extends Transformer {
       refName: first.refName,
       deprecated,
       example,
+      ...(title && { title }),
     };
   }
 
@@ -57,6 +59,7 @@ export class EnumTransformer extends Transformer {
     };
     const enums = declaration.members.map(e => resolver.current.typeChecker.getConstantValue(e)).filter(isNotUndefined);
     const enumVarnames = declaration.members.map(e => e.name.getText()).filter(isNotUndefined);
+    const title = resolver.getNodeTitle(declaration);
 
     return {
       dataType: 'refEnum',
@@ -66,6 +69,7 @@ export class EnumTransformer extends Transformer {
       enumVarnames,
       refName: enumName,
       deprecated: isExistJSDocTag(declaration, tag => tag.tagName.text === 'deprecated'),
+      ...(title && { title }),
     };
   }
 

--- a/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
@@ -7,7 +7,7 @@ import { GenerateMetadataError } from '../exceptions';
 import { TypeResolver } from '../typeResolver';
 import { getInitializerValue } from '../initializer-value';
 import { getPropertyValidators } from '../../utils/validatorUtils';
-import { getJSDocComment, isExistJSDocTag } from '../../utils/jsDocUtils';
+import { isExistJSDocTag } from '../../utils/jsDocUtils';
 import { isDecorator } from '../../utils/decoratorUtils';
 import { throwUnless } from '../../utils/flowUtils';
 
@@ -68,7 +68,7 @@ export class PropertyTransformer extends Transformer {
       type: new TypeResolver(propertySignature.type, resolver.current, propertySignature.type.parent, resolver.context).resolve(),
       validators: getPropertyValidators(propertySignature) || {},
       deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
-      title: getJSDocComment(propertySignature, 'title'),
+      title: resolver.getNodeTitle(propertySignature),
       extensions: resolver.getNodeExtension(propertySignature),
     };
     return property;
@@ -108,7 +108,7 @@ export class PropertyTransformer extends Transformer {
       validators: getPropertyValidators(propertyDeclaration) || {},
       // class properties and constructor parameters may be deprecated either via jsdoc annotation or decorator
       deprecated: isExistJSDocTag(propertyDeclaration, tag => tag.tagName.text === 'deprecated') || isDecorator(propertyDeclaration, identifier => identifier.text === 'Deprecated'),
-      title: getJSDocComment(propertyDeclaration, 'title'),
+      title: resolver.getNodeTitle(propertyDeclaration),
       extensions: resolver.getNodeExtension(propertyDeclaration),
     };
     return property;

--- a/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/propertyTransformer.ts
@@ -7,7 +7,7 @@ import { GenerateMetadataError } from '../exceptions';
 import { TypeResolver } from '../typeResolver';
 import { getInitializerValue } from '../initializer-value';
 import { getPropertyValidators } from '../../utils/validatorUtils';
-import { isExistJSDocTag } from '../../utils/jsDocUtils';
+import { getJSDocComment, isExistJSDocTag } from '../../utils/jsDocUtils';
 import { isDecorator } from '../../utils/decoratorUtils';
 import { throwUnless } from '../../utils/flowUtils';
 
@@ -68,6 +68,7 @@ export class PropertyTransformer extends Transformer {
       type: new TypeResolver(propertySignature.type, resolver.current, propertySignature.type.parent, resolver.context).resolve(),
       validators: getPropertyValidators(propertySignature) || {},
       deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
+      title: getJSDocComment(propertySignature, 'title'),
       extensions: resolver.getNodeExtension(propertySignature),
     };
     return property;
@@ -107,6 +108,7 @@ export class PropertyTransformer extends Transformer {
       validators: getPropertyValidators(propertyDeclaration) || {},
       // class properties and constructor parameters may be deprecated either via jsdoc annotation or decorator
       deprecated: isExistJSDocTag(propertyDeclaration, tag => tag.tagName.text === 'deprecated') || isDecorator(propertyDeclaration, identifier => identifier.text === 'Deprecated'),
+      title: getJSDocComment(propertyDeclaration, 'title'),
       extensions: resolver.getNodeExtension(propertyDeclaration),
     };
     return property;

--- a/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
@@ -63,12 +63,12 @@ export class ReferenceTransformer extends Transformer {
     const result: Tsoa.RefObjectType = {
       dataType: 'refObject',
       description,
-      title,
       properties,
       additionalProperties,
       refName: first.refName,
       deprecated,
       example,
+      ...(title && { title }),
     };
 
     return result;
@@ -82,12 +82,12 @@ export class ReferenceTransformer extends Transformer {
       dataType: 'refAlias',
       default: TypeResolver.getDefault(declaration),
       description: resolver.getNodeDescription(declaration),
-      title,
       refName: refTypeName,
       format: resolver.getNodeFormat(declaration),
       type: new TypeResolver(declaration.type, resolver.current, declaration, resolver.context, resolver.referencer || referencer).resolve(),
       validators: getPropertyValidators(declaration) || {},
       ...(example && { example }),
+      ...(title && { title }),
     };
     return referenceType;
   }

--- a/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
+++ b/packages/cli/src/metadataGeneration/transformer/referenceTransformer.ts
@@ -59,9 +59,11 @@ export class ReferenceTransformer extends Transformer {
         : first.additionalProperties
       : second.additionalProperties;
 
+    const title = first.title || second.title;
     const result: Tsoa.RefObjectType = {
       dataType: 'refObject',
       description,
+      title,
       properties,
       additionalProperties,
       refName: first.refName,
@@ -75,10 +77,12 @@ export class ReferenceTransformer extends Transformer {
   public transform(declaration: TypeAliasDeclaration, refTypeName: string, resolver: TypeResolver, referencer?: Type): Tsoa.ReferenceType {
     const example = resolver.getNodeExample(declaration);
 
+    const title = resolver.getNodeTitle(declaration);
     const referenceType: Tsoa.ReferenceType = {
       dataType: 'refAlias',
       default: TypeResolver.getDefault(declaration),
       description: resolver.getNodeDescription(declaration),
+      title,
       refName: refTypeName,
       format: resolver.getNodeFormat(declaration),
       type: new TypeResolver(declaration.type, resolver.current, declaration, resolver.context, resolver.referencer || referencer).resolve(),

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -875,6 +875,7 @@ export class TypeResolver {
     const example = this.getNodeExample(modelType);
     const description = this.getNodeDescription(modelType);
     const deprecated = isExistJSDocTag(modelType, tag => tag.tagName.text === 'deprecated') || isDecorator(modelType, identifier => identifier.text === 'Deprecated');
+    const title = this.getNodeTitle(modelType);
 
     // Handle toJSON methods
     throwUnless(modelType.name, new GenerateMetadataError("Can't get Symbol from anonymous class", modelType));
@@ -897,6 +898,7 @@ export class TypeResolver {
         validators: {},
         deprecated,
         ...(example && { example }),
+        ...(title && { title }),
       };
       return referenceType;
     }
@@ -913,6 +915,7 @@ export class TypeResolver {
       refName: refTypeName,
       deprecated,
       ...(example && { example }),
+      ...(title && { title }),
     };
 
     referenceType.properties = referenceType.properties.concat(properties);

--- a/packages/cli/src/metadataGeneration/typeResolver.ts
+++ b/packages/cli/src/metadataGeneration/typeResolver.ts
@@ -117,6 +117,7 @@ export class TypeResolver {
           type,
           validators: getPropertyValidators(propertySignature) || {},
           deprecated: isExistJSDocTag(propertySignature, tag => tag.tagName.text === 'deprecated'),
+          title: this.getNodeTitle(propertySignature),
           extensions: this.getNodeExtension(propertySignature),
         };
 
@@ -1161,6 +1162,10 @@ export class TypeResolver {
 
   public getNodeFormat(node: ts.Node) {
     return getJSDocComment(node, 'format');
+  }
+
+  public getNodeTitle(node: ts.Node) {
+    return getJSDocComment(node, 'title');
   }
 
   public getPropertyName(prop: ts.PropertySignature | ts.PropertyDeclaration | ts.ParameterDeclaration): string {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -107,6 +107,10 @@ export class SpecGenerator2 extends SpecGenerator {
         if (referenceType.example) {
           definitions[referenceType.refName].example = referenceType.example;
         }
+
+        if (referenceType.title) {
+          definitions[referenceType.refName].title = referenceType.title;
+        }
       } else if (referenceType.dataType === 'refEnum') {
         definitions[referenceType.refName] = {
           description: referenceType.description,
@@ -118,6 +122,9 @@ export class SpecGenerator2 extends SpecGenerator {
         }
         if (referenceType.example) {
           definitions[referenceType.refName].example = referenceType.example;
+        }
+        if (referenceType.title) {
+          definitions[referenceType.refName].title = referenceType.title;
         }
       } else if (referenceType.dataType === 'refAlias') {
         const swaggerType = this.getSwaggerType(referenceType.type);
@@ -137,6 +144,7 @@ export class SpecGenerator2 extends SpecGenerator {
           example: referenceType.example,
           format: format || swaggerType.format,
           description: referenceType.description,
+          ...(referenceType.title && { title: referenceType.title }),
           ...validators,
         };
       } else {

--- a/packages/cli/src/swagger/specGenerator2.ts
+++ b/packages/cli/src/swagger/specGenerator2.ts
@@ -424,6 +424,10 @@ export class SpecGenerator2 extends SpecGenerator {
         swaggerType['x-deprecated'] = true;
       }
 
+      if (property.title) {
+        swaggerType.title = property.title;
+      }
+
       if (property.extensions) {
         property.extensions.forEach(property => {
           swaggerType[property.key] = property.value;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -158,7 +158,6 @@ export class SpecGenerator3 extends SpecGenerator {
         const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
         schema[referenceType.refName] = {
           description: referenceType.description,
-          title: referenceType.title,
           properties: this.buildProperties(referenceType.properties),
           required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
           type: 'object',
@@ -174,6 +173,10 @@ export class SpecGenerator3 extends SpecGenerator {
 
         if (referenceType.example) {
           schema[referenceType.refName].example = referenceType.example;
+        }
+
+        if (referenceType.title) {
+          schema[referenceType.refName].title = referenceType.title;
         }
       } else if (referenceType.dataType === 'refEnum') {
         const enumTypes = this.determineTypesUsedInEnum(referenceType.enums);
@@ -223,6 +226,7 @@ export class SpecGenerator3 extends SpecGenerator {
           example: referenceType.example,
           format: format || swaggerType.format,
           description: referenceType.description,
+          ...(referenceType.title && { title: referenceType.title }),
           ...validators,
         };
       } else {

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -208,6 +208,9 @@ export class SpecGenerator3 extends SpecGenerator {
         if (referenceType.example) {
           schema[referenceType.refName].example = referenceType.example;
         }
+        if (referenceType.title) {
+          schema[referenceType.refName].title = referenceType.title;
+        }
       } else if (referenceType.dataType === 'refAlias') {
         const swaggerType = this.getSwaggerType(referenceType.type);
         const format = referenceType.format as Swagger.DataFormat;

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -158,6 +158,7 @@ export class SpecGenerator3 extends SpecGenerator {
         const required = referenceType.properties.filter(p => this.isRequiredWithoutDefault(p) && !this.hasUndefined(p)).map(p => p.name);
         schema[referenceType.refName] = {
           description: referenceType.description,
+          title: referenceType.title,
           properties: this.buildProperties(referenceType.properties),
           required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
           type: 'object',

--- a/packages/cli/src/swagger/specGenerator3.ts
+++ b/packages/cli/src/swagger/specGenerator3.ts
@@ -588,6 +588,10 @@ export class SpecGenerator3 extends SpecGenerator {
         swaggerType.deprecated = true;
       }
 
+      if (property.title) {
+        swaggerType.title = property.title;
+      }
+
       if (property.extensions) {
         property.extensions.forEach(property => {
           swaggerType[property.key] = property.value;

--- a/packages/runtime/src/metadataGeneration/tsoa.ts
+++ b/packages/runtime/src/metadataGeneration/tsoa.ts
@@ -49,6 +49,7 @@ export namespace Tsoa {
     validators: Validators;
     deprecated: boolean;
     exampleLabels?: Array<string | undefined>;
+    title?: string;
   }
 
   export interface ResParameter extends Response, Parameter {
@@ -98,6 +99,7 @@ export namespace Tsoa {
     validators: Validators;
     deprecated: boolean;
     extensions?: Extension[];
+    title?: string;
   }
 
   export type TypeStringLiteral =
@@ -269,6 +271,7 @@ export namespace Tsoa {
     refName: string;
     example?: unknown;
     deprecated: boolean;
+    title?: string;
   }
 
   export interface UnionType extends TypeBase {

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -182,6 +182,7 @@ export interface TestModel extends Model {
   // prettier-ignore
   stringAndBoolArray?: Array<(string | boolean)>;
   testModelWithAnnotations?: TestModelWithAnnotations;
+  enumWithTitle?: EnumWithTitle;
 
   /**
    * @example {
@@ -1305,4 +1306,12 @@ interface TestModelWithAnnotations {
    * @title Title annotation for property
    */
   param: string;
+}
+
+/**
+ * @title Title annotation for enum
+ */
+export enum EnumWithTitle {
+  Value1 = 'value1',
+  Value2 = 'value2',
 }

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -181,6 +181,7 @@ export interface TestModel extends Model {
 
   // prettier-ignore
   stringAndBoolArray?: Array<(string | boolean)>;
+  testModelWithAnnotations?: TestModelWithAnnotations;
 
   /**
    * @example {
@@ -810,9 +811,6 @@ export interface UserResponseModel {
   name: string;
 }
 
-/**
- * @title TitleTestModel
- */
 export class ParameterTestModel {
   public firstname!: string;
   public lastname!: string;
@@ -1298,3 +1296,13 @@ type OrderDirection = 'asc' | 'desc';
 type OrderOptions<E> = `${keyof E & string}:${OrderDirection}`;
 
 type TemplateLiteralString = OrderOptions<ParameterTestModel>;
+
+/**
+ * @title Title annotation for model
+ */
+interface TestModelWithAnnotations {
+  /**
+   * @title Title annotation for property
+   */
+  param: string;
+}

--- a/tests/fixtures/testModel.ts
+++ b/tests/fixtures/testModel.ts
@@ -810,6 +810,9 @@ export interface UserResponseModel {
   name: string;
 }
 
+/**
+ * @title TitleTestModel
+ */
 export class ParameterTestModel {
   public firstname!: string;
   public lastname!: string;

--- a/tests/unit/metadataGeneration/transformer/enumTransformer.spec.ts
+++ b/tests/unit/metadataGeneration/transformer/enumTransformer.spec.ts
@@ -207,6 +207,57 @@ describe('EnumTransformer - Null Safety', () => {
         example: 'example1', // First example should be used
       });
     });
+
+    it('should merge title property correctly', () => {
+      const first: Tsoa.RefEnumType = {
+        dataType: 'refEnum',
+        refName: 'TestEnum',
+        enums: ['value1'],
+        enumVarnames: ['VALUE1'],
+        description: 'First enum',
+        deprecated: false,
+        title: 'First Title',
+      };
+
+      const second: Tsoa.RefEnumType = {
+        dataType: 'refEnum',
+        refName: 'TestEnum',
+        enums: ['value2'],
+        enumVarnames: ['VALUE2'],
+        description: 'Second enum',
+        deprecated: false,
+        title: 'Second Title',
+      };
+
+      const result = EnumTransformer.merge(first, second);
+
+      expect(result.title).to.equal('First Title'); // First title should be used
+    });
+
+    it('should use second title if first is undefined', () => {
+      const first: Tsoa.RefEnumType = {
+        dataType: 'refEnum',
+        refName: 'TestEnum',
+        enums: ['value1'],
+        enumVarnames: ['VALUE1'],
+        description: 'First enum',
+        deprecated: false,
+      };
+
+      const second: Tsoa.RefEnumType = {
+        dataType: 'refEnum',
+        refName: 'TestEnum',
+        enums: ['value2'],
+        enumVarnames: ['VALUE2'],
+        description: 'Second enum',
+        deprecated: false,
+        title: 'Second Title',
+      };
+
+      const result = EnumTransformer.merge(first, second);
+
+      expect(result.title).to.equal('Second Title');
+    });
   });
 
   describe('mergeMany method', () => {

--- a/tests/unit/metadataGeneration/transformer/referenceTransformer.spec.ts
+++ b/tests/unit/metadataGeneration/transformer/referenceTransformer.spec.ts
@@ -99,7 +99,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         description: 'First object\nSecond object',
         deprecated: false,
         example: undefined,
-        title: undefined,
       });
     });
 
@@ -160,7 +159,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         },
         description: 'First object\nSecond object',
         deprecated: false,
-        title: undefined,
         example: undefined,
       });
     });
@@ -207,7 +205,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object',
         deprecated: false,
-        title: undefined,
         example: 'example1', // First example should be used
       });
     });
@@ -252,7 +249,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object',
         deprecated: true, // Should be true if any is deprecated
-        title: undefined,
         example: undefined,
       });
     });
@@ -312,7 +308,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
       expect(result).to.deep.equal({
         ...refObject,
         description: 'Test object\nTest object',
-        title: undefined,
         example: undefined,
       });
     });
@@ -370,7 +365,6 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object\nThird object',
         deprecated: true,
-        title: undefined,
         example: undefined,
       });
     });

--- a/tests/unit/metadataGeneration/transformer/referenceTransformer.spec.ts
+++ b/tests/unit/metadataGeneration/transformer/referenceTransformer.spec.ts
@@ -99,6 +99,7 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         description: 'First object\nSecond object',
         deprecated: false,
         example: undefined,
+        title: undefined,
       });
     });
 
@@ -159,6 +160,7 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         },
         description: 'First object\nSecond object',
         deprecated: false,
+        title: undefined,
         example: undefined,
       });
     });
@@ -205,6 +207,7 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object',
         deprecated: false,
+        title: undefined,
         example: 'example1', // First example should be used
       });
     });
@@ -249,12 +252,50 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object',
         deprecated: true, // Should be true if any is deprecated
+        title: undefined,
         example: undefined,
       });
     });
   });
 
   describe('mergeManyRefObj method', () => {
+    it('should merge title field from refObjects', () => {
+      const refObjects: Tsoa.RefObjectType[] = [
+        {
+          dataType: 'refObject',
+          refName: 'TestObject',
+          properties: [createProperty('id', { dataType: 'string' })],
+          additionalProperties: false as any,
+          description: 'First object',
+          deprecated: false,
+          title: 'FirstTitle',
+        },
+        {
+          dataType: 'refObject',
+          refName: 'TestObject',
+          properties: [createProperty('name', { dataType: 'string' })],
+          additionalProperties: false as any,
+          description: 'Second object',
+          deprecated: false,
+          title: 'SecondTitle',
+        },
+      ];
+
+      const result = ReferenceTransformer.mergeManyRefObj(refObjects);
+
+      expect(result.title).to.equal('FirstTitle');
+      expect(result).to.include({
+        dataType: 'refObject',
+        refName: 'TestObject',
+        description: 'First object\nSecond object',
+        deprecated: false,
+        example: undefined,
+      });
+      expect(result.properties).to.deep.include.members([
+        { name: 'id', type: { dataType: 'string' }, required: true },
+        { name: 'name', type: { dataType: 'string' }, required: true },
+      ]);
+    });
     it('should handle single refObject', () => {
       const refObject: Tsoa.RefObjectType = {
         dataType: 'refObject',
@@ -271,6 +312,7 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
       expect(result).to.deep.equal({
         ...refObject,
         description: 'Test object\nTest object',
+        title: undefined,
         example: undefined,
       });
     });
@@ -328,6 +370,7 @@ describe('ReferenceTransformer - Empty Array Handling', () => {
         additionalProperties: false as any,
         description: 'First object\nSecond object\nThird object',
         deprecated: true,
+        title: undefined,
         example: undefined,
       });
     });

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1632,6 +1632,12 @@ describe('Definition generation', () => {
           testModelWithAnnotations: () => {
             // schema is validated in OpenAPI 3 specific tests
           },
+          enumWithTitle: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/definitions/EnumWithTitle', `for property ${propertyName}.$ref`);
+
+            const schema = getValidatedDefinition('EnumWithTitle', currentSpec);
+            expect(schema.title).to.eq('Title annotation for enum');
+          },
           extensionComment: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq(
               {

--- a/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/definitions.spec.ts
@@ -1629,6 +1629,9 @@ describe('Definition generation', () => {
             expect(propertySchema.description).to.eq(undefined, `for property ${propertyName}.description`);
             expect(propertySchema).to.not.haveOwnProperty('additionalProperties', `for property ${propertyName}`);
           },
+          testModelWithAnnotations: () => {
+            // schema is validated in OpenAPI 3 specific tests
+          },
           extensionComment: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq(
               {

--- a/tests/unit/swagger/parameterDetails3.spec.ts
+++ b/tests/unit/swagger/parameterDetails3.spec.ts
@@ -57,14 +57,6 @@ describe('Parameter generation for OpenAPI 3.0.0', () => {
           `for spec ${forSpec(currentSpec)}`,
         );
       });
-
-      it('should include title in schema if present', () => {
-        const schemas = currentSpec.spec.components.schemas;
-        const modelSchema = schemas ? schemas['ParameterTestModel'] : undefined;
-        if (modelSchema && modelSchema.title) {
-          expect(modelSchema.title).to.be.equal('TitleTestModel', `Title should be 'TitleTestModel' ${forSpec(currentSpec)}`);
-        }
-      });
     });
   });
 });

--- a/tests/unit/swagger/parameterDetails3.spec.ts
+++ b/tests/unit/swagger/parameterDetails3.spec.ts
@@ -57,6 +57,14 @@ describe('Parameter generation for OpenAPI 3.0.0', () => {
           `for spec ${forSpec(currentSpec)}`,
         );
       });
+
+      it('should include title in schema if present', () => {
+        const schemas = currentSpec.spec.components.schemas;
+        const modelSchema = schemas ? schemas['ParameterTestModel'] : undefined;
+        if (modelSchema && modelSchema.title) {
+          expect(modelSchema.title).to.be.equal('TitleTestModel', `Title should be 'TitleTestModel' ${forSpec(currentSpec)}`);
+        }
+      });
     });
   });
 });

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -1160,6 +1160,22 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
         expect(testModel.properties.optionalString).to.not.have.property('x-nullable');
         expect(testModel.properties.optionalString.nullable).to.be.undefined;
       });
+
+      it('should add title to schema if annotation exists', () => {
+        if (!specDefault.spec.components.schemas) {
+          throw new Error('Schemas not defined.');
+        }
+        if (!specDefault.spec.components.schemas.TestModelWithAnnotations) {
+          throw new Error('TestModelWithAnnotations not defined.');
+        }
+        const testModel = specDefault.spec.components.schemas.TestModelWithAnnotations;
+        expect(testModel.title).to.equal('Title annotation for model', `Schema - ${JSON.stringify(testModel)}`);
+        expect(testModel.properties).to.exist;
+        if (!testModel.properties) {
+          throw new Error('TestModelWithAnnotations should have had properties');
+        }
+        expect(testModel.properties.param.title).to.equal('Title annotation for property');
+      });
     });
   });
 
@@ -1970,6 +1986,19 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
               format: undefined,
             });
           },
+          testModelWithAnnotations: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/TestModelWithAnnotations', `for property ${propertyName}.$ref`);
+
+            const schema = getComponentSchema('TestModelWithAnnotations', currentSpec);
+            expect(schema.title).to.eq('Title annotation for model');
+
+            const paramSchema = schema.properties?.param;
+            if (!paramSchema) {
+              throw new Error('TestModelWithAnnotations should have had a param property');
+            }
+
+            expect(paramSchema.title).to.eq('Title annotation for property');
+          },
           advancedTypeAliases: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq(
               {
@@ -2441,7 +2470,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(defaultArgs).to.deep.eq(
               {
                 description: undefined,
-                title: undefined,
+
                 properties: {
                   t: { $ref: '#/components/schemas/GenericRequest_Word_', description: undefined, format: undefined, example: undefined },
                   u: { $ref: '#/components/schemas/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined, example: undefined },
@@ -2464,7 +2493,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
-                title: undefined,
               },
               `for schema linked by property ${propertyName}`,
             );
@@ -2479,7 +2507,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
-                title: undefined,
               },
               `for schema linked by property ${propertyName}`,
             );
@@ -2822,7 +2849,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 },
                 required: ['inModule', 'inNamespace2'],
                 type: 'object',
-                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
               },
@@ -2850,7 +2876,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inModule'],
                 type: 'object',
                 description: undefined,
-                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder2.inModule`,
@@ -2877,7 +2902,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
-                title: undefined,
               },
               `for property ${propertyName}.typeHolder1`,
             );
@@ -2904,7 +2928,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inFirstNamespace', 'inFirstNamespace2'],
                 type: 'object',
                 description: undefined,
-                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder1.inNamespace1_1`,
@@ -2925,7 +2948,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inSecondNamespace'],
                 type: 'object',
                 description: undefined,
-                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder2.inNamespace2`,
@@ -3063,7 +3085,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   },
                 },
                 type: 'object',
-                title: undefined,
                 required: undefined,
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
@@ -3689,7 +3710,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 },
                 required: ['a', 'b'],
                 type: 'object',
-                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
               },
@@ -4709,7 +4729,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             type: 'string',
           },
         },
-        title: undefined,
         required: undefined,
         type: 'object',
       });
@@ -4725,7 +4744,6 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(getComponentSchema('tsoaTest.TsoaTest.TestModel73', specDefault)).to.deep.equal({
         additionalProperties: true,
         description: undefined,
-        title: undefined,
         properties: {
           value: {
             default: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
 import { EnumDynamicPropertyKey, TestModel } from '../../fixtures/testModel';
+import { title } from 'process';
 
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadataGet = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();
@@ -2440,6 +2441,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             expect(defaultArgs).to.deep.eq(
               {
                 description: undefined,
+                title: undefined,
                 properties: {
                   t: { $ref: '#/components/schemas/GenericRequest_Word_', description: undefined, format: undefined, example: undefined },
                   u: { $ref: '#/components/schemas/DefaultArgs_Omit_ErrorResponseModel.status__', description: undefined, format: undefined, example: undefined },
@@ -2462,6 +2464,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
+                title: undefined,
               },
               `for schema linked by property ${propertyName}`,
             );
@@ -2476,6 +2479,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
+                title: undefined,
               },
               `for schema linked by property ${propertyName}`,
             );
@@ -2818,6 +2822,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 },
                 required: ['inModule', 'inNamespace2'],
                 type: 'object',
+                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
               },
@@ -2845,6 +2850,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inModule'],
                 type: 'object',
                 description: undefined,
+                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder2.inModule`,
@@ -2871,6 +2877,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 type: 'object',
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
+                title: undefined,
               },
               `for property ${propertyName}.typeHolder1`,
             );
@@ -2897,6 +2904,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inFirstNamespace', 'inFirstNamespace2'],
                 type: 'object',
                 description: undefined,
+                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder1.inNamespace1_1`,
@@ -2917,6 +2925,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 required: ['inSecondNamespace'],
                 type: 'object',
                 description: undefined,
+                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
               },
               `for property ${propertyName}.typeHolder2.inNamespace2`,
@@ -3054,6 +3063,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                   },
                 },
                 type: 'object',
+                title: undefined,
                 required: undefined,
                 description: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
@@ -3679,6 +3689,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
                 },
                 required: ['a', 'b'],
                 type: 'object',
+                title: undefined,
                 additionalProperties: currentSpec.specName === 'specWithNoImplicitExtras' ? false : true,
                 description: undefined,
               },
@@ -4698,6 +4709,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
             type: 'string',
           },
         },
+        title: undefined,
         required: undefined,
         type: 'object',
       });
@@ -4713,6 +4725,7 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
       expect(getComponentSchema('tsoaTest.TsoaTest.TestModel73', specDefault)).to.deep.equal({
         additionalProperties: true,
         description: undefined,
+        title: undefined,
         properties: {
           value: {
             default: undefined,

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -8,7 +8,6 @@ import * as os from 'os';
 import { versionMajorMinor } from 'typescript';
 import { getDefaultExtendedOptions } from '../../fixtures/defaultOptions';
 import { EnumDynamicPropertyKey, TestModel } from '../../fixtures/testModel';
-import { title } from 'process';
 
 describe('Definition generation for OpenAPI 3.0.0', () => {
   const metadataGet = new MetadataGenerator('./fixtures/controllers/getController.ts').Generate();

--- a/tests/unit/swagger/schemaDetails3.spec.ts
+++ b/tests/unit/swagger/schemaDetails3.spec.ts
@@ -2000,6 +2000,12 @@ describe('Definition generation for OpenAPI 3.0.0', () => {
 
             expect(paramSchema.title).to.eq('Title annotation for property');
           },
+          enumWithTitle: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/EnumWithTitle', `for property ${propertyName}.$ref`);
+
+            const schema = getComponentSchema('EnumWithTitle', currentSpec);
+            expect(schema.title).to.eq('Title annotation for enum');
+          },
           advancedTypeAliases: (propertyName, propertySchema) => {
             expect(propertySchema).to.deep.eq(
               {

--- a/tests/unit/swagger/schemaDetails31.spec.ts
+++ b/tests/unit/swagger/schemaDetails31.spec.ts
@@ -4487,6 +4487,19 @@ describe('Definition generation for OpenAPI 3.1.0', () => {
               `for property ${propertyName}`,
             );
           },
+          testModelWithAnnotations: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/TestModelWithAnnotations', `for property ${propertyName}.$ref`);
+
+            const schema = getComponentSchema('TestModelWithAnnotations', currentSpec);
+            expect(schema.title).to.eq('Title annotation for model');
+
+            const paramSchema = schema.properties?.param;
+            if (!paramSchema) {
+              throw new Error('TestModelWithAnnotations should have had a param property');
+            }
+
+            expect(paramSchema.title).to.eq('Title annotation for property');
+          },
         };
 
         const testModel = currentSpec.spec.components.schemas[interfaceModelName];

--- a/tests/unit/swagger/schemaDetails31.spec.ts
+++ b/tests/unit/swagger/schemaDetails31.spec.ts
@@ -4500,6 +4500,12 @@ describe('Definition generation for OpenAPI 3.1.0', () => {
 
             expect(paramSchema.title).to.eq('Title annotation for property');
           },
+          enumWithTitle: (propertyName, propertySchema) => {
+            expect(propertySchema.$ref).to.eq('#/components/schemas/EnumWithTitle', `for property ${propertyName}.$ref`);
+
+            const schema = getComponentSchema('EnumWithTitle', currentSpec);
+            expect(schema.title).to.eq('Title annotation for enum');
+          },
         };
 
         const testModel = currentSpec.spec.components.schemas[interfaceModelName];


### PR DESCRIPTION
This pull request adds support for extracting and including `@title` JSDoc annotations from TypeScript models and properties into the generated OpenAPI/Swagger schema definitions. It does so by updating the metadata generation pipeline to read the `title` annotation and propagate it through all relevant types, transformers, and spec generators. Comprehensive tests are added to verify that the `title` annotation appears correctly in the output schemas.

These changes ensure that descriptive `title` annotations are preserved from source code to API documentation, improving schema clarity for consumers.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**
closes #1656 

Put `closes #XXXX` (where XXXX is the issue number) in your comment to auto-close the issue that your PR fixes.

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

**Potential Problems With The Approach**

<!-- if there are areas of the solution that you think might have limitations or potential "gotchas", then discuss them here -->
<!-- if you have many questions, then please consider discussing them in the issue thread (unless you need to share code to illustrate the questions) -->

**Test plan**

* Added a new `TestModelWithAnnotations` fixture with `@title` JSDoc annotations at both model and property levels to verify extraction and propagation. (`tests/fixtures/testModel.ts`, [[1]](diffhunk://#diff-50beacf29d60548e15797d197d8fe1c640d4caa23b1f60207739a57cf4ec6876R184); [[2]](diffhunk://#diff-50beacf29d60548e15797d197d8fe1c640d4caa23b1f60207739a57cf4ec6876R1299-R1308)
* Expanded unit and integration tests to validate that the generated schemas correctly include `title` for models and properties, including OpenAPI 3 specific checks. (`tests/unit/swagger/schemaDetails3.spec.ts`, [[1]](diffhunk://#diff-4cfa19cc405ca43a96a388e376a457aa478ac0163c5459fcdbf9d8f1d9697d27R1163-R1178); [[2]](diffhunk://#diff-4cfa19cc405ca43a96a388e376a457aa478ac0163c5459fcdbf9d8f1d9697d27R1989-R2001); [[3]](diffhunk://#diff-4cfa19cc405ca43a96a388e376a457aa478ac0163c5459fcdbf9d8f1d9697d27R2473); [[4]](diffhunk://#diff-91b7a12e57c551d560cbd832feac1f73d9e014c0700c929a8eb9cd8563dde788R1632-R1634)


<!-- explain why the unit tests that you added are demonstrating that the feature works -->
