### PR TITLE
feat: implement tsconfig.json support for compiler options in config

### DIFF
--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -33,7 +33,17 @@ export interface Config {
   noImplicitAdditionalProperties?: 'throw-on-extras' | 'silently-remove-extras' | 'ignore';
 
   /**
-   * Typescript CompilerOptions to be used during generation
+   * Path to tsconfig.json file to read compilerOptions from.
+   * If not specified, defaults to 'tsconfig.json' in the working directory.
+   * The compilerOptions from tsconfig.json will be merged with compilerOptions
+   * from this config, with this config's compilerOptions taking precedence.
+   */
+  tsconfig?: string;
+
+  /**
+   * Typescript CompilerOptions to be used during generation.
+   * These will be merged with compilerOptions from tsconfig.json (if specified),
+   * with these options taking precedence over tsconfig.json.
    *
    * @type {Record<string, unknown>}
    * @memberof RoutesConfig

--- a/tests/unit/swagger/compilerOptions.spec.ts
+++ b/tests/unit/swagger/compilerOptions.spec.ts
@@ -1,0 +1,248 @@
+import { expect } from 'chai';
+import 'mocha';
+import { validateCompilerOptions } from '@tsoa/cli/cli';
+import { Config } from '@tsoa/runtime';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import { tmpdir } from 'os';
+import * as ts from 'typescript';
+
+const fsWriteFile = promisify(fs.writeFile);
+const fsUnlink = promisify(fs.unlink);
+const fsMkdir = promisify(fs.mkdir);
+const fsRmdir = promisify(fs.rmdir);
+
+describe('CompilerOptions', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary directory for each test
+    testDir = path.join(tmpdir(), `tsoa-test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`);
+    await fsMkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    try {
+      const files = await promisify(fs.readdir)(testDir);
+      for (const file of files) {
+        await promisify(fs.unlink)(path.join(testDir, file));
+      }
+      await fsRmdir(testDir);
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('validateCompilerOptions', () => {
+    it('should read compilerOptions from tsconfig.json', async () => {
+      // Create a tsconfig.json with compilerOptions
+      const tsconfigPath = path.join(testDir, 'tsconfig.json');
+      await fsWriteFile(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2020',
+            module: 'commonjs',
+            strict: true,
+            experimentalDecorators: true,
+          },
+        }),
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2020);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.CommonJS);
+      expect(compilerOptions.strict).to.be.true;
+      expect(compilerOptions.experimentalDecorators).to.be.true;
+    });
+
+    it('should support tsconfig.json with comments and trailing commas', async () => {
+      // Create a tsconfig.json with comments and trailing commas (like real tsconfig.json)
+      const tsconfigPath = path.join(testDir, 'tsconfig.json');
+      await fsWriteFile(
+        tsconfigPath,
+        `{
+  "compilerOptions": {
+    "target": "es2021", // This is a comment
+    "module": "commonjs",
+    "strict": true,
+    "experimentalDecorators": true, // trailing comma
+  }
+}`,
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2021);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.CommonJS);
+      expect(compilerOptions.strict).to.be.true;
+      expect(compilerOptions.experimentalDecorators).to.be.true;
+    });
+
+    it('should merge compilerOptions from tsoa.json over tsconfig.json', async () => {
+      // Create a tsconfig.json
+      const tsconfigPath = path.join(testDir, 'tsconfig.json');
+      await fsWriteFile(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2020',
+            module: 'commonjs',
+            strict: true,
+            experimentalDecorators: true,
+          },
+        }),
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        compilerOptions: {
+          target: 'es2015', // Override tsconfig.json
+          module: 'esnext', // Override tsconfig.json
+          // strict and experimentalDecorators should come from tsconfig.json
+        },
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      // tsoa.json options should take precedence
+      // TypeScript's parseJsonConfigFileContent converts strings to enum values
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2015);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.ESNext);
+      // Options not in tsoa.json should come from tsconfig.json
+      expect(compilerOptions.strict).to.be.true;
+      expect(compilerOptions.experimentalDecorators).to.be.true;
+    });
+
+    it('should use custom tsconfig path when specified', async () => {
+      // Create a custom tsconfig file
+      const customTsconfigPath = path.join(testDir, 'custom-tsconfig.json');
+      await fsWriteFile(
+        customTsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2018',
+            module: 'es2015',
+          },
+        }),
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        tsconfig: 'custom-tsconfig.json',
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2018);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.ES2015);
+    });
+
+    it('should handle missing tsconfig.json gracefully when not explicitly specified', async () => {
+      // Don't create tsconfig.json
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      // Should return empty compilerOptions
+      expect(compilerOptions).to.deep.equal({});
+    });
+
+    it('should throw error when explicitly specified tsconfig.json is missing', async () => {
+      // Don't create tsconfig.json
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        tsconfig: 'custom-tsconfig.json', // Explicitly specified but doesn't exist
+      };
+
+      try {
+        await validateCompilerOptions(config, testDir);
+        expect.fail('Should have thrown an error');
+      } catch (err) {
+        expect(err).to.be.instanceOf(Error);
+        expect((err as Error).message).to.include('custom-tsconfig.json');
+      }
+    });
+
+    it('should use only tsoa.json compilerOptions when tsconfig.json is missing', async () => {
+      // Don't create tsconfig.json
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        compilerOptions: {
+          target: 'es2017',
+          module: 'amd',
+          strict: false,
+        },
+      };
+
+      const compilerOptions = await validateCompilerOptions(config, testDir);
+
+      // TypeScript's parseJsonConfigFileContent converts strings to enum values
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2017);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.AMD);
+      expect(compilerOptions.strict).to.be.false;
+    });
+  });
+});

--- a/tests/unit/swagger/compilerOptions.spec.ts
+++ b/tests/unit/swagger/compilerOptions.spec.ts
@@ -12,6 +12,7 @@ const fsWriteFile = promisify(fs.writeFile);
 const fsUnlink = promisify(fs.unlink);
 const fsMkdir = promisify(fs.mkdir);
 const fsRmdir = promisify(fs.rmdir);
+const fsRm = promisify(fs.rm);
 
 describe('CompilerOptions', () => {
   let testDir: string;
@@ -23,13 +24,9 @@ describe('CompilerOptions', () => {
   });
 
   afterEach(async () => {
-    // Clean up temporary directory
+    // Clean up temporary directory recursively
     try {
-      const files = await promisify(fs.readdir)(testDir);
-      for (const file of files) {
-        await promisify(fs.unlink)(path.join(testDir, file));
-      }
-      await fsRmdir(testDir);
+      await fsRm(testDir, { recursive: true, force: true });
     } catch (err) {
       // Ignore cleanup errors
     }
@@ -62,7 +59,7 @@ describe('CompilerOptions', () => {
         },
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2020);
       expect(compilerOptions.module).to.equal(ts.ModuleKind.CommonJS);
@@ -96,7 +93,7 @@ describe('CompilerOptions', () => {
         },
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2021);
       expect(compilerOptions.module).to.equal(ts.ModuleKind.CommonJS);
@@ -135,7 +132,7 @@ describe('CompilerOptions', () => {
         },
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       // tsoa.json options should take precedence
       // TypeScript's parseJsonConfigFileContent converts strings to enum values
@@ -171,10 +168,92 @@ describe('CompilerOptions', () => {
         tsconfig: 'custom-tsconfig.json',
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2018);
       expect(compilerOptions.module).to.equal(ts.ModuleKind.ES2015);
+    });
+
+    it('should use tsconfig.a.json when specified', async () => {
+      // Create a tsconfig.a.json file
+      const tsconfigAPath = path.join(testDir, 'tsconfig.a.json');
+      await fsWriteFile(
+        tsconfigAPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2019',
+            module: 'esnext',
+            strict: true,
+            experimentalDecorators: true,
+          },
+        }),
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        tsconfig: 'tsconfig.a.json',
+      };
+
+      const compilerOptions = validateCompilerOptions(config, testDir);
+
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2019);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.ESNext);
+      expect(compilerOptions.strict).to.be.true;
+      expect(compilerOptions.experimentalDecorators).to.be.true;
+    });
+
+    it('should find tsconfig.json in the parent directory', async () => {
+      // Create a parent directory structure
+      // testDir (parent) contains tsconfig.json
+      // testDir/child (child) is the working directory
+      const parentDir = testDir;
+      const childDir = path.join(testDir, 'child');
+
+      // Create child directory
+      await fsMkdir(childDir, { recursive: true });
+
+      // Create tsconfig.json in parent directory
+      const tsconfigPath = path.join(parentDir, 'tsconfig.json');
+      await fsWriteFile(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2022',
+            module: 'node16',
+            strict: true,
+            experimentalDecorators: true,
+            esModuleInterop: true,
+          },
+        }),
+        'utf8',
+      );
+
+      const config: Config = {
+        entryFile: './test.ts',
+        spec: {
+          outputDirectory: './dist',
+        },
+        routes: {
+          routesDir: './routes',
+        },
+        // Don't specify tsconfig - should find parent's tsconfig.json
+      };
+
+      // Call from child directory - should find parent's tsconfig.json
+      const compilerOptions = validateCompilerOptions(config, childDir);
+
+      expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2022);
+      expect(compilerOptions.module).to.equal(ts.ModuleKind.Node16);
+      expect(compilerOptions.strict).to.be.true;
+      expect(compilerOptions.experimentalDecorators).to.be.true;
+      expect(compilerOptions.esModuleInterop).to.be.true;
     });
 
     it('should handle missing tsconfig.json gracefully when not explicitly specified', async () => {
@@ -190,7 +269,7 @@ describe('CompilerOptions', () => {
         },
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       // Should return empty compilerOptions
       expect(compilerOptions).to.deep.equal({});
@@ -211,7 +290,7 @@ describe('CompilerOptions', () => {
       };
 
       try {
-        await validateCompilerOptions(config, testDir);
+        validateCompilerOptions(config, testDir);
         expect.fail('Should have thrown an error');
       } catch (err) {
         expect(err).to.be.instanceOf(Error);
@@ -237,7 +316,7 @@ describe('CompilerOptions', () => {
         },
       };
 
-      const compilerOptions = await validateCompilerOptions(config, testDir);
+      const compilerOptions = validateCompilerOptions(config, testDir);
 
       // TypeScript's parseJsonConfigFileContent converts strings to enum values
       expect(compilerOptions.target).to.equal(ts.ScriptTarget.ES2017);

--- a/tests/unit/swagger/pathGeneration/rootSecurityRoutes.spec.ts
+++ b/tests/unit/swagger/pathGeneration/rootSecurityRoutes.spec.ts
@@ -8,13 +8,11 @@ import type { Swagger } from '@tsoa/runtime';
 
 describe('Security route generation with root security', () => {
   describe('with @Security() on controller', () => {
-    const noSecurityControllerMetadata = new MetadataGenerator(
-      './fixtures/controllers/noSecurityController.ts',
-      undefined,
-      undefined,
-      undefined, [{
-        root_level_auth: []
-    }]).Generate();
+    const noSecurityControllerMetadata = new MetadataGenerator('./fixtures/controllers/noSecurityController.ts', undefined, undefined, undefined, [
+      {
+        root_level_auth: [],
+      },
+    ]).Generate();
     const noSecuritySpec = new SpecGenerator2(noSecurityControllerMetadata, getDefaultExtendedOptions()).GetSpec();
 
     it('should use the method level security over root/controller security', () => {
@@ -46,17 +44,14 @@ describe('Security route generation with root security', () => {
 
       expect(path.get.security).to.deep.equal([{ tsoa_auth: ['write:pets', 'read:pets'] }]);
     });
-
   });
 
   describe('with undefined controller level security', () => {
-    const plainControllerMetadata = new MetadataGenerator(
-      './fixtures/controllers/pathlessGetController.ts',
-      undefined,
-      undefined,
-      undefined, [{
-        root_level_auth: []
-    }]).Generate();
+    const plainControllerMetadata = new MetadataGenerator('./fixtures/controllers/pathlessGetController.ts', undefined, undefined, undefined, [
+      {
+        root_level_auth: [],
+      },
+    ]).Generate();
     const plainSpec = new SpecGenerator2(plainControllerMetadata, getDefaultExtendedOptions()).GetSpec();
 
     it('should use root level security if no security defined on method', () => {
@@ -66,21 +61,20 @@ describe('Security route generation with root security', () => {
         throw new Error('No get operation.');
       }
 
-      expect(path.get.security).to.deep.equal([{
-        root_level_auth: []
-      }]);
+      expect(path.get.security).to.deep.equal([
+        {
+          root_level_auth: [],
+        },
+      ]);
     });
-
   });
 
   describe('with @NoSecurity() on controller', () => {
-    const noSecurityControllerMetadata = new MetadataGenerator(
-      './fixtures/controllers/noSecurityOnController.ts',
-      undefined,
-      undefined,
-      undefined, [{
-        root_level_auth: []
-    }]).Generate();
+    const noSecurityControllerMetadata = new MetadataGenerator('./fixtures/controllers/noSecurityOnController.ts', undefined, undefined, undefined, [
+      {
+        root_level_auth: [],
+      },
+    ]).Generate();
     const noSecurityOnControllerSpec = new SpecGenerator2(noSecurityControllerMetadata, getDefaultExtendedOptions()).GetSpec();
 
     it('should use the method level security over root/controller security', () => {
@@ -112,8 +106,7 @@ describe('Security route generation with root security', () => {
 
       expect(path.get.security).to.deep.equal([]);
     });
-
-  })
+  });
 
   function verifyPath(spec: Swagger.Spec2, route: string, model = 'UserResponseModel') {
     return VerifyPath(spec, route, path => path.get, undefined, false, `#/definitions/${model}`);


### PR DESCRIPTION
- Added a new function to read and parse tsconfig.json for compiler
  options.
- Updated the validateCompilerOptions function to merge options from
  tsconfig.json and tsoa.json, with precedence given to tsoa.json.
- error handling for missing tsconfig.json files.
- unit tests to validate the new functionality
