### PR TITLE
Refactor: Replace validator.js dependency from @tsoa/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,6 @@
     "minimatch": "^9.0.1",
     "ts-deepmerge": "^7.0.2",
     "typescript": "^5.7.2",
-    "validator": "^13.12.0",
     "yaml": "^2.6.1",
     "yargs": "^17.7.1"
   },
@@ -47,7 +46,6 @@
     "@types/glob": "^8.1.0",
     "@types/minimatch": "^5.1.0",
     "@types/node": "^18.0.0",
-    "@types/validator": "^13.12.2",
     "@types/yargs": "^17.0.33",
     "copyfiles": "^2.4.1",
     "rimraf": "^5.0.5"

--- a/packages/cli/src/utils/validatorUtils.ts
+++ b/packages/cli/src/utils/validatorUtils.ts
@@ -66,7 +66,7 @@ export function getParameterValidators(parameter: ts.ParameterDeclaration, param
           break;
         case 'minDate':
         case 'maxDate':
-          if (!validator.isISO8601(String(value), { strict: true })) {
+          if (!isISO8601(String(value))) {
             throw new GenerateMetadataError(`${name} parameter use date format ISO 8601 ex. 2017-05-14, 2017-05-14T05:18Z`);
           }
           validateObj[name] = {
@@ -165,7 +165,7 @@ export function getPropertyValidators(property: ts.Node): Tsoa.Validators | unde
           break;
         case 'minDate':
         case 'maxDate':
-          if (!validator.isISO8601(String(value), { strict: true })) {
+          if (!isISO8601(String(value))) {
             throw new GenerateMetadataError(`${name} parameter use date format ISO 8601 ex. 2017-05-14, 2017-05-14T05:18Z`);
           }
           validateObj[name] = {
@@ -245,4 +245,55 @@ function removeSurroundingQuotes(str: string) {
 
 export function shouldIncludeValidatorInSchema(key: string): key is Tsoa.SchemaValidatorKey {
   return !key.startsWith('is') && key !== 'minDate' && key !== 'maxDate';
+}
+
+/**
+ * Validates if a string is in ISO 8601 format (strict mode, matching validator.js behavior)
+ * Supports date-only (YYYY-MM-DD) and datetime with strict 'T' separator (YYYY-MM-DDTHH:mm:ss[.sss][Z])
+ * Based on validator.js with strictSeparator: true and strict: true options
+ */
+export function isISO8601(value: string): boolean {
+  // ISO 8601 strict separator regex from validator.js
+  // Time portion is optional, but if present, requires 'T' separator
+  const iso8601Regex = /^([+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-3])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([.,]\d+(?!:))?)?(\17[0-5]\d([.,]\d+)?)?([zZ]|([+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
+
+  if (!iso8601Regex.test(value)) {
+    return false;
+  }
+
+  // Validate the actual date is correct (catches invalid dates like 2009-02-31)
+  // This matches validator.js isValidDate function behavior
+
+  // Check for ordinal dates (YYYY-DDD format)
+  const ordinalMatch = value.match(/^(\d{4})-?(\d{3})([ T]{1}\.*|$)/);
+  if (ordinalMatch) {
+    const oYear = Number(ordinalMatch[1]);
+    const oDay = Number(ordinalMatch[2]);
+    // Check if leap year
+    if ((oYear % 4 === 0 && oYear % 100 !== 0) || oYear % 400 === 0) {
+      return oDay <= 366;
+    }
+    return oDay <= 365;
+  }
+
+  // Regular date format
+  const match = value.match(/(\d{4})-?(\d{0,2})-?(\d*)/)?.map(Number);
+  if (!match) {
+    return false;
+  }
+
+  const year = match[1];
+  const month = match[2];
+  const day = match[3];
+  const monthString = month ? `0${month}`.slice(-2) : month;
+  const dayString = day ? `0${day}`.slice(-2) : day;
+
+  // Create a date object and compare
+  const d = new Date(`${year}-${monthString || '01'}-${dayString || '01'}`);
+  if (month && day) {
+    return d.getUTCFullYear() === year
+      && (d.getUTCMonth() + 1) === month
+      && d.getUTCDate() === day;
+  }
+  return true;
 }

--- a/packages/cli/src/utils/validatorUtils.ts
+++ b/packages/cli/src/utils/validatorUtils.ts
@@ -1,6 +1,5 @@
 import { Tsoa } from '@tsoa/runtime';
 import * as ts from 'typescript';
-import validator from 'validator';
 import { GenerateMetadataError } from './../metadataGeneration/exceptions';
 import { commentToString, getJSDocTags } from './jsDocUtils';
 

--- a/tests/unit/utilities/validatorUtils.spec.ts
+++ b/tests/unit/utilities/validatorUtils.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import 'mocha';
+import { isISO8601 } from '@tsoa/cli/utils/validatorUtils';
+
+describe('isISO8601', () => {
+  describe('Valid ISO 8601 dates', () => {
+    it('should accept valid date-only format (YYYY-MM-DD)', () => {
+      expect(isISO8601('2017-05-14')).to.be.true;
+      expect(isISO8601('2020-01-01')).to.be.true;
+      expect(isISO8601('2025-12-31')).to.be.true;
+    });
+
+    it('should accept valid datetime with T separator', () => {
+      expect(isISO8601('2017-05-14T05:18Z')).to.be.true;
+      expect(isISO8601('2020-01-01T00:00:00Z')).to.be.true;
+      expect(isISO8601('2025-12-31T23:59:59Z')).to.be.true;
+    });
+
+    it('should accept datetime with milliseconds', () => {
+      expect(isISO8601('2020-01-01T12:30:45.123Z')).to.be.true;
+      expect(isISO8601('2020-01-01T12:30:45.999Z')).to.be.true;
+    });
+
+    it('should accept datetime with timezone offsets', () => {
+      expect(isISO8601('2020-01-01T12:00:00+02:00')).to.be.true;
+      expect(isISO8601('2020-01-01T12:00:00-05:00')).to.be.true;
+    });
+
+    it('should accept leap year dates', () => {
+      expect(isISO8601('2020-02-29')).to.be.true; // 2020 is a leap year
+      expect(isISO8601('2000-02-29')).to.be.true; // 2000 is a leap year (divisible by 400)
+    });
+
+    it('should accept ordinal dates (YYYY-DDD format)', () => {
+      expect(isISO8601('2009-123')).to.be.true; // Day 123 of 2009
+      expect(isISO8601('2009-222')).to.be.true; // Day 222 of 2009
+    });
+
+    it('should accept ordinal dates for leap years', () => {
+      expect(isISO8601('2020-366')).to.be.true; // 2020 is a leap year with 366 days
+      expect(isISO8601('2400-366')).to.be.true; // 2400 is a leap year
+    });
+  });
+
+  describe('Invalid ISO 8601 dates', () => {
+    it('should reject invalid date formats', () => {
+      expect(isISO8601('2020/01/01')).to.be.false; // wrong separator
+      expect(isISO8601('01-01-2020')).to.be.false; // wrong order
+      expect(isISO8601('2020-1-1')).to.be.false; // missing leading zeros
+      expect(isISO8601('not-a-date')).to.be.false;
+    });
+
+    it('should reject datetime with different separator instead of T', () => {
+      expect(isISO8601('2020-01-01 12:00:00Z')).to.be.false;
+      expect(isISO8601('2020-01-01X12:00:00Z')).to.be.false;
+    });
+
+    it('should reject invalid dates', () => {
+      expect(isISO8601('2020-02-31')).to.be.false; // February doesn't have 31 days
+      expect(isISO8601('2020-13-01')).to.be.false; // Month 13 doesn't exist
+      expect(isISO8601('2020-04-31')).to.be.false; // April has only 30 days
+      expect(isISO8601('2010-02-30')).to.be.false; // February 30 doesn't exist
+      expect(isISO8601('2019-02-31')).to.be.false; // February 31 doesn't exist
+    });
+
+    it('should reject invalid leap year dates', () => {
+      expect(isISO8601('2019-02-29')).to.be.false; // 2019 is not a leap year
+      expect(isISO8601('1900-02-29')).to.be.false; // 1900 is not a leap year (divisible by 100 but not 400)
+      expect(isISO8601('2009-02-29')).to.be.false; // 2009 is not a leap year
+    });
+
+    it('should reject invalid ordinal dates', () => {
+      expect(isISO8601('2009-366')).to.be.false; // 2009 is not a leap year, only has 365 days
+    });
+
+    it('should reject invalid time components', () => {
+      expect(isISO8601('2020-01-01T25:00:00Z')).to.be.false; // Hour 25
+      expect(isISO8601('2020-01-01T23:61:00Z')).to.be.false; // Minute 61
+      expect(isISO8601('2020-01-01T23:59:61Z')).to.be.false; // Second 61
+    });
+  });
+});


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [ ] This PR is associated with an existing issue?

<img width="1545" height="347" alt="Screenshot 2026-01-22 at 16 01 09" src="https://github.com/user-attachments/assets/50851641-ee70-4b57-b180-3f730ae6e0ff" />

Motivation: we use `@tsoa/cli` in some of our AWS Lambdas and it happens to import the entirety of `validator.js` which is 130kB of about just anything, where it's just used for ISO8601 checks in `@tsoa/cli`.

130kB of unused code is bad in itself – but in general bundling that much extra code makes cold starts in Node.JS lambdas worse.

**Potential Problems With The Approach**

This only replaces `validator.js` dependency in `@tsoa/cli`, not in `@tsoa/runtime`.

Other than that, `validator.js` is a CJS package and it's not tree-shakeable no matter how you import it. Once you import it, you get everything.

**Test plan**

Unit tested the custom function.
