### PR TITLE
fix(routes): include inherited controller methods (#1832)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ customRoutes.ts
 yarn-error.log
 tsconfig.tsbuildinfo
 .typedoc
+codealike.json

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean": "lerna run clean --stream",
     "prepare": "yarn build",
     "preversion": "yarn test",
-    "test": "lerna run test --stream",
+    "test": "lerna run test --stream --concurrency 1",
     "lint": "eslint . --ext .ts",
     "lint:fix": "yarn run eslint --ext .ts --fix",
     "watch": "lerna run watch",

--- a/packages/cli/src/metadataGeneration/controllerGenerator.ts
+++ b/packages/cli/src/metadataGeneration/controllerGenerator.ts
@@ -5,7 +5,19 @@ import { MethodGenerator } from './methodGenerator';
 import { TypeResolver } from './typeResolver';
 import { Tsoa } from '@tsoa/runtime';
 import { getHeaderType } from '../utils/headerTypeHelpers';
-import { isMethodDeclaration, type ClassDeclaration, type CallExpression, type StringLiteral } from 'typescript';
+import {
+  SymbolFlags,
+  SyntaxKind,
+  isImportSpecifier,
+  isClassDeclaration,
+  isIdentifier,
+  isMethodDeclaration,
+  type ExpressionWithTypeArguments,
+  type ClassDeclaration,
+  type MethodDeclaration,
+  type CallExpression,
+  type StringLiteral,
+} from 'typescript';
 
 export class ControllerGenerator {
   private readonly path?: string;
@@ -15,7 +27,11 @@ export class ControllerGenerator {
   private readonly commonResponses: Tsoa.Response[];
   private readonly produces?: string[];
 
-  constructor(private readonly node: ClassDeclaration, private readonly current: MetadataGenerator, private readonly parentSecurity: Tsoa.Security[] = []) {
+  constructor(
+    private readonly node: ClassDeclaration,
+    private readonly current: MetadataGenerator,
+    private readonly parentSecurity: Tsoa.Security[] = [],
+  ) {
     this.path = this.getPath();
     this.tags = this.getTags();
     this.security = this.getSecurity();
@@ -48,11 +64,131 @@ export class ControllerGenerator {
   }
 
   private buildMethods() {
-    return this.node.members
-      .filter(isMethodDeclaration)
+    return this.getMethodsWithInheritedMethods()
       .map(m => new MethodGenerator(m, this.current, this.commonResponses, this.path, this.tags, this.security, this.isHidden))
       .filter(generator => generator.IsValid())
       .map(generator => generator.Generate());
+  }
+
+  private getMethodsWithInheritedMethods(): MethodDeclaration[] {
+    const inheritanceChain = this.getInheritanceChainForRoutes();
+    if (inheritanceChain.length === 1) {
+      return this.node.members.filter(isMethodDeclaration);
+    }
+
+    // Process from base to derived so derived classes can override inherited names.
+    const methodsByName = new Map<string, MethodDeclaration>();
+    inheritanceChain.reverse().forEach(classDeclaration => {
+      classDeclaration.members.filter(isMethodDeclaration).forEach(method => {
+        const key = this.getMethodKey(method);
+        if (!key) {
+          return;
+        }
+        methodsByName.set(key, method);
+      });
+    });
+
+    return [...methodsByName.values()];
+  }
+
+  private getInheritanceChainForRoutes(): ClassDeclaration[] {
+    const chain: ClassDeclaration[] = [this.node];
+    let hasRuntimeControllerBase = false;
+    let currentClass: ClassDeclaration | undefined = this.node;
+
+    while (currentClass) {
+      const { baseClass, extendsRuntimeController } = this.getDirectBaseClassInfo(currentClass);
+      if (extendsRuntimeController) {
+        hasRuntimeControllerBase = true;
+        break;
+      }
+
+      if (!baseClass) {
+        break;
+      }
+
+      chain.push(baseClass);
+      currentClass = baseClass;
+    }
+
+    return hasRuntimeControllerBase ? chain : [this.node];
+  }
+
+  private getDirectBaseClassInfo(classDeclaration: ClassDeclaration): { baseClass?: ClassDeclaration; extendsRuntimeController: boolean } {
+    const extendsClause = classDeclaration.heritageClauses?.find(clause => clause.token === SyntaxKind.ExtendsKeyword);
+    const extendsType = extendsClause?.types[0];
+    if (!extendsType) {
+      return { extendsRuntimeController: false };
+    }
+
+    if (this.extendsRuntimeController(extendsType)) {
+      return { extendsRuntimeController: true };
+    }
+
+    const expression = extendsType.expression;
+    const symbols = [this.current.typeChecker.getSymbolAtLocation(expression), this.current.typeChecker.getTypeAtLocation(expression).getSymbol()].filter(
+      (symbol): symbol is NonNullable<typeof symbol> => !!symbol,
+    );
+
+    const symbolsToSearch = new Set(symbols);
+    symbols.forEach(symbol => {
+      if (symbol.flags & SymbolFlags.Alias) {
+        symbolsToSearch.add(this.current.typeChecker.getAliasedSymbol(symbol));
+      }
+    });
+
+    for (const symbol of symbolsToSearch) {
+      const declarations = symbol.declarations || (symbol.valueDeclaration ? [symbol.valueDeclaration] : []);
+      const classDeclarationNode = declarations.find(isClassDeclaration);
+      if (classDeclarationNode) {
+        return { baseClass: classDeclarationNode, extendsRuntimeController: false };
+      }
+    }
+
+    return { extendsRuntimeController: false };
+  }
+
+  private extendsRuntimeController(extendsType: ExpressionWithTypeArguments): boolean {
+    const expression = extendsType.expression;
+    const symbol = this.current.typeChecker.getSymbolAtLocation(expression) || this.current.typeChecker.getTypeAtLocation(expression).getSymbol();
+    if (!symbol) {
+      return false;
+    }
+
+    if (!(symbol.flags & SymbolFlags.Alias)) {
+      return false;
+    }
+
+    const aliasDeclarations = symbol.declarations || [];
+    return aliasDeclarations.some(declaration => {
+      if (!isImportSpecifier(declaration)) {
+        return false;
+      }
+
+      const importedName = declaration.propertyName?.text || declaration.name.text;
+      if (importedName !== 'Controller') {
+        return false;
+      }
+
+      const moduleSpecifier = this.getImportModuleSpecifier(declaration);
+      if (!moduleSpecifier) {
+        return false;
+      }
+      return moduleSpecifier.getText().replace(/['"]/g, '') === '@tsoa/runtime';
+    });
+  }
+
+  private getMethodKey(method: MethodDeclaration): string | undefined {
+    if (!method.name) {
+      return undefined;
+    }
+    return isIdentifier(method.name) ? method.name.text : method.name.getText();
+  }
+
+  private getImportModuleSpecifier(declaration: import('typescript').ImportSpecifier) {
+    // ImportSpecifier -> NamedImports -> ImportClause -> ImportDeclaration
+    const importDeclaration = declaration.parent.parent.parent;
+    return 'moduleSpecifier' in importDeclaration ? importDeclaration.moduleSpecifier : undefined;
   }
 
   private getPath() {

--- a/packages/runtime/src/routeGeneration/templates/templateService.ts
+++ b/packages/runtime/src/routeGeneration/templates/templateService.ts
@@ -24,8 +24,24 @@ export abstract class TemplateService<ApiHandlerParameters, ValidationArgsParame
   }
 
   protected buildPromise(methodName: string, controller: Controller | object, validatedArgs: any) {
-    const prototype = Object.getPrototypeOf(controller);
-    const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
-    return (descriptor!.value as () => Promise<PropertyDescriptor>).apply(controller, validatedArgs);
+    const ownPrototype = Object.getPrototypeOf(controller);
+    let prototype: object | null = ownPrototype;
+    let descriptor: PropertyDescriptor | undefined;
+
+    // Search up the prototype chain so inherited controller actions can be dispatched.
+    // We stop at Object.prototype because methods above that level are not user actions.
+    while (prototype && prototype !== Object.prototype) {
+      descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
+      if (descriptor?.value && typeof descriptor.value === 'function') {
+        break;
+      }
+
+      prototype = Object.getPrototypeOf(prototype);
+    }
+
+    // Keep previous behavior when nothing is found by allowing the same
+    // descriptor access failure path to occur on the original prototype.
+    const resolvedDescriptor = descriptor || Object.getOwnPropertyDescriptor(ownPrototype, methodName);
+    return (resolvedDescriptor!.value as (...args: any[]) => Promise<any>).apply(controller, validatedArgs);
   }
 }

--- a/tests/esm/package.json
+++ b/tests/esm/package.json
@@ -28,7 +28,7 @@
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "lerna": "^8.1.9",
-    "mocha": "^10.7.3",
+    "mocha": "^11.7.5",
     "prettier": "^3.4.2",
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.2",

--- a/tests/esm/unit/templating/routeGenerator.spec.ts
+++ b/tests/esm/unit/templating/routeGenerator.spec.ts
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import 'mocha';
-import { ExtendedRoutesConfig, generateRoutes } from 'tsoa';
+import { generateRoutes, type ExtendedRoutesConfig } from 'tsoa';
 import { DummyRouteGenerator } from '../../fixtures/templating/dummyRouteGenerator';
 
 chai.use(chaiAsPromised);

--- a/tests/package.json
+++ b/tests/package.json
@@ -62,7 +62,7 @@
     "lerna": "^8.1.9",
     "lint-staged": "^15.2.10",
     "method-override": "^3.0.0",
-    "mocha": "^10.7.3",
+    "mocha": "^11.7.5",
     "multer": "^2.0.2",
     "prettier": "^3.4.2",
     "reflect-metadata": "^0.2.2",

--- a/tests/unit/templating/inheritedRouteGenerator.spec.ts
+++ b/tests/unit/templating/inheritedRouteGenerator.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import 'mocha';
+import { generateRoutes } from '@tsoa/cli';
+
+describe('RouteGenerator inherited routes', () => {
+  it('emits routes declared on a base class and a child class', async () => {
+    const tmpRoot = await fs.mkdtemp(join(tmpdir(), 'tsoa-inherited-routes-'));
+    const routesDir = join(tmpRoot, 'generated-routes');
+    const controllerFile = join(tmpRoot, 'inheritedController.ts');
+
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      class BaseController extends Controller {
+        @Get('from-base')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('inherited')
+      export class ChildController extends BaseController {
+        @Get('from-child')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    try {
+      await fs.writeFile(controllerFile, source, 'utf8');
+
+      await generateRoutes({
+        bodyCoercion: true,
+        controllerPathGlobs: [controllerFile],
+        entryFile: '',
+        middleware: 'express',
+        noImplicitAdditionalProperties: 'silently-remove-extras',
+        routesDir,
+      });
+
+      const generatedRoutes = await fs.readFile(join(routesDir, 'routes.ts'), 'utf8');
+      expect(generatedRoutes).to.contain("'/inherited/from-base'");
+      expect(generatedRoutes).to.contain("'/inherited/from-child'");
+    } finally {
+      await fs.rm(tmpRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/unit/templating/inheritedRouteGenerator.spec.ts
+++ b/tests/unit/templating/inheritedRouteGenerator.spec.ts
@@ -1,16 +1,67 @@
 import { expect } from 'chai';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import 'mocha';
-import { generateRoutes } from '@tsoa/cli';
+import { generateRoutes } from '@tsoa/cli/module/generate-routes';
+import { MetadataGenerator } from '@tsoa/cli/metadataGeneration/metadataGenerator';
+import { spy } from 'sinon';
+import * as ts from 'typescript';
+import { CompilerOptions } from 'typescript';
+
+type TempControllerPaths = {
+  controllerFile: string;
+  routesDir: string;
+};
+
+function getTempCompilerOptions(): CompilerOptions {
+  const repoRoot = resolve(__dirname, '../../..');
+  return {
+    baseUrl: repoRoot,
+    emitDecoratorMetadata: true,
+    experimentalDecorators: true,
+    module: ts.ModuleKind.CommonJS,
+    paths: {
+      '@tsoa/runtime': ['packages/runtime/src/index.ts'],
+      '@tsoa/runtime/*': ['packages/runtime/src/*'],
+    },
+    target: ts.ScriptTarget.ES2021,
+  };
+}
+
+async function withTempController(source: string, run: (paths: TempControllerPaths) => Promise<void>) {
+  const tmpRoot = await fs.mkdtemp(join(tmpdir(), 'tsoa-inherited-routes-'));
+  const routesDir = join(tmpRoot, 'generated-routes');
+  const controllerFile = join(tmpRoot, 'inheritedController.ts');
+
+  try {
+    await fs.writeFile(controllerFile, source, 'utf8');
+    await run({ controllerFile, routesDir });
+  } finally {
+    await fs.rm(tmpRoot, { force: true, recursive: true });
+  }
+}
+
+async function generateRoutesForController(paths: TempControllerPaths) {
+  await generateRoutes(
+    {
+      bodyCoercion: true,
+      controllerPathGlobs: [paths.controllerFile],
+      entryFile: '',
+      middleware: 'express',
+      noImplicitAdditionalProperties: 'silently-remove-extras',
+      routesDir: paths.routesDir,
+    },
+    getTempCompilerOptions(),
+  );
+}
+
+async function readGeneratedRoutesFile(routesDir: string) {
+  return await fs.readFile(join(routesDir, 'routes.ts'), 'utf8');
+}
 
 describe('RouteGenerator inherited routes', () => {
   it('emits routes declared on a base class and a child class', async () => {
-    const tmpRoot = await fs.mkdtemp(join(tmpdir(), 'tsoa-inherited-routes-'));
-    const routesDir = join(tmpRoot, 'generated-routes');
-    const controllerFile = join(tmpRoot, 'inheritedController.ts');
-
     const source = `
       import { Controller, Get, Route } from '@tsoa/runtime';
 
@@ -30,23 +81,192 @@ describe('RouteGenerator inherited routes', () => {
       }
     `;
 
-    try {
-      await fs.writeFile(controllerFile, source, 'utf8');
-
-      await generateRoutes({
-        bodyCoercion: true,
-        controllerPathGlobs: [controllerFile],
-        entryFile: '',
-        middleware: 'express',
-        noImplicitAdditionalProperties: 'silently-remove-extras',
-        routesDir,
-      });
-
-      const generatedRoutes = await fs.readFile(join(routesDir, 'routes.ts'), 'utf8');
+    await withTempController(source, async paths => {
+      await generateRoutesForController(paths);
+      const generatedRoutes = await readGeneratedRoutesFile(paths.routesDir);
       expect(generatedRoutes).to.contain("'/inherited/from-base'");
       expect(generatedRoutes).to.contain("'/inherited/from-child'");
-    } finally {
-      await fs.rm(tmpRoot, { force: true, recursive: true });
-    }
+    });
+  });
+
+  it('uses the derived controller route prefix for inherited methods when base and derived routes differ', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      @Route('base')
+      export class BaseController extends Controller {
+        @Get('from-base')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('derived')
+      export class ChildController extends BaseController {
+        @Get('from-child')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      await generateRoutesForController(paths);
+      const generatedRoutes = await readGeneratedRoutesFile(paths.routesDir);
+
+      expect(generatedRoutes).to.contain("'/base/from-base'");
+      expect(generatedRoutes).to.contain("'/derived/from-base'");
+      expect(generatedRoutes).to.contain("'/derived/from-child'");
+      expect(generatedRoutes).not.to.contain("'/base/from-child'");
+    });
+  });
+
+  it('does not include inherited methods when the base class does not extend tsoa Controller', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      class PlainBase {
+        @Get('from-base')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('inherited')
+      export class ChildController extends PlainBase {
+        @Get('from-child')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      await generateRoutesForController(paths);
+      const generatedRoutes = await readGeneratedRoutesFile(paths.routesDir);
+
+      expect(generatedRoutes).to.contain("'/inherited/from-child'");
+      expect(generatedRoutes).not.to.contain("'/inherited/from-base'");
+    });
+  });
+
+  it('rejects duplicate routes when inherited and child methods resolve to the same HTTP method and path', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      class BaseController extends Controller {
+        @Get('duplicate')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('conflict')
+      export class ChildController extends BaseController {
+        @Get('duplicate')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      expect(() => {
+        new MetadataGenerator(paths.controllerFile, getTempCompilerOptions()).Generate();
+      }).to.throw(/Duplicate method signature @get\(conflict\/duplicate\) found in controllers/);
+    });
+  });
+
+  it('warns on duplicate path-parameter signatures between inherited and child methods', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      class BaseController extends Controller {
+        @Get('{id}')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('collisions')
+      export class ChildController extends BaseController {
+        @Get('{identifier}')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      const consoleWarn = spy(console, 'warn');
+
+      try {
+        new MetadataGenerator(paths.controllerFile, getTempCompilerOptions()).Generate();
+        expect(
+          consoleWarn.calledWith(
+            'Duplicate path parameter definition signature found in controller ChildController [ method GET fromChild route: {identifier} ] collides with [ method GET fromBase route: {id} ]\n',
+          ),
+        ).to.be.true;
+      } finally {
+        consoleWarn.restore();
+      }
+    });
+  });
+
+  it('rejects duplicate inherited route signatures across base and derived controllers with same route prefix', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      @Route('same')
+      export class BaseController extends Controller {
+        @Get('from-base')
+        public async fromBase(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('same')
+      export class ChildController extends BaseController {
+        @Get('from-child')
+        public async fromChild(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      expect(() => {
+        new MetadataGenerator(paths.controllerFile, getTempCompilerOptions()).Generate();
+      }).to.throw(/Duplicate method signature @get\(same\/from-base\) found in controllers: BaseController#fromBase, ChildController#fromBase/);
+    });
+  });
+
+  it('prefers child method decorators when the child overrides an inherited method name', async () => {
+    const source = `
+      import { Controller, Get, Route } from '@tsoa/runtime';
+
+      class BaseController extends Controller {
+        @Get('from-base')
+        public async shared(): Promise<string> {
+          return 'base';
+        }
+      }
+
+      @Route('override')
+      export class ChildController extends BaseController {
+        @Get('from-child')
+        public async shared(): Promise<string> {
+          return 'child';
+        }
+      }
+    `;
+
+    await withTempController(source, async paths => {
+      await generateRoutesForController(paths);
+      const generatedRoutes = await readGeneratedRoutesFile(paths.routesDir);
+
+      expect(generatedRoutes).to.contain("'/override/from-child'");
+      expect(generatedRoutes).not.to.contain("'/override/from-base'");
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,7 +1889,7 @@ ajv@^8.0.1:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-ansi-colors@^4.1.1, ansi-colors@^4.1.3:
+ansi-colors@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
@@ -1934,14 +1934,6 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
-
-anymatch@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
-  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -2079,11 +2071,6 @@ bin-links@^4.0.4:
     read-cmd-shim "^4.0.0"
     write-file-atomic "^5.0.0"
 
-binary-extensions@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
-  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
-
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -2126,7 +2113,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2332,20 +2319,12 @@ check-error@^1.0.2, check-error@^1.0.3:
   dependencies:
     get-func-name "^2.0.2"
 
-chokidar@^3.5.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
-  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+chokidar@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
+    readdirp "^4.0.1"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -2903,11 +2882,6 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-diff@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
-  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 diff@^7.0.0:
   version "7.0.0"
@@ -3543,11 +3517,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -3695,14 +3664,14 @@ glob-parent@6.0.2, glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
-glob@^10.2.2, glob@^10.3.10, glob@^10.3.7:
+glob@^10.2.2, glob@^10.3.10, glob@^10.3.7, glob@^10.4.5:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -3725,17 +3694,6 @@ glob@^7.0.5, glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
 
 glob@^9.2.0:
   version "9.3.5"
@@ -4124,13 +4082,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-ci@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
@@ -4179,7 +4130,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5079,7 +5030,7 @@ minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.6:
+minimatch@^5.0.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -5195,30 +5146,31 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mocha@^10.7.3:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
-  integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
+mocha@^11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
   dependencies:
-    ansi-colors "^4.1.3"
     browser-stdout "^1.3.1"
-    chokidar "^3.5.3"
+    chokidar "^4.0.1"
     debug "^4.3.5"
-    diff "^5.2.0"
+    diff "^7.0.0"
     escape-string-regexp "^4.0.0"
     find-up "^5.0.0"
-    glob "^8.1.0"
+    glob "^10.4.5"
     he "^1.2.0"
+    is-path-inside "^3.0.3"
     js-yaml "^4.1.0"
     log-symbols "^4.1.0"
-    minimatch "^5.1.6"
+    minimatch "^9.0.5"
     ms "^2.1.3"
+    picocolors "^1.1.1"
     serialize-javascript "^6.0.2"
     strip-json-comments "^3.1.1"
     supports-color "^8.1.1"
-    workerpool "^6.5.1"
-    yargs "^16.2.0"
-    yargs-parser "^20.2.9"
+    workerpool "^9.2.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
 
 modify-values@^1.0.1:
@@ -5384,11 +5336,6 @@ normalize-package-data@^6.0.0, normalize-package-data@^6.0.1:
     hosted-git-info "^7.0.0"
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
-
-normalize-path@^3.0.0, normalize-path@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
-  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 npm-bundled@^3.0.0:
   version "3.0.1"
@@ -5900,7 +5847,7 @@ picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -6195,12 +6142,10 @@ readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 redent@^3.0.0:
   version "3.0.0"
@@ -7298,10 +7243,10 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-workerpool@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
-  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
+workerpool@^9.2.0:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
+  integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
@@ -7431,7 +7376,7 @@ yargs-parser@21.1.1, yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -7446,7 +7391,7 @@ yargs-unparser@^2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@17.7.2, yargs@^17.6.2, yargs@^17.7.1:
+yargs@17.7.2, yargs@^17.6.2, yargs@^17.7.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/lukeautry/tsoa/tree/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lukeautry/tsoa/pulls) for the same update/change?
- [x] Have you written unit tests?
- [x] Have you written unit tests that cover the negative cases (i.e.: if bad data is submitted, does the library respond properly)?
- [x] This PR is associated with an existing issue?

**Closing issues**

closes #1832

### If this is a new feature submission:

- [ ] Has the issue had a maintainer respond to the issue and clarify that the feature is something that aligns with the [goals](https://github.com/lukeautry/tsoa#goal) and [philosophy](https://github.com/lukeautry/tsoa#philosophy) of the project?

This PR is a bug fix for inherited controller route generation behavior, plus CI/runtime compatibility hardening for Node 22/24/25.

## What changed

### Inherited route generation/runtime fix

- `ControllerGenerator` now includes inherited HTTP-verb-decorated methods when generating a derived controller’s routes.
- Inheritance traversal only applies to class chains rooted in `@tsoa/runtime` `Controller`.
- Traversal hard-stops at runtime `Controller` itself, so methods declared on runtime `Controller` are never exposed as routes.
- Child overrides win: if a child method name overrides a base method, only the child method is used for that derived controller.
- Runtime invocation now searches the prototype chain for controller methods so inherited actions can execute.
- Runtime fallback behavior remains compatible with previous expectations when method lookup fails (no new custom runtime error surface).

### CI / Node compatibility stabilization

- Upgraded test workspaces from `mocha@^10.7.3` to `mocha@^11.7.5` (Node 25 compatibility).
- Updated root test orchestration to run workspace tests serially:
  - `lerna run test --stream --concurrency 1`
- Adjusted one ESM test import to be type-only:
  - `import { generateRoutes, type ExtendedRoutesConfig } from 'tsoa';`
- Kept `tests/integration/utils.ts::verifyFileUploadRequest` behavior unchanged from baseline.

## Why these CI changes were needed

- With Mocha 10 on Node 25, tests fail with:
  - `ReferenceError: require is not defined in ES module scope`
  - originating from `mocha -> yargs` in the ESM test workspace.
- Serial workspace execution significantly reduces intermittent cross-suite/network timing flakes seen when `tsoa-tests` and `tsoa-tests-esm` run concurrently.

## Special-case behavior covered (inherited routes)

- Base class does not need `@Route` for its verb-decorated methods to be included on the derived controller.
- If base and derived both have `@Route`, inherited methods are mounted under the derived controller route when generating the derived controller, while the base controller still generates its own routes.
- Existing duplicate route and path-parameter collision checks are preserved and still throw/warn as before.

## Potential problems with the approach

- Runtime `Controller` stop detection depends on the `extends` target resolving as an aliased import from module specifier `@tsoa/runtime`. Unusual import indirection patterns could affect detection in edge setups.
- Including inherited methods can surface duplicate route errors in projects that previously had hidden inheritance conflicts.
- Prototype-chain method lookup is broader than before (intentional), but still bounded to stop at `Object.prototype`.
- CI test stage may run longer due to `--concurrency 1`.

## Test plan

Added/expanded unit coverage in `tests/unit/templating/inheritedRouteGenerator.spec.ts`:

- includes inherited base + child routes
- verifies derived route prefix behavior for inherited methods
- verifies base-not-extending-Controller exclusion
- verifies duplicate full-path conflict detection
- verifies path-parameter collision warning behavior
- verifies duplicate inherited signatures across base+derived controllers
- verifies child override precedence

Validation commands run:

- `yarn workspace tsoa-tests run mocha "unit/templating/inheritedRouteGenerator.spec.ts"`
- `yarn workspace tsoa-tests run mocha "unit/templating/routeGenerator.spec.ts"`
- `yarn workspace tsoa-tests run mocha "unit/swagger/pathGeneration/routeDuplicates.spec.ts"`
- `npx -y node@22 $(which yarn) run test`
- `npx -y node@24 $(which yarn) run test`
- `npx -y node@25 $(which yarn) run test`

These demonstrate:

- inherited route metadata/runtime behavior works as intended,
- negative/conflict paths are enforced,
- test suite executes successfully across Node 22/24/25 with updated tooling and serialized workspace test execution.