### PR TITLE
Add bugs metadata to packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,9 @@
     "type": "git",
     "url": "https://github.com/lukeautry/tsoa.git"
   },
+  "bugs": {
+    "url": "https://github.com/lukeautry/tsoa/issues"
+  },
   "bin": {
     "tsoa": "dist/cli.js"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -45,6 +45,9 @@
     "type": "git",
     "url": "https://github.com/lukeautry/tsoa.git"
   },
+  "bugs": {
+    "url": "https://github.com/lukeautry/tsoa/issues"
+  },
   "engines": {
     "yarn": ">=1.9.4",
     "node": ">=18.0.0"

--- a/packages/tsoa/package.json
+++ b/packages/tsoa/package.json
@@ -39,6 +39,9 @@
     "type": "git",
     "url": "https://github.com/lukeautry/tsoa.git"
   },
+  "bugs": {
+    "url": "https://github.com/lukeautry/tsoa/issues"
+  },
   "bin": {
     "tsoa": "dist/cli.js"
   },


### PR DESCRIPTION
## Summary

Adds missing bugs metadata to the package manifests for:

- tsoa
- @tsoa/cli
- @tsoa/runtime

Each package already points at this repository, and GitHub issues are enabled for lukeautry/tsoa.

## Verification

- Confirmed current npm metadata for these three packages has no bugs field.
- Verified each updated package manifest now points bugs.url to the repository issues page.
- Ran git diff --check.
- Ran npm pack --dry-run --ignore-scripts --json for each updated package.
