### PR TITLE
Fix empty @returns JSDoc tags

### DIFF
--- a/packages/cli/src/utils/jsDocUtils.ts
+++ b/packages/cli/src/utils/jsDocUtils.ts
@@ -39,7 +39,7 @@ export function getJSDocTagNames(node: ts.Node, requireTagName = false) {
     tags = getJSDocTags(node.parent as any, tag => {
       if (ts.isJSDocParameterTag(tag)) {
         return false;
-      } else if (tag.comment === undefined) {
+      } else if (tag.comment === undefined && !ts.isJSDocReturnTag(tag)) {
         throw new GenerateMetadataError(`Orphan tag: @${String(tag.tagName.text || tag.tagName.escapedText)} should have a parameter name follows with.`);
       }
 

--- a/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
+++ b/tests/fixtures/controllers/controllerWithJsDocResponseDescription.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Route, SuccessResponse } from '@tsoa/runtime';
+import { Body, Controller, Get, Post, Route, SuccessResponse } from '@tsoa/runtime';
 import { TestModel } from '../testModel';
 import { ModelService } from 'fixtures/services/modelService';
 
@@ -14,6 +14,18 @@ export class CustomResponseDescController extends Controller {
   @Get('descriptionWithJsDocAnnotation')
   public async descriptionWithJsDocAnnotation(): Promise<TestModel> {
     return new ModelService().getModel();
+  }
+
+  /** @returns */
+  @Post('emptyReturnsTag')
+  public async emptyReturnsTag(@Body() body: TestModel): Promise<number> {
+    return body.id;
+  }
+
+  /** @returns {Promise<number>} */
+  @Post('typeOnlyReturnsTag')
+  public async typeOnlyReturnsTag(@Body() body: TestModel): Promise<number> {
+    return body.id;
   }
 
   @Get('successResponseAndJsDocAnnotation')

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -1042,6 +1042,17 @@ describe('Metadata generation', () => {
       expect(method.responses[0].name).to.equal('200');
       expect(method.responses[0].description).to.equal(description);
     });
+
+    it('ignores empty and type-only @returns tags', () => {
+      for (const methodName of ['emptyReturnsTag', 'typeOnlyReturnsTag']) {
+        const method = controller.methods.find(m => m.name === methodName);
+        if (!method) {
+          throw new Error(`method ${methodName} not defined`);
+        }
+        expect(method.responses[0].description).to.equal('Ok');
+      }
+    });
+
     it("should not override @SuccessResponse's description even if @returns is present", () => {
       const description = 'Success Response description';
       const method = controller.methods.find(m => m.name === 'successResponseAndJsDocAnnotation');


### PR DESCRIPTION
## Summary

- Ignore empty and type-only `@returns` JSDoc tags during parameter metadata generation.
- Add regression coverage for both forms.

## Root cause

TypeScript represents these return tags without a comment, and the parameter-tag validation treated them as orphan parameter annotations.

## Testing

- `yarn workspace tsoa-tests exec mocha unit/swagger/definitionsGeneration/metadata.spec.ts --grep 'controllerWithJsDocResponseDescriptionGeneration'`

Fixes #1741
