### PR TITLE
Fix @pattern regexes with spaces

### DIFF
--- a/packages/cli/src/utils/validatorUtils.ts
+++ b/packages/cli/src/utils/validatorUtils.ts
@@ -75,15 +75,17 @@ export function getParameterValidators(parameter: ts.ParameterDeclaration, param
             value,
           };
           break;
-        case 'pattern':
-          if (typeof value !== 'string') {
+        case 'pattern': {
+          const pattern = getPatternValueAndErrorMsg(comment);
+          if (typeof pattern.value !== 'string') {
             throw new GenerateMetadataError(`${name} parameter use string.`);
           }
           validateObj[name] = {
-            errorMsg: getErrorMsg(comment),
-            value: removeSurroundingQuotes(value),
+            errorMsg: pattern.errorMsg,
+            value: pattern.value,
           };
           break;
+        }
         default:
           if (name.startsWith('is')) {
             const errorMsg = getErrorMsg(comment, false);
@@ -174,15 +176,17 @@ export function getPropertyValidators(property: ts.Node): Tsoa.Validators | unde
             value,
           };
           break;
-        case 'pattern':
-          if (typeof value !== 'string') {
+        case 'pattern': {
+          const pattern = getPatternValueAndErrorMsg(commentToString(comment));
+          if (typeof pattern.value !== 'string') {
             throw new GenerateMetadataError(`${name} parameter use string.`);
           }
           validateObj[name] = {
-            errorMsg: getErrorMsg(commentToString(comment)),
-            value: removeSurroundingQuotes(value),
+            errorMsg: pattern.errorMsg,
+            value: pattern.value,
           };
           break;
+        }
         case 'title':
           if (typeof value !== 'string') {
             throw new GenerateMetadataError(`${name} parameter use string.`);
@@ -242,6 +246,36 @@ function removeSurroundingQuotes(str: string) {
     return str.substring(3, str.length - 3);
   }
   return str;
+}
+
+function getPatternValueAndErrorMsg(comment?: string) {
+  if (!comment) {
+    return { errorMsg: undefined, value: undefined };
+  }
+
+  const trimmedComment = comment.trim();
+  if (trimmedComment.startsWith('/')) {
+    let escaped = false;
+    for (let index = 1; index < trimmedComment.length; index++) {
+      const character = trimmedComment[index];
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === '/') {
+        return {
+          errorMsg: trimmedComment.substring(index + 1).trim() || undefined,
+          value: trimmedComment.substring(1, index),
+        };
+      }
+    }
+  }
+
+  const [value, ...errorMsg] = trimmedComment.split(' ');
+  return {
+    errorMsg: errorMsg.join(' ') || undefined,
+    value: removeSurroundingQuotes(value),
+  };
 }
 
 export function shouldIncludeValidatorInSchema(key: string): key is Tsoa.SchemaValidatorKey {

--- a/tests/unit/utilities/validatorUtils.spec.ts
+++ b/tests/unit/utilities/validatorUtils.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as ts from 'typescript';
+import { getParameterValidators, getPropertyValidators } from '@tsoa/cli/utils/validatorUtils';
+
+describe('Validator JSDoc utilities', () => {
+  const sourceFile = ts.createSourceFile(
+    'validators.ts',
+    `
+      interface Model {
+        /** @pattern /^[a-zA-Z0-9 ]*$/ */
+        value: string;
+      }
+      /** @pattern value /^[a-zA-Z0-9 ]*$/ only letters, numbers, and spaces */
+      function validate(value: string) {}
+    `,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const model = sourceFile.statements[0] as ts.InterfaceDeclaration;
+  const validate = sourceFile.statements[1] as ts.FunctionDeclaration;
+
+  it('preserves spaces in property regex literals', () => {
+    expect(getPropertyValidators(model.members[0]).pattern).to.deep.equal({
+      errorMsg: undefined,
+      value: '^[a-zA-Z0-9 ]*$',
+    });
+  });
+
+  it('preserves spaces in parameter regex literals', () => {
+    expect(getParameterValidators(validate.parameters[0], 'value').pattern).to.deep.equal({
+      errorMsg: 'only letters, numbers, and spaces',
+      value: '^[a-zA-Z0-9 ]*$',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Parse slash-delimited `@pattern` regex literals as a complete value.
- Preserve literal spaces in property and parameter patterns.
- Add regression coverage for both annotation locations.

## Root cause

Pattern parsing split the annotation at its first space, truncating regex character classes containing literal spaces.

## Testing

- `yarn workspace tsoa-tests exec mocha unit/utilities/validatorUtils.spec.ts`
- `yarn run lint`

Fixes #1857
